### PR TITLE
Prevent spamming UUIDs, remove RPI.GPIO module, add improved error handling and a cleanup method using atexit

### DIFF
--- a/scripts/Reader_RDM6300.py
+++ b/scripts/Reader_RDM6300.py
@@ -12,8 +12,8 @@ Edit the /boot/config.txt (sudo nano /boot/config.txt) and add the following lin
 
 3.) Install dependecies
 -----------------------
-Be aware not to install the "serial" module, install "pyserial" instead and the RPi.GPIO module:
-    pip install pyserial RPi.GPIO
+Be aware not to install the "serial" module, install "pyserial" instead:
+    pip install pyserial
 
 4.) Replace the default Reader.py
 ---------------------------------
@@ -21,10 +21,9 @@ Replace the Reader.py file with the Reader_RDM6300.py:
 mv Reader.py Reader_default.py; mv Reader_RDM6300.py Reader.py
 """
 
-
-import RPi.GPIO as GPIO
 import serial
 import string
+import atexit
 
 
 class Reader:
@@ -32,24 +31,45 @@ class Reader:
         device = '/dev/ttyS0'
         baudrate = 9600
         ser_timeout = 0.1
-
-        GPIO.setmode(GPIO.BCM)
-        self.rfid_serial = serial.Serial(device, baudrate, timeout=ser_timeout)
+        self.last_card_id = ''
+        atexit.register(self.cleanup)
+        try:
+            self.rfid_serial = serial.Serial(device, baudrate, timeout=ser_timeout)
+        except serial.SerialException as e:
+            print(e)
+            exit(1)
 
     def readCard(self):
-        while True:
-            card_id = ''
-            try:
-                read_byte = self.rfid_serial.read()
-                if read_byte == b'\x02':
-                    while read_byte != b'\x03':
-                        read_byte = self.rfid_serial.read()
-                        card_id += read_byte.decode('utf-8')
-                    card_id = ''.join(x for x in card_id if x in string.printable)
-                    card_id
-                    return card_id
+        byte_card_id = b''
 
-            except ValueError as e:
-                print(e)
-                self.readCard()
+        try:
+            while True:
+                try:
+                    read_byte = self.rfid_serial.read()
 
+                    if read_byte == b'\x02':    # start byte
+                        while read_byte != b'\x03':     # end bye
+                            read_byte = self.rfid_serial.read()
+                            byte_card_id += read_byte
+
+                        card_id = byte_card_id.decode('utf-8')
+                        byte_card_id = ''
+                        card_id = ''.join(x for x in card_id if x in string.printable)
+
+                        # Only return UUIDs with correct length
+                        if len(card_id) == 12 and card_id != self.last_card_id:
+                            self.last_card_id = card_id
+                            self.rfid_serial.reset_input_buffer()
+                            return self.last_card_id
+
+                        else:   # wrong UUID length or aleady send that UUID last time
+                            self.rfid_serial.reset_input_buffer()
+
+                except ValueError as ve:
+                    print(ve)
+
+        except serial.SerialException as se:
+            print(se)
+
+    def cleanup(self):
+        self.rfid_serial.close()


### PR DESCRIPTION
The readCard() method will only return an UUID if it's got the correct length and wasn't returned last time to prevent stuttering caused by spamming unnecessary or wrong data. Add improved error handling for SerialExceptions and close the used ports using the Serial.closed() method registered with atexit. Remove unused RPi.GPIO module from code.