### PR TITLE
Fix for #85

### DIFF
--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -269,7 +269,7 @@ if [ "$FOLDERNAME" ]; then
                 # Podcast
                 PODCASTURL=`cat "$PATHDATA/../shared/audiofolders/$FOLDERNAME/podcast.txt"`
                 # parse podcast XML in sloppy but efficient way and write URLs to playlist
-                wget -q -O - "$PODCASTURL" | sed -n 's/.*enclosure.*url="\([^"]*\)" .*/\1/p' > "$PLAYLISTPATH"
+                wget -q -O - "$PODCASTURL" | sed -n 's/.*enclosure.*url="\([^"]*\)".*/\1/p' > "$PLAYLISTPATH"
                 # uncomment the following line to see playlist content in terminal
                 # cat "$PLAYLISTPATH"
                 ;;


### PR DESCRIPTION
The regex required a space after the second " of url=
This works in this case:
`<enclosure url="https://some.mp3" length="61828556" type="audio/mpeg" />`
But not in this case:
`<enclosure length="4960768" type="audio/mpeg" url="https://some.mp3"/>`