### PR TITLE
Kill running player synchronousy

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -86,7 +86,7 @@ if(isset($urlparams['shutdown']) && $urlparams['shutdown'] == "true") {
 // stop playing
 if(isset($urlparams['stop']) && $urlparams['stop'] == "true") {
     // NOTE: this is being done as sudo, because the webserver does not have the rights to kill VLC
-    $exec = "/usr/bin/sudo pkill vlc > /dev/null 2>/dev/null &";
+    $exec = "/usr/bin/sudo pkill vlc > /dev/null 2>/dev/null";
     exec($exec);
     /* redirect to drop all the url parameters */
     header("Location: ".$conf['url_abs']);
@@ -97,7 +97,7 @@ if(isset($urlparams['stop']) && $urlparams['stop'] == "true") {
 if(isset($urlparams['play']) && $urlparams['play'] != "" && is_dir($urlparams['play'])) {
     // kill vlc if running
     // NOTE: this is being done as sudo, because the webserver does not have the rights to kill VLC
-    $exec = "/usr/bin/sudo pkill vlc > /dev/null 2>/dev/null &";
+    $exec = "/usr/bin/sudo pkill vlc > /dev/null 2>/dev/null";
     exec($exec);
 
     // pipe playlist into VLC


### PR DESCRIPTION
Most of the time the buttons on the web interface did not have any effect in my installation (RPi 3, raspbian stretch, vlc 2.2.6-1~deb9u1+rpi1, lighttpd 1.4.45-1). This change solves the problem.

When pushing a button in the Web UI the index.php script kills first an eventually running cvlc process. Then it launches a new cvlc process. The killing is done asynchronously in the background. The assumption is that pkill may not only stop the previously running cvlc process but also the just launched one. Therefore no sound is played. This is solved by waiting for pkill to complete before launching the new cvlc process.