### PR TITLE
Fix idle-watchdog service type

### DIFF
--- a/misc/idle-watchdog.service
+++ b/misc/idle-watchdog.service
@@ -5,7 +5,7 @@ After=network.target iptables.service firewalld.service
 [Service]
 User=pi
 Group=pi
-Type=oneshot
+Type=simple
 WorkingDirectory=/home/pi/RPi-Jukebox-RFID
 ExecStart=/home/pi/RPi-Jukebox-RFID/scripts/idle-watchdog.sh
 


### PR DESCRIPTION
I stumbled across that issue while i was trying to start the service via web app. The service type "oneshot" lets the watchdog stay in a systemctl "starting" state, while "simple" gives a "started" state.
While it's no difference for the function of the idle-watchdog, "starting" lets a PHP script failing which should restart the service. 