### PR TITLE
RDM6300 V2: Add separated variables and an additional timeout

### DIFF
--- a/scripts/Reader_RDM6300.py
+++ b/scripts/Reader_RDM6300.py
@@ -29,16 +29,27 @@ import string
 
 class Reader:
     def __init__(self):
+        self.last_id = ''
+        device = '/dev/ttyS0'
+        baudrate = 9600
+        ser_timeout = 0.1
+
         GPIO.setmode(GPIO.BCM)
-        self.rfid_serial = serial.Serial('/dev/ttyS0', 9600)
+        self.rfid_serial = serial.Serial(device, baudrate, timeout=ser_timeout)
 
     def readCard(self):
         while True:
             card_id = ''
-            read_byte = self.rfid_serial.read()
-            if read_byte == b'\x02':
-                while read_byte != b'\x03':
-                    read_byte = self.rfid_serial.read()
-                    card_id += read_byte.decode('utf-8')
-                card_id = ''.join(x for x in card_id if x in string.printable)
-                return card_id
+            try:
+                read_byte = self.rfid_serial.read()
+                if read_byte == b'\x02':
+                    while read_byte != b'\x03':
+                        read_byte = self.rfid_serial.read()
+                        card_id += read_byte.decode('utf-8')
+                    card_id = ''.join(x for x in card_id if x in string.printable)
+                    self.last_id = card_id
+                    return card_id
+
+            except ValueError as e:
+                print(e)
+                return self.last_id

--- a/scripts/Reader_RDM6300.py
+++ b/scripts/Reader_RDM6300.py
@@ -29,7 +29,6 @@ import string
 
 class Reader:
     def __init__(self):
-        self.last_id = ''
         device = '/dev/ttyS0'
         baudrate = 9600
         ser_timeout = 0.1
@@ -47,9 +46,10 @@ class Reader:
                         read_byte = self.rfid_serial.read()
                         card_id += read_byte.decode('utf-8')
                     card_id = ''.join(x for x in card_id if x in string.printable)
-                    self.last_id = card_id
+                    card_id
                     return card_id
 
             except ValueError as e:
                 print(e)
-                return self.last_id
+                self.readCard()
+


### PR DESCRIPTION
This commit moves the device and baudrate (default is used) in additional variables.

It adds a timeout to prevent an infinite loop, if last byte could not be read.

Also added an exception handling vor ValueErrors to prevent to return invalid UUIDs