### PR TITLE
Add separated variables and an additional timeout for Reader_RDM6300

### DIFF
--- a/scripts/Reader_RDM6300.py
+++ b/scripts/Reader_RDM6300.py
@@ -1,0 +1,44 @@
+"""
+Support for the RDM6300 serial RFID module
+
+1.) Connect the RDM6300 module
+------------------------------
+Connect the RDM6300 module to the serial GPIO pins 14 and 15.
+
+2.) Enable GPIO serial port
+---------------------------
+Edit the /boot/config.txt (sudo nano /boot/config.txt) and add the following line:
+    enable_uart=1
+
+3.) Install dependecies
+-----------------------
+Be aware not to install the "serial" module, install "pyserial" instead and the RPi.GPIO module:
+    pip install pyserial RPi.GPIO
+
+4.) Replace the default Reader.py
+---------------------------------
+Replace the Reader.py file with the Reader_RDM6300.py:
+mv Reader.py Reader_default.py; mv Reader_RDM6300.py Reader.py
+"""
+
+
+import RPi.GPIO as GPIO
+import serial
+import string
+
+
+class Reader:
+    def __init__(self):
+        GPIO.setmode(GPIO.BCM)
+        self.rfid_serial = serial.Serial('/dev/ttyS0', 9600)
+
+    def readCard(self):
+        while True:
+            card_id = ''
+            read_byte = self.rfid_serial.read()
+            if read_byte == b'\x02':
+                while read_byte != b'\x03':
+                    read_byte = self.rfid_serial.read()
+                    card_id += read_byte.decode('utf-8')
+                card_id = ''.join(x for x in card_id if x in string.printable)
+                return card_id

--- a/scripts/Reader_RDM6300.py
+++ b/scripts/Reader_RDM6300.py
@@ -29,16 +29,27 @@ import string
 
 class Reader:
     def __init__(self):
+        self.last_id = ''
+        device = '/dev/ttyS0'
+        baudrate = 9600
+        ser_timeout = 0.1
+
         GPIO.setmode(GPIO.BCM)
-        self.rfid_serial = serial.Serial('/dev/ttyS0', 9600)
+        self.rfid_serial = serial.Serial(device, baudrate, timeout=ser_timeout)
 
     def readCard(self):
         while True:
             card_id = ''
-            read_byte = self.rfid_serial.read()
-            if read_byte == b'\x02':
-                while read_byte != b'\x03':
-                    read_byte = self.rfid_serial.read()
-                    card_id += read_byte.decode('utf-8')
-                card_id = ''.join(x for x in card_id if x in string.printable)
-                return card_id
+            try:
+                read_byte = self.rfid_serial.read()
+                if read_byte == b'\x02':
+                    while read_byte != b'\x03':
+                        read_byte = self.rfid_serial.read()
+                        card_id += read_byte.decode('utf-8')
+                    card_id = ''.join(x for x in card_id if x in string.printable)
+                    self.last_id = card_id
+                    return card_id
+
+            except ValueError as e:
+                print(e)
+                return self.last_id


### PR DESCRIPTION
This commit moves the device and baudrate in additional variables and adds a timeout to prevent an infinite loop if last byte could not be read. Alos added a self.last_id variable which returns the last read card, if an exception is raised.
