### PR TITLE
Optimized shuffle mode for rfid control [issue #130] 

### DIFF
--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -9,7 +9,7 @@
 
 # $DEBUG true|false
 # prints $COMMAND in the terminal and/or log file
-DEBUG=false
+DEBUG=true
 
 # Set the date and time of now
 NOW=`date +%Y-%m-%d.%H:%M:%S`
@@ -107,7 +107,7 @@ AUDIOFOLDERSPATH=`cat $PATHDATA/../settings/Audio_Folders_Path`
 #echo $VOLSTEP
 #echo $VOLFILE
 #echo $MAXVOL
-#echo `cat $VOLFILE`
+#echo $VOLFILE
 #echo $IDLETIME
 #echo $AUDIOFOLDERSPATH
 
@@ -131,12 +131,9 @@ if [ $DEBUG == "true" ]; then echo "VAR VALUE: $VALUE" >> $PATHDATA/../logs/debu
 case $COMMAND in 
     shutdown)
         $PATHDATA/resume_play.sh -c=savepos && mpc clear
-    	#remove shuffle mode
-	if [ -e $AUDIOFOLDERSPATH/random.txt ]
-        then
-            sudo rm $AUDIOFOLDERSPATH/random.txt
-            mpc random off
-        fi
+    	#remove shuffle mode if active
+	SHUFFLE_STATUS=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep -o -P '(?<=random: ).*')
+        if [ "$SHUFFLE_STATUS" == 1 ] ; then  mpc random off; fi
 	sleep 1
         /usr/bin/mpg123 $PATHDATA/../shared/shutdownsound.mp3 
         sleep 3
@@ -145,12 +142,9 @@ case $COMMAND in
     shutdownsilent)
         # doesn't play a shutdown sound
         $PATHDATA/resume_play.sh -c=savepos && mpc clear
-        #remove shuffle mode
-        if [ -e $AUDIOFOLDERSPATH/random.txt ]
-        then
-            sudo rm $AUDIOFOLDERSPATH/random.txt
-            mpc random off
-        fi
+        #remove shuffle mode if active
+        SHUFFLE_STATUS=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep -o -P '(?<=random: ).*')
+        if [ "$SHUFFLE_STATUS" == 1 ] ; then  mpc random off; fi
 	sudo halt
         ;;
     shutdownafter)
@@ -165,12 +159,9 @@ case $COMMAND in
         ;;
     reboot)
         $PATHDATA/resume_play.sh -c=savepos && mpc clear
-	#remove shuffle mode
-        if [ -e $AUDIOFOLDERSPATH/random.txt ]
-        then
-            sudo rm $AUDIOFOLDERSPATH/random.txt
-            mpc random off
-        fi
+	#remove shuffle mode if active
+        SHUFFLE_STATUS=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep -o -P '(?<=random: ).*')
+        if [ "$SHUFFLE_STATUS" == 1 ] ; then  mpc random off; fi
         sudo reboot
         ;;
     mute)
@@ -328,17 +319,10 @@ case $COMMAND in
         esac
         ;;
     playershuffle)
-        # activates random file order permanently (not only the current playlist)
-        # Remark: IF $AUDIOFOLDERSPATH/random.txt exists, random will be deactivated 
+        # toogles shuffle mode on/off (not only the current playlist but for the whole mpd)
+        # this is why a check if "random on" has to be done for shutdown and reboot
         # This command may be called with ./playout_controls.sh -c=playershuffle
-	if [ -e $AUDIOFOLDERSPATH/random.txt ]
-        then
-            sudo rm $AUDIOFOLDERSPATH/random.txt
-	    mpc random off
-        else
-	    sudo echo $VALUE > $AUDIOFOLDERSPATH/random.txt
-	    mpc random on
-	fi
+	mpc random
 	;;
     playlistclear)
         # clear playlist

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -9,7 +9,7 @@
 
 # $DEBUG true|false
 # prints $COMMAND in the terminal and/or log file
-DEBUG=true
+DEBUG=false
 
 # Set the date and time of now
 NOW=`date +%Y-%m-%d.%H:%M:%S`

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -131,7 +131,13 @@ if [ $DEBUG == "true" ]; then echo "VAR VALUE: $VALUE" >> $PATHDATA/../logs/debu
 case $COMMAND in 
     shutdown)
         $PATHDATA/resume_play.sh -c=savepos && mpc clear
-        sleep 1
+    	#remove shuffle mode
+	if [ -e $AUDIOFOLDERSPATH/random.txt ]
+        then
+            sudo rm $AUDIOFOLDERSPATH/random.txt
+            mpc random off
+        fi
+	sleep 1
         /usr/bin/mpg123 $PATHDATA/../shared/shutdownsound.mp3 
         sleep 3
         sudo halt
@@ -139,7 +145,13 @@ case $COMMAND in
     shutdownsilent)
         # doesn't play a shutdown sound
         $PATHDATA/resume_play.sh -c=savepos && mpc clear
-        sudo halt
+        #remove shuffle mode
+        if [ -e $AUDIOFOLDERSPATH/random.txt ]
+        then
+            sudo rm $AUDIOFOLDERSPATH/random.txt
+            mpc random off
+        fi
+	sudo halt
         ;;
     shutdownafter)
         # remove shutdown times if existent
@@ -153,6 +165,12 @@ case $COMMAND in
         ;;
     reboot)
         $PATHDATA/resume_play.sh -c=savepos && mpc clear
+	#remove shuffle mode
+        if [ -e $AUDIOFOLDERSPATH/random.txt ]
+        then
+            sudo rm $AUDIOFOLDERSPATH/random.txt
+            mpc random off
+        fi
         sudo reboot
         ;;
     mute)
@@ -313,8 +331,6 @@ case $COMMAND in
         # activates random file order permanently (not only the current playlist)
         # Remark: IF $AUDIOFOLDERSPATH/random.txt exists, random will be deactivated 
         # This command may be called with ./playout_controls.sh -c=playershuffle
-        # sudo echo $VALUE > $AUDIOFOLDERSPATH/random.txt
-
 	if [ -e $AUDIOFOLDERSPATH/random.txt ]
         then
             sudo rm $AUDIOFOLDERSPATH/random.txt

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -9,7 +9,7 @@
 
 # $DEBUG true|false
 # prints $COMMAND in the terminal and/or log file
-DEBUG=false
+DEBUG=true
 
 # Set the date and time of now
 NOW=`date +%Y-%m-%d.%H:%M:%S`
@@ -44,6 +44,7 @@ NOW=`date +%Y-%m-%d.%H:%M:%S`
 # playerplay
 # playerreplay
 # playerrepeat
+# playershuffle
 # playlistclear
 # playlistaddplay
 # playlistadd
@@ -186,7 +187,7 @@ case $COMMAND in
             # read volume in percent
             VOLPERCENT=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep -o -P '(?<=volume: ).*')
             # increase by $VOLSTEP
-            VOLPERCENT=`expr ${VOLPERCENT} + ${VOLSTEP}` 
+	    VOLPERCENT=`expr ${VOLPERCENT} + ${VOLSTEP}` 
             #increase volume only if VOLPERCENT is below the max volume limit
             if [ $VOLPERCENT -le $MAXVOL ];
             then
@@ -308,6 +309,21 @@ case $COMMAND in
                 ;;
         esac
         ;;
+    playershuffle)
+        # activates random file order permanently (not only the current playlist)
+        # Remark: IF $AUDIOFOLDERSPATH/random.txt exists, random will be deactivated 
+        # This command may be called with ./playout_controls.sh -c=playershuffle
+        # sudo echo $VALUE > $AUDIOFOLDERSPATH/random.txt
+
+	if [ -e $AUDIOFOLDERSPATH/random.txt ]
+        then
+            sudo rm $AUDIOFOLDERSPATH/random.txt
+	    mpc random off
+        else
+	    sudo echo $VALUE > $AUDIOFOLDERSPATH/random.txt
+	    mpc random on
+	fi
+	;;
     playlistclear)
         # clear playlist
         $PATHDATA/resume_play.sh -c=savepos

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -86,7 +86,7 @@ if [ "$CARDID" ]; then
 
     case $CARDID in 
 	$CMDSHUFFLE)
-	    # sets random=on or =off
+	    # toogles shuffle mode  (random on/off)
             $PATHDATA/playout_controls.sh -c=playershuffle
 	    ;;
         $CMDMUTE)

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -24,7 +24,7 @@
 
 #############################################################
 # $DEBUG true|false
-DEBUG=true
+DEBUG=false
 
 # Set the date and time of now
 NOW=`date +%Y-%m-%d.%H:%M:%S`
@@ -85,11 +85,10 @@ if [ "$CARDID" ]; then
     # Special uses are for example volume changes, skipping, muting sound.
 
     case $CARDID in 
-	#SCA Shuffle mode
 	$CMDSHUFFLE)
+	    # sets random=on or =off
             $PATHDATA/playout_controls.sh -c=playershuffle
 	    ;;
-
         $CMDMUTE)
             # amixer sset 'PCM' 0%
             $PATHDATA/playout_controls.sh -c=mute

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -85,7 +85,7 @@ if [ "$CARDID" ]; then
     # Special uses are for example volume changes, skipping, muting sound.
 
     case $CARDID in 
-	#SCA 15.08.2018 Shuffle mode
+	#SCA Shuffle mode
 	$CMDSHUFFLE)
             $PATHDATA/playout_controls.sh -c=playershuffle
 	    ;;

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -85,6 +85,11 @@ if [ "$CARDID" ]; then
     # Special uses are for example volume changes, skipping, muting sound.
 
     case $CARDID in 
+	#SCA 15.08.2018 Shuffle mode
+	$CMDSHUFFLE)
+            $PATHDATA/playout_controls.sh -c=playershuffle
+	    ;;
+
         $CMDMUTE)
             # amixer sset 'PCM' 0%
             $PATHDATA/playout_controls.sh -c=mute


### PR DESCRIPTION
Adds a shuffle mode for MPD to be triggered by RFID card.
The shuffle mode stays permanently active until deactivation (also after shutdown and reboot).
That is why i decided to automatically set random off (if currently active) during shutdown and reboot.

_Scenario: You use your toddlers phoniebox as party jukebox in the evening and shuffle over folders with your music and forget to deactivate the shuffle mode. 
Next morning your toddler gets crazy because his preferred fairytale plays the chapters in random mode => Therefore the automatism_

**Update:** This time without the need to create an extra random.txt file. 
Thanks to @zxa 