### PR TITLE
Simple second swipe

### DIFF
--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -246,11 +246,6 @@ case $COMMAND in
     playerstop)
         # stop the player
         $PATHDATA/resume_play.sh -c=savepos && mpc stop
-        if [ -e $AUDIOFOLDERSPATH/playing.txt ]
-        then
-            sudo rm $AUDIOFOLDERSPATH/playing.txt
-        fi
-        if [ "$DEBUG" == "true" ]; then echo "remove playing.txt" >> $PATHDATA/../logs/debug.log; fi
         ;;
     playerstopafter)
         # stop player after $VALUE minutes
@@ -271,7 +266,6 @@ case $COMMAND in
         ;;
     playerplay)
         # play / resume current track
-        if [ $DEBUG == "true" ]; then echo "Attempting to play: $VALUE" >> $PATHDATA/../logs/debug.log; fi
         # May be called with e.g. -v=1 to start a track in the middle of the playlist.
         # Note: the numbering of the tracks starts with 0, so -v=1 starts the second track
         # of the playlist
@@ -315,25 +309,16 @@ case $COMMAND in
 	;;
     playlistaddplay)
         # add to playlist (and play)
-        if [ $DEBUG == "true" ]; then echo "   playlistaddplay VALUE: $VALUE" >> $PATHDATA/../logs/debug.log; fi
-        
-        # save playlist playing
-        sudo echo $VALUE > $AUDIOFOLDERSPATH/playing.txt 
-        
-        # write latest folder played to settings file
-        # Chances are, this was already written in 'rfid_trigger_play.sh'
-        # However, new development might jump right here and not pipe
-        # through 'rfid_trigger_play.sh'
-        #echo $VALUE > $PATHDATA/../settings/Latest_Folder_Played
+        # save latest loaded playlist
+        sudo echo $VALUE > $PATHDATA/../settings/Latest_Folder_Played
         # clear track(s) from playlist
         mpc clear
         mpc load "${VALUE}" && $PATHDATA/resume_play.sh -c=resume
-        if [ "$DEBUG" == "true" ]; then echo "mpc load "${VALUE}" && $PATHDATA/resume_play.sh -c=resume"; fi
         ;;
     playlistadd)
         # add to playlist, no autoplay
-        # save playlist playing
-        sudo echo $VALUE > $AUDIOFOLDERSPATH/playing.txt 
+        # save latest loaded playlist
+        sudo echo $VALUE > $PATHDATA/../settings/Latest_Folder_Played
         mpc load "${VALUE}"
         ;;
     setidletime)

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -311,8 +311,6 @@ case $COMMAND in
         # add to playlist (and play)
         # save latest loaded playlist
         sudo echo $VALUE > $PATHDATA/../settings/Latest_Folder_Played
-        # clear track(s) from playlist
-        mpc clear
         mpc load "${VALUE}" && $PATHDATA/resume_play.sh -c=resume
         ;;
     playlistadd)

--- a/scripts/resume_play.sh
+++ b/scripts/resume_play.sh
@@ -14,13 +14,6 @@
 # - before you stop the player
 # - before you shutdown the Pi (maybe not necessary as mpc stores the position between reboots, but it feels saver)
 
-#############################################################
-# $DEBUG true|false
-DEBUG=false
-
-# Set the date and time of now
-NOW=`date +%Y-%m-%d.%H:%M:%S`
-
 for i in "$@"
 do
 case $i in
@@ -30,32 +23,17 @@ case $i in
     -v=*|--value=*)
     VALUE="${i#*=}"
     ;;
-    -d=*|--dir=*)
-    FOLDER="${i#*=}"
-    ;;
 esac
 done
 
 PATHDATA="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-if [ $DEBUG == "true" ]; then echo "## SCRIPT resume_play.sh ($NOW) ##" >> $PATHDATA/../logs/debug.log; fi
-if [ $DEBUG == "true" ]; then echo "VAR COMMAND: $COMMAND" >> $PATHDATA/../logs/debug.log; fi
-if [ $DEBUG == "true" ]; then echo "VAR VALUE: $VALUE" >> $PATHDATA/../logs/debug.log; fi
-if [ $DEBUG == "true" ]; then echo "VAR FOLDER: $FOLDER" >> $PATHDATA/../logs/debug.log; fi
 
 # Get folder name of currently played audio by extracting the playlist name 
-# ONLY if none was passed on. The "pass on" is needed to save position
-# when starting a new playlist while an old is playing. In this case
-# mpc lsplaylists will get confused because it has more than one.
-# check if $FOLDER is empty / unset
-if [ -z "$FOLDER" ]
-then 
-    FOLDER=$(mpc lsplaylists)
-fi
+FOLDER=$(cat $PATHDATA/../settings/Latest_Folder_Played)
 
 case "$COMMAND" in
 
 savepos)
-    if [ $DEBUG == "true" ]; then echo "   savepos FOLDER: $FOLDER" >> $PATHDATA/../logs/debug.log; fi
     # Check if "lastplayed.dat" exists
     if [ -e "$PATHDATA/../shared/audiofolders/$FOLDER/lastplayed.dat" ];
     then

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -23,16 +23,12 @@
 # Do NOT edit anything in this file.
 
 #############################################################
-# $DEBUG true|false
-DEBUG=false
-
 # Set the date and time of now
 NOW=`date +%Y-%m-%d.%H:%M:%S`
 
 # The absolute path to the folder whjch contains all the scripts.
 # Unless you are working with symlinks, leave the following line untouched.
 PATHDATA="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-if [ $DEBUG == "true" ]; then echo "## SCRIPT rfid_trigger_play.sh ($NOW) ##" >> $PATHDATA/../logs/debug.log; fi
 
 # create the configuration file from sample - if it does not exist
 if [ ! -f $PATHDATA/../settings/rfid_trigger_play.conf ]; then
@@ -65,8 +61,6 @@ case $i in
     ;;
 esac
 done
-if [ $DEBUG == "true" ]; then echo "VAR CARDID: $CARDID" >> $PATHDATA/../logs/debug.log; fi
-if [ $DEBUG == "true" ]; then echo "VAR FOLDER: $FOLDER" >> $PATHDATA/../logs/debug.log; fi
 
 ##################################################################
 # Check if we got the card ID or the audio folder from the prompt.
@@ -76,10 +70,9 @@ if [ "$CARDID" ]; then
     # If you want to see the CARDID printed, uncomment the following line
     # echo CARDID = $CARDID
 
-    # Add info into the log, making it easer to monitor cards 
+    # Add info into the log, making it easier to monitor cards
     echo "Card ID '$CARDID' was used at '$NOW'." > $PATHDATA/../shared/latestID.txt
     echo "$CARDID" > $PATHDATA/../settings/Latest_RFID
-    if [ $DEBUG == "true" ]; then echo "Card ID '$CARDID' was used"   >> $PATHDATA/../logs/debug.log; fi
 
     # If the input is of 'special' use, don't treat it like a trigger to play audio.
     # Special uses are for example volume changes, skipping, muting sound.
@@ -222,7 +215,6 @@ if [ "$CARDID" ]; then
                 FOLDER=`cat $PATHDATA/../shared/shortcuts/$CARDID`
                 # Add info into the log, making it easer to monitor cards
                 echo "This ID has been used before." >> $PATHDATA/../shared/latestID.txt
-                if [ $DEBUG == "true" ]; then echo "This ID has been used before."   >> $PATHDATA/../logs/debug.log; fi
             else
                 # Human readable shortcut does not exists, so create one with the content $CARDID
                 # this file can later be edited manually over the samba network
@@ -230,11 +222,9 @@ if [ "$CARDID" ]; then
                 FOLDER=$CARDID
                 # Add info into the log, making it easer to monitor cards
                 echo "This ID was used for the first time." >> $PATHDATA/../shared/latestID.txt
-                if [ $DEBUG == "true" ]; then echo "This ID was used for the first time."   >> $PATHDATA/../logs/debug.log; fi
             fi
             # Add info into the log, making it easer to monitor cards
             echo "The shortcut points to audiofolder '$FOLDER'." >> $PATHDATA/../shared/latestID.txt
-            if [ $DEBUG == "true" ]; then echo "The shortcut points to audiofolder '$FOLDER'." >> $PATHDATA/../logs/debug.log; fi
             ;;
     esac
 fi
@@ -244,52 +234,41 @@ fi
 # Either from prompt of from the card ID processing above
 # Sloppy error check, because we assume the best.
 
-if [ $DEBUG == "true" ]; then echo "Attempting to play: $AUDIOFOLDERSPATH/$FOLDER" >> $PATHDATA/../logs/debug.log; fi
-
 if [ "$FOLDER" ]; then
+    # get the name of the last folder played. As mpd doesn't store the name of the last
+    # playlist, we have to keep track of it via the Latest_Folder_Played file
+    LASTFOLDER=$(cat $PATHDATA/../settings/Latest_Folder_Played)
 
-    # Save position (to catch playing and paused audio) for resume and clear the playlist -> audio off
-    # Is has to be sudo as daemon_rfid_reader.py doesn't call this script with sudo
-    # and this produces an error while saving lastplayed.dat
-	
-    # Before we create a new playlist, we remove the old one from the folder.
-    # It's a workaround for resume playing as mpd doesn't know how its current playlist is named,
-    # so we only want the current playlist in the "mpc lsplaylists" output.
-    mpc lsplaylists | \
-    while read i
-    do
-        mpc rm "$i"
-    done
-
-    # if a folder $FOLDER exists, play content
-    if [ -d "$AUDIOFOLDERSPATH/$FOLDER" ]
+    # check if we have a the playlist already loaded which is associated with the rfid card.
+    # check the length of the playlist, if =0 then it was cleared before (a state, which should only
+    # be possible after a reboot).
+    PLLENGTH=$(echo -e "status\nclose" | nc -w 1 localhost 6600 | grep -o -P '(?<=playlistlength: ).*')
+    if [ "$LASTFOLDER" == "$FOLDER" ] && [ $PLLENGTH -gt 0 ]
     then
+        STATE=$(echo -e "status\nclose" | nc -w 1 localhost 6600 | grep -o -P '(?<=state: ).*')
+        if [ $STATE == "play" ]
+        then
+            sudo $PATHDATA/playout_controls.sh -c=playerpause
+        else
+            sudo $PATHDATA/playout_controls.sh -c=playerplay
+        fi
+    # if a folder $FOLDER exists, play content
+    elif [ -d "$AUDIOFOLDERSPATH/$FOLDER" ]
+    then
+        # As there will be a new playlist loaded, we clear the old one and 
+        # save the position (to catch playing and paused audio) for resume -> audio off
+        # Is has to be sudo as daemon_rfid_reader.py doesn't call this script with sudo
+        # and this produces an error while saving lastplayed.dat
+        sudo $PATHDATA/playout_controls.sh -c=playlistclear
 
         # set path to playlist
         PLAYLISTPATH="/tmp/$FOLDER.m3u"
-        if [ $DEBUG == "true" ]; then echo "VAR PLAYLISTPATH: $PLAYLISTPATH"   >> $PATHDATA/../logs/debug.log; fi
-
-        # prep to check "if same playlist playing or paused" later
-        if [ $DEBUG == "true" ]; then mpc status; fi
-        mpd_status="offline"
-        if mpc status | awk 'NR==2' | grep playing > /dev/null;
-        then 
-            mpd_status="playing"
-        fi
-        if mpc status | awk 'NR==2' | grep paused > /dev/null;
-        then 
-            mpd_status="paused"
-        fi
-        if [ $DEBUG == "true" ]; then echo "VAR mpd_status: $mpd_status" >> $PATHDATA/../logs/debug.log; fi
 
         # Check if we have something special to do
         # Read content file names of folder into string
         SPECIALFORMAT=$(ls "$AUDIOFOLDERSPATH/$FOLDER" | grep .txt)
-        if [ $DEBUG == "true" ]; then echo "VAR SPECIALFORMAT: $SPECIALFORMAT"   >> $PATHDATA/../logs/debug.log; fi
-
         # the following switch can be extended with other 'special' formats which require
         # more complex action than just piping the folder content into a playlist
-        if [ $DEBUG == "true" ]; then echo "CHECK Something special to do?" >> $PATHDATA/../logs/debug.log; fi
         case $SPECIALFORMAT in
             "podcast.txt")
                 # Podcast
@@ -298,94 +277,23 @@ if [ "$FOLDER" ]; then
                 wget -q -O - "$PODCASTURL" | sed -n 's/.*enclosure.*url="\([^"]*\)".*/\1/p' > "$PLAYLISTPATH"
                 # uncomment the following line to see playlist content in terminal
                 # cat "$PLAYLISTPATH"
-                if [ $DEBUG == "true" ]
-                then
-                    echo "Podcast: $PODCASTURL"   >> $PATHDATA/../logs/debug.log
-                fi
             ;;
             "livestream.txt")
                 # mpd can't read from .txt, so we have to write the livestream URL into playlist
                 cat "$AUDIOFOLDERSPATH/$FOLDER/livestream.txt" > "$PLAYLISTPATH"
-                if [ $DEBUG == "true" ]
-                then
-                    echo "Livestream $PLAYLISTPATH"   >> $PATHDATA/../logs/debug.log
-                fi
             ;;
             *)
                 # Nothing special to do, folder with audio files
                 # write playlist to file using the same name as the folder with ending .m3u
                 # wrap $PLAYLIST string in "" to keep line breaks
-        	# cd to $AUDIOFOLDERSPATH as mpd accepts only filepaths relative to its music folder
-        	# or starting with file:// (e.g. file:///home/pi...)
+        		# cd to ../shared/audiofolders as mpd accepts only filepaths relative to its music folder
+        		# or starting with file:// (e.g. file:///home/pi...)
                 cd $AUDIOFOLDERSPATH
                 find "$FOLDER" -type f | sort -n > "$PLAYLISTPATH"
-                if [ $DEBUG == "true" ]; then echo "Nothing special $PLAYLISTPATH" >> $PATHDATA/../logs/debug.log; fi
             ;;
         esac
-        
-        # Now we know what we will be playing -> start playing (or pausing?)!
-        
-        # read the latest folder into var
-        Latest_Folder_Played=`cat $PATHDATA/../settings/Latest_Folder_Played`
-        if [ $DEBUG == "true" ]; then echo "VAR Latest_Folder_Played: $Latest_Folder_Played" >> $PATHDATA/../logs/debug.log; fi
-
-        # 1. MPD playing
-        if [ $mpd_status == "playing" ]
-        then
-            if [ $DEBUG == "true" ]; then echo "1. MPD playing" >> $PATHDATA/../logs/debug.log; fi
-            # 1.1 IF new folder given ("$Latest_Folder_Played" != "$FOLDER")
-            if [ $DEBUG == "true" ]; then echo "1.1 CHECK Latest_Folder_Played ($Latest_Folder_Played) != FOLDER($FOLDER)" >> $PATHDATA/../logs/debug.log; fi
-            if [ "$Latest_Folder_Played" != "$FOLDER" ]
-            then
-                # 1.1.1 YES => stop current && start (resume) new
-                if [ $DEBUG == "true" ]; then echo "1.1.1 CHECK TRUE => resume_play.sh -c=savepos -d=${Latest_Folder_Played} playout_controls.sh -c=playlistaddplay -v=${FOLDER}" >> $PATHDATA/../logs/debug.log; fi
-                $PATHDATA/resume_play.sh -c=savepos -d="${Latest_Folder_Played}"
-                $PATHDATA/playout_controls.sh -c=playlistaddplay -v="${FOLDER}"
-            else 
-                # 1.1.2 NO => stop current
-                if [ $DEBUG == "true" ]; then echo "1.1.2 CHECK FALSE => playout_controls.sh -c=playerstop" >> $PATHDATA/../logs/debug.log; fi
-                $PATHDATA/playout_controls.sh -c=playerstop
-            fi
-        fi
-        
-        # 2. MPD paused
-        if [ $mpd_status == "paused" ]
-        then
-            if [ $DEBUG == "true" ]; then echo "2. MPD paused" >> $PATHDATA/../logs/debug.log; fi
-            # 2.1 IF new folder given ("$Latest_Folder_Played" != "$FOLDER")
-            if [ $DEBUG == "true" ]; then echo "2.1 CHECK Latest_Folder_Played ($Latest_Folder_Played) != FOLDER($FOLDER)" >> $PATHDATA/../logs/debug.log; fi
-            if [ "$Latest_Folder_Played" != "$FOLDER" ]
-            then
-                # 2.1.1 YES => stop current && start (resume) new
-                if [ $DEBUG == "true" ]; then echo "2.1.1 CHECK TRUE => resume_play.sh -c=savepos -d=${Latest_Folder_Played} playout_controls.sh -c=playlistaddplay -v=${FOLDER}" >> $PATHDATA/../logs/debug.log; fi
-                $PATHDATA/resume_play.sh -c=savepos -d="${Latest_Folder_Played}"
-                $PATHDATA/playout_controls.sh -c=playlistaddplay -v="${FOLDER}"
-            else 
-                # 2.1.2 NO => play (resume) current
-                if [ $DEBUG == "true" ]; then echo "2.1.2 CHECK FALSE => playout_controls.sh -c=playerpause" >> $PATHDATA/../logs/debug.log; fi
-                $PATHDATA/playout_controls.sh -c=playerpause
-            fi
-        fi
-        
-        # 3. MPD offline
-        if [ $mpd_status == "offline" ]
-        then
-            if [ $DEBUG == "true" ]; then echo "3. MPD offline" >> $PATHDATA/../logs/debug.log; fi
-            # 3.1 play (resume) current
-            if [ $DEBUG == "true" ]; then echo "3.1 play (resume) current" >> $PATHDATA/../logs/debug.log; fi
-            $PATHDATA/playout_controls.sh -c=playlistaddplay -v="${FOLDER}"
-        fi
-
-    else
-        if [ $DEBUG == "true" ]; then echo "Path not found $AUDIOFOLDERSPATH/$FOLDER" >> $PATHDATA/../logs/debug.log; fi
+	
+        # load new playlist and play
+        $PATHDATA/playout_controls.sh -c=playlistaddplay -v="${FOLDER}"
     fi
-
-    # write RFID to file 
-    # because webapp is also pushed from htdocs/inc.header.php to this script,
-    # but without a CARDID, only -d (FOLDER), we need to check IF CARDID is set.
-    if [ "$CARDID" ]; then
-        echo "${CARDID}" > $PATHDATA/../settings/Latest_RFID_Played
-    fi
-    # write foldername triggered by RFID to file 
-    echo "${FOLDER}" > $PATHDATA/../settings/Latest_Folder_Played
 fi


### PR DESCRIPTION
I've simplified the "second swipe" implementation. It has only approx 10 lines now.
I've used https://github.com/MiczFlor/RPi-Jukebox-RFID/commit/d690d423cba561e6a7189a5f22edd386f5e7c24c as the base as the rfid_trigger_play.sh got confusing over the last commits.

Another change, which is not essential for the functionality of this "second swipe" implementation, is that the unused playlists in /tmp aren't deleted anymore (which was a quick hack when i wrote it). The last played folder is tracked in the Last_Folder_Played file now and read by resume play. This change is done to enable playlists in the future e.g. like in #126 .