### PR TITLE
Combined the GPIO Buttons with playout controls and added it to systemd

### DIFF
--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -145,6 +145,7 @@ The last step is to enable the service files:
 ```
 sudo systemctl enable rfid-reader
 sudo systemctl enable startup-sound
+sudo systemctl enable gpio-buttons (optional)
 ```
 
 The newly installed service can be started either by rebooting the jukebox or

--- a/misc/GPIO-button-sample.py
+++ b/misc/GPIO-button-sample.py
@@ -10,25 +10,25 @@ from subprocess import check_call
 # If anybody has ideas or tests or experience regarding this solution, please create pull requests or contact me.
 
 def def_shutdown():
-    check_call(['sudo', 'poweroff'])
+    check_call("./scripts/playout_controls.sh -c=shutdown", shell=True)
 
 def def_volU():
-    check_call("amixer sset PCM 1.5db+", shell=True)
+    check_call("./scripts/playout_controls.sh -c=volumeup", shell=True)
 
 def def_volD():
-    check_call("amixer sset PCM 1.5db-", shell=True)
+    check_call("./scripts/playout_controls.sh -c=volumedown", shell=True)
 
 def def_vol0():
-    check_call("amixer sset PCM 0db", shell=True)
+    check_call("./scripts/playout_controls.sh -c=mute", shell=True)
 
 def def_next():
-    check_call("echo 'next' | nc.openbsd -w 1 localhost 4212", shell=True)
+    check_call("./scripts/playout_controls.sh -c=playernext", shell=True)
 
 def def_prev():
-    check_call("echo 'prev' | nc.openbsd -w 1 localhost 4212", shell=True)
+    check_call("./scripts/playout_controls.sh -c=playerprev", shell=True)
 
 def def_halt():
-    check_call("echo 'pause' | nc.openbsd -w 1 localhost 4212", shell=True)
+    check_call("./scripts/playout_controls.sh -c=playerpause", shell=True)
 
 shut = Button(3, hold_time=2)
 vol0 = Button(13)    

--- a/misc/gpio-buttons.service
+++ b/misc/gpio-buttons.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=GPIO Buttons Service
+After=network.target iptables.service firewalld.service
+
+[Service]
+Restart=always
+WorkingDirectory=/home/pi/RPi-Jukebox-RFID
+ExecStart=/home/pi/RPi-Jukebox-RFID/scripts/gpio-buttons.py
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Added the GPIO Buttons to my project and wanted to share the changes I made.
I used the playout controls so that sound device config is only needed in playout_controls.sh.

Tested this on my Raspberry Pi Zero Jukebox.