### PR TITLE
Settings for 'second swipe' and bug fixes

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -45,10 +45,20 @@ piped to `playout_controls.sh -c=playlistaddplay -v=...`
 Created in script `rfid_trigger_play.sh`
 
 ### `settings/Latest_Folder_Played`
-Contains the last folder that was played. 
+Contains the last folder that was being played. 
 Created in `playout_controls.sh` AND `rfid_trigger_play.sh` (currently all play triggers - webapp and RFID are
 piped through `rfid_trigger_play.sh`. So it seems redundant. But who knows if at a later dev stage
 some scripts might use only `playout_controls.sh`). 
+
+### `settings/Latest_Playlist_Played`
+Contains the last playlist name that was being played. 
+Used in `rfid_trigger_play.sh` to establish if a second swipe on the same playlist was made. 
+
+### `settings/Second_Swipe`
+Contains RESTART or PAUSE. 
+This establises if a second swipe of the same RFID card either starts the playlist from the beginning (RESTART)
+or toggles pause and play (PAUSE) for the current playlist.
+The value can be changed in the web app under settings.
 
 This feature is helpful for powerbank users who want to save battery power. It shuts down the idle Phoniebox after a specified number of minutes.
 If you want to use the *idle shutdown* feature, you can specify the number of minutes in this file, after which the Phoniebox will shut down when either the audio player is not playing and/or the sound has been muted.

--- a/htdocs/inc.header.php
+++ b/htdocs/inc.header.php
@@ -72,12 +72,15 @@ include("func.php");
 $conf['scripts_abs'] = realpath(getcwd().'/../scripts/');
 // path to shared folder from github repo on RPi
 $conf['shared_abs'] = realpath(getcwd().'/../shared/');
+// path to settings folder from github repo on RPi
+$conf['settings_abs'] = realpath(getcwd().'/../settings/');
 
 /*
 * Vars from the settings folder
 */
-$Audio_Folders_Path = trim(file_get_contents('../settings/Audio_Folders_Path'));
-$Latest_Folder_Played = trim(file_get_contents('../settings/Latest_Folder_Played'));
+$Audio_Folders_Path = trim(file_get_contents($conf['settings_abs'].'/Audio_Folders_Path'));
+$Latest_Folder_Played = trim(file_get_contents($conf['settings_abs'].'/Latest_Folder_Played'));
+$Second_Swipe = trim(file_get_contents($conf['settings_abs'].'/Second_Swipe'));
 
 /*******************************************
 * URLPARAMETERS

--- a/htdocs/inc.loadedPlaylist.php
+++ b/htdocs/inc.loadedPlaylist.php
@@ -50,10 +50,10 @@ print '
                             <div class="col-xs-1">
                                 <i class="mdi mdi-'. $playerStatus['state'] .'"></i>
                             </div>
-                            <div class="col-xs-8 col-md-9">
+                            <div class="col-xs-7">
                                 '.$playerStatus['file'].'
                             </div> 
-                            <div class="col-xs-2">
+                            <div class="col-xs-4">
                                 <span class="badge">'.date("i:s",$playerStatus['elapsed']);
                                 // Livestream and podcasts have no time length, show only elapsed time
                                 if ( $plTime['1'][$playerStatus['pos']] > 0 ) {
@@ -66,10 +66,10 @@ print '
                             <div class="col-xs-1">
                                 <i class="mdi mdi-playlist-play"></i>
                             </div>
-                            <div class="col-xs-8 col-md-9">
+                            <div class="col-xs-7">
                                 <a data-toggle="collapse" href="#collapse1" class="panel-title">Show playlist</a>
                             </div>
-                            <div class="col-xs-2">';
+                            <div class="col-xs-4">';
                                 // Livestream and podcasts have no time length, check to suppress badge
                                 if ( $playlistOverallTime > 0 ) {
                                     print '<span class="badge">'.date("i:s",$playlistPlayedTime).' / '.date("i:s",$playlistOverallTime).'</span>';
@@ -87,13 +87,13 @@ print '
                         print '
                         <li class="list-group-item">
                             <div class="row">
-                                <div class="col-xs-2 col-md-1">
+                                <div class="col-xs-1">
                                     <a href="?playpos='.$i.'" class="btn btn-success"><i class="mdi mdi-play" aria-hidden="true"></i></a>
                                 </div>
-                                <div class="col-xs-8 col-md-9">
+                                <div class="col-xs-7">
                                     '.$trackname.'
                                 </div>
-                                <div class="col-xs-2">';
+                                <div class="col-xs-4">';
                                     // Livestreams and podcasts have no time length, check to suppress badge
                                     if ( $plTime['1'][$i] > 0 ) {
                                         print '<span class="badge">'.date("i:s",$plTime['1'][$i]).'</span>';

--- a/htdocs/inc.setSecondSwipe.php
+++ b/htdocs/inc.setSecondSwipe.php
@@ -1,0 +1,61 @@
+<!--
+Set Second Swipe
+When you swipe the same RFID a second time, what happens? Start the playlist again? Toggle pause/play?
+-->
+<?php
+if(isset($_POST['secondSwipe']) && trim($_POST['secondSwipe']) != "") {
+    /*
+    * make sure it is a value we can accept, do not just write whatever is in the POST
+    */
+    if(trim($_POST['secondSwipe']) == "RESTART") {
+        $Second_Swipe = "RESTART";
+        $exec = 'echo "'.$Second_Swipe.'" > '.$conf['settings_abs'].'/Second_Swipe';
+        if($debug == "true") {
+            print $exec;
+        } else {
+            exec($exec);
+        }
+    } elseif(trim($_POST['secondSwipe']) == "PAUSE") {
+        $Second_Swipe = "PAUSE";
+        $exec = 'echo "'.$Second_Swipe.'" > '.$conf['settings_abs'].'/Second_Swipe';
+        if($debug == "true") {
+            print $exec;
+        } else {
+            exec($exec);
+        }
+    }
+}
+?>
+        <!-- input-group --> 
+            <div class="row" style="margin-bottom:1em;">
+              <div class="col-md-6 col-xs-12">
+              <h4><?php print $lang['settingsSecondSwipeInfo']; ?></h4>
+                <form name='secondSwipe' method='post' action='<?php print $_SERVER['PHP_SELF']; ?>'>
+                  <div class="input-group my-group">
+                    <select id="secondSwipe" name="secondSwipe" class="selectpicker form-control">
+                    <?php
+                        print "
+                        <option value='RESTART'";
+                        if($Second_Swipe == "RESTART") {
+                            print " selected";
+                        }
+                        print ">".$lang['settingsSecondSwipeRestart'];
+                        print "</option>\n";
+                        print "
+                        <option value='PAUSE'";
+                        if($Second_Swipe == "PAUSE") {
+                            print " selected";
+                        }
+                        print ">".$lang['settingsSecondSwipePause'];
+                        print "</option>\n";
+                    ?>
+                    </select> 
+                    <span class="input-group-btn">
+                        <input type='submit' class="btn btn-default" name='submit' value='<?php print $lang['globalSet']; ?>'/>
+                    </span>
+                  </div>
+                </form>
+              </div>
+              
+            </div><!-- ./row -->
+        <!-- /input-group -->

--- a/htdocs/inc.viewFolderTree.php
+++ b/htdocs/inc.viewFolderTree.php
@@ -101,11 +101,13 @@ foreach($subfolders as $key => $subfolder) {
         /*
         * Check if folder.conf file exists. If not create it
         */
+        /* not needed to check and create folder conf on each load?
         if(!file_exists($subfolder."/folder.conf")) {
             $exec = $conf['scripts_abs'].'/inc.writeFolderConfig.sh -c="createDefaultFolderConf" -d="'.preg_replace('/\ /', ' ', $temp['path_rel']).'"';
             //print $exec;
             exec($exec);
         }
+        */
         /*
         print "<hr>
         ".$contentTree[$temp['path_abs']]['path_abs']." |

--- a/htdocs/inc.viewFolderTree.php
+++ b/htdocs/inc.viewFolderTree.php
@@ -85,7 +85,8 @@ foreach($subfolders as $key => $subfolder) {
         $temp['path_rel'] = substr($subfolder, strlen($Audio_Folders_Path) + 1, strlen($subfolder));
         // some special version with no slashes or whitespaces for IDs on the panel collapse
         $temp['id'] = preg_replace('/\//', '---', $temp['path_rel']);
-        $temp['id'] = "ID".preg_replace('/\ /', '-_-', $temp['id']);
+        $temp['id'] = preg_replace('/\ /', '-_-', $temp['id']);
+        $temp['id'] = "ID".preg_replace('/\:/', '-+-', $temp['id']);
         // count the level depth in the tree by counting the slashes in the path
         $temp['level'] = substr_count($temp['path_rel'], '/');
         // information about the content

--- a/htdocs/inc.viewFolderWell.php
+++ b/htdocs/inc.viewFolderWell.php
@@ -1,0 +1,94 @@
+<?php
+
+// get list of content for each folder
+$files = scandir($audiofolder);
+$accordion = "<h4>".$lang['indexContainsFiles']."</h4><ul>";
+foreach($files as $file) {
+// add file name to list, supress if it's lastplayed.dat
+    if(is_file($audiofolder."/".$file) && $file != "folder.conf"){
+        $accordion .= "\n<li>".$file;
+        $accordion .= " <a href='trackEdit.php?folder=$audiofolder&filename=$file'><i class='mdi mdi-wrench'></i> ".$lang['globalEdit']."</a>";
+        $accordion .= "</li>";
+    }
+}
+$accordion .= "</ul>";
+
+// get all IDs that match this folder
+$ids = ""; // print later
+$audiofolderbasename = trim(basename($audiofolder));
+if(in_array($audiofolderbasename, $shortcuts)) {
+    foreach ($shortcuts as $key => $value) {
+        if($value == $audiofolderbasename) {
+            $ids .= " <a href='cardEdit.php?cardID=$key'>".$key." <i class='mdi mdi-wrench'></i></a> | ";
+        }
+    }
+    $ids = rtrim($ids, "| "); // get rid of trailing slash
+}
+parse_str($Audio_Folders_Path.'/'.$audiofolder.'/folder.conf', $folderConf);
+$folderConfRaw = file_get_contents($audiofolder.'/folder.conf');
+// if folder not empty, display play button and content
+if ($accordion != "<h4>".$lang['indexContainsFiles']."</h4><ul></ul>") {
+    print "
+    <div class='col-md-6'>
+    <div class='well'>";
+    print "
+        <h4><i class='mdi mdi-folder'></i>
+            ".str_replace($Audio_Folders_Path.'/', '', $audiofolder)."
+            </h4>";
+    print "
+        <a href='?play=".$audiofolder."' class='btn btn-info'><i class='mdi mdi-play'></i> ".$lang['globalPlay']."</a> ";
+    // Adds a button to enable/disable resume play. Checks if lastplayed.dat exists and livestream.txt not (no resume for livestreams)
+
+    // RESUME BUTTON
+    // do not show any if there is a live stream in the folder
+    if (!in_array("livestream.txt", $files) ) {
+        $foundResume = "OFF";
+        if( file_exists($audiofolder."/folder.conf") && strpos(file_get_contents($audiofolder."/folder.conf"),'RESUME="ON"') !== false) {
+            $foundResume = "ON";
+        } else {
+        }
+    }
+    if( $foundResume == "OFF" ) {
+        // do stuff
+        print "<a href='?enableresume=".$audiofolder."' class='btn btn-warning '>".$lang['globalResume'].": ".$lang['globalOff']." <i class='mdi mdi-toggle-switch-off-outline' aria-hidden='true'></i></a> ";
+    } elseif($foundResume == "ON") {
+        print "<a href='?disableresume=".$audiofolder."' class='btn btn-success '>".$lang['globalResume'].": ".$lang['globalOn']." <i class='mdi mdi-toggle-switch' aria-hidden='true'></i></a>";
+    }
+    
+    // SHUFFLE BUTTON
+    // do not show any if there is a live stream in the folder
+    if (!in_array("livestream.txt", $files) ) {
+        $foundShuffle = "OFF";
+        if( file_exists($audiofolder."/folder.conf") && strpos(file_get_contents($audiofolder."/folder.conf"),'SHUFFLE="ON"') !== false) {
+            $foundShuffle = "ON";
+        }
+    }
+    if( $foundShuffle == "OFF" ) {
+        // do stuff
+        print "<a href='?enableshuffle=".$audiofolder."' class='btn btn-warning '>".$lang['globalShuffle'].": ".$lang['globalOff']." <i class='mdi mdi-toggle-switch-off-outline' aria-hidden='true'></i></a> ";
+    } elseif($foundShuffle == "ON") {
+        print "<a href='?disableshuffle=".$audiofolder."' class='btn btn-success '>".$lang['globalShuffle'].": ".$lang['globalOn']." <i class='mdi mdi-toggle-switch' aria-hidden='true'></i></a>";
+    }
+
+
+    print "
+        <span data-toggle='collapse' data-target='#folder".$idcounter."' class='btn btnFolder hoverGrey'>".$lang['indexShowFiles']." <i class='mdi mdi-folder-open'></i></span> ";
+    print "
+        <div id='folder".$idcounter."' class='collapse folderContent'>
+        ".$accordion."
+        </div>
+    ";
+    // print ID if any found
+    if($ids != "") {
+        print "
+        <br/>".$lang['globalCardId'].": ".$ids;
+    } else {
+        print "            
+        <br/>&nbsp;";
+    }
+    print "
+    </div><!-- ./well -->
+    </div><!-- ./row -->
+    ";
+}
+?>

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -44,7 +44,7 @@ if (isset($playerStatus['file'])) {
     print '
     <div class="row">
         <div class="col-lg-12">';
-            include("inc.loadedPlaylist.php");
+include("inc.loadedPlaylist.php");
     print '
         </div><!-- / .col-lg-12 -->
     </div><!-- /.row -->';

--- a/htdocs/lang/lang-en.php
+++ b/htdocs/lang/lang-en.php
@@ -137,6 +137,10 @@ $lang['settingsMaxVol'] = "Maximum Volume";
 $lang['settingsWifiRestart'] = "The changes applied to your WiFi connection require a restart to take effect.";
 $lang['settingsWifiSsidPlaceholder'] = "e.g.: PhonieHomie";
 $lang['settingsWifiSsidHelp'] = "The name under which your WiFi shows up as 'available network'";
+$lang['settingsSecondSwipe'] = "Second Swipe";
+$lang['settingsSecondSwipeInfo'] = "When you swipe the same RFID a second time, what happens? Start the playlist again? Toggle pause/play?";
+$lang['settingsSecondSwipeRestart'] = "Re-start playlist";
+$lang['settingsSecondSwipePause'] = "Toggle pause / play";
 
 /*
 * System info

--- a/htdocs/settings.php
+++ b/htdocs/settings.php
@@ -41,6 +41,9 @@ if($debug == "true") {
         </a> | 
         <a href="#externalInterfaces" class="xbtn xbtn-default ">
         <i class='mdi mdi-usb'></i> <?php print $lang['globalExternalInterfaces']; ?>
+        </a>  | 
+        <a href="#secondSwipe" class="xbtn xbtn-default ">
+        <i class='mdi mdi-cards-outline'></i> <?php print $lang['settingsSecondSwipe']; ?>
         </a> 
   </div>
 </div>
@@ -145,6 +148,23 @@ include("inc.setWifi.php");
       <div class="panel-body">
 <?php
 include("inc.setInputDevices.php");
+?>
+      </div><!-- /.panel-body -->
+    
+  </div><!-- /.panel -->
+</div><!-- /.panel-group -->
+
+<div class="panel-group">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title"><a name="secondSwipe"></a>
+        <i class='mdi mdi-cards-outline'></i> <?php print $lang['settingsSecondSwipe']; ?>
+      </h4>
+    </div><!-- /.panel-heading -->
+    
+      <div class="panel-body">
+<?php
+include("inc.setSecondSwipe.php");
 ?>
       </div><!-- /.panel-body -->
     

--- a/scripts/installscripts/stretch-install-default.sh
+++ b/scripts/installscripts/stretch-install-default.sh
@@ -444,6 +444,7 @@ echo "$DIRaudioFolders" > /home/pi/RPi-Jukebox-RFID/settings/Audio_Folders_Path
 echo "3" > /home/pi/RPi-Jukebox-RFID/settings/Audio_Volume_Change_Step
 echo "100" > /home/pi/RPi-Jukebox-RFID/settings/Max_Volume_Limit
 echo "0" > /home/pi/RPi-Jukebox-RFID/settings/Idle_Time_Before_Shutdown
+echo "RESTART" > /home/pi/RPi-Jukebox-RFID/settings/Second_Swipe
 
 # make sure bash scripts have the right settings
 sudo chown pi:pi /home/pi/RPi-Jukebox-RFID/scripts/*.sh

--- a/scripts/playlist_recursive_by_folder.php
+++ b/scripts/playlist_recursive_by_folder.php
@@ -176,7 +176,7 @@ foreach($files_playlist as $file_playlist) {
         $return .= $file_playlist."\n";
     }
 }
-
-print trim($return);
+print $return;
+//print trim($return);
 
 ?>

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -366,7 +366,7 @@ case $COMMAND in
         if [ $DEBUG == "true" ]; then echo "VAR Latest_Folder_Played: $Latest_Folder_Played" >> $PATHDATA/../logs/debug.log; fi
 
         mpc load "${VALUE//\//SLASH}" && $PATHDATA/resume_play.sh -c=resume
-        if [ "$DEBUG" == "true" ]; then echo "mpc load "${VALUE}" && $PATHDATA/resume_play.sh -c=resume"; fi
+        if [ "$DEBUG" == "true" ]; then echo "mpc load "${VALUE//\//SLASH}" && $PATHDATA/resume_play.sh -c=resume"; fi
         # call shuffle_ceck to enable/disable folder-based shuffeling
         $PATHDATA/shuffle_play.sh -c=shuffle_check
         if [ $DEBUG == "true" ]; then echo "entering: shuffle_play.sh to execute shuffle_check" >> $PATHDATA/../logs/debug.log; fi

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -27,7 +27,7 @@
 
 #############################################################
 # $DEBUG true|false
-DEBUG=true
+DEBUG=false
 
 # Set the date and time of now
 NOW=`date +%Y-%m-%d.%H:%M:%S`

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -49,6 +49,7 @@ fi
 # 1. create a default if file does not exist
 if [ ! -f $PATHDATA/../settings/Audio_Folders_Path ]; then
     echo "/home/pi/RPi-Jukebox-RFID/shared/audiofolders" > $PATHDATA/../settings/Audio_Folders_Path
+    chmod 777 $PATHDATA/../settings/Audio_Folders_Path
 fi
 # 2. then|or read value from file
 AUDIOFOLDERSPATH=`cat $PATHDATA/../settings/Audio_Folders_Path`
@@ -57,9 +58,22 @@ AUDIOFOLDERSPATH=`cat $PATHDATA/../settings/Audio_Folders_Path`
 # 1. create a default if file does not exist
 if [ ! -f $PATHDATA/../settings/Playlists_Folders_Path ]; then
     echo "/tmp" > $PATHDATA/../settings/Playlists_Folders_Path
+    chmod 777 $PATHDATA/../settings/Playlists_Folders_Path
 fi
 # 2. then|or read value from file
 PLAYLISTSFOLDERPATH=`cat $PATHDATA/../settings/Playlists_Folders_Path`
+
+##############################################
+# Second swipe
+# What happens when the same card is swiped a second time?
+# RESTART => start the playlist again vs. PAUSE => toggle pause and play current
+# 1. create a default if file does not exist
+if [ ! -f $PATHDATA/../settings/Second_Swipe ]; then
+    echo "RESTART" > $PATHDATA/../settings/Second_Swipe
+    chmod 777 $PATHDATA/../settings/Second_Swipe
+fi
+# 2. then|or read value from file
+SECONDSWIPE=`cat $PATHDATA/../settings/Second_Swipe`
 
 # Read configuration file
 . $PATHDATA/../settings/rfid_trigger_play.conf
@@ -252,9 +266,9 @@ if [ $DEBUG == "true" ]; then echo "# Type of play \$VALUE: $VALUE" >> $PATHDATA
 # - $FOLDER is set (! -z ${FOLDER+x})
 # - AND (-a) 
 # - and points to existing directory (-d "$AUDIOFOLDERSPATH/$FOLDER")
-if [ ! -z "$FOLDER" -a ! -z ${FOLDER+x} -a -d "$AUDIOFOLDERSPATH/$FOLDER" ]; then
+if [ ! -z "$FOLDER" -a ! -z ${FOLDER+x} -a -d "${AUDIOFOLDERSPATH}/${FOLDER}" ]; then
 
-    if [ $DEBUG == "true" ]; then echo "\$FOLDER set, not empty and dir exists: $AUDIOFOLDERSPATH/$FOLDER" >> $PATHDATA/../logs/debug.log; fi
+    if [ $DEBUG == "true" ]; then echo "\$FOLDER set, not empty and dir exists: ${AUDIOFOLDERSPATH}/${FOLDER}" >> $PATHDATA/../logs/debug.log; fi
 
     # if we play a folder the first time, add some sensible information to the folder.conf
     if [ ! -f "$AUDIOFOLDERSPATH/$FOLDER/folder.conf" ]; then
@@ -271,12 +285,7 @@ if [ ! -z "$FOLDER" -a ! -z ${FOLDER+x} -a -d "$AUDIOFOLDERSPATH/$FOLDER" ]; the
     LASTFOLDER=$(cat $PATHDATA/../settings/Latest_Folder_Played)
     LASTPLAYLIST=$(cat $PATHDATA/../settings/Latest_Playlist_Played)
     if [ $DEBUG == "true" ]; then echo "Var \$LASTFOLDER: $LASTFOLDER" >> $PATHDATA/../logs/debug.log; fi
-    if [ $DEBUG == "true" ]; then echo "Var \$LASTPLAYLIST: $LASTPLAYLIST" >> $PATHDATA/../logs/debug.log; fi
-
-    # check if we have a the playlist already loaded which is associated with the rfid card ("second swipe").
-    # check the length of the playlist, if =0 then it was cleared before (a state, which should only
-    # be possible after a reboot).
-    
+    if [ $DEBUG == "true" ]; then echo "Var \$LASTPLAYLIST: $LASTPLAYLIST" >> $PATHDATA/../logs/debug.log; fi    
     if [ $DEBUG == "true" ]; then echo "Checking 'recursive' list? VAR \$VALUE: $VALUE" >> $PATHDATA/../logs/debug.log; fi
 
     if [ "$VALUE" == "recursive" ]; then
@@ -295,8 +304,15 @@ if [ ! -z "$FOLDER" -a ! -z ${FOLDER+x} -a -d "$AUDIOFOLDERSPATH/$FOLDER" ]; the
         if [ $DEBUG == "true" ]; then echo "$PATHDATA/playlist_recursive_by_folder.php folder=\"${FOLDER}\" > \"${PLAYLISTPATH}\""   >> $PATHDATA/../logs/debug.log; fi
     fi
 
+    # check if 
+    # - $SECONDSWIPE is set to toggle pause/play ("$SECONDSWIPE" == "PAUSE") 
+    # - AND (-a) 
+    # - The same playlist is cued up ("$LASTPLAYLIST" == "$PLAYLISTNAME")
+    # - AND (-a) 
+    # - check the length of the playlist, if =0 then it was cleared before, a state, which should only
+    #   be possible after a reboot ($PLLENGTH -gt 0)
     PLLENGTH=$(echo -e "status\nclose" | nc -w 1 localhost 6600 | grep -o -P '(?<=playlistlength: ).*')
-    if [ "$LASTPLAYLIST" == "$PLAYLISTNAME" ] && [ $PLLENGTH -gt 0 ]
+    if [ "$SECONDSWIPE" == "PAUSE" -a "$LASTPLAYLIST" == "$PLAYLISTNAME" -a $PLLENGTH -gt 0 ]
     then
         STATE=$(echo -e "status\nclose" | nc -w 1 localhost 6600 | grep -o -P '(?<=state: ).*')
         if [ $STATE == "play" ]
@@ -307,25 +323,25 @@ if [ ! -z "$FOLDER" -a ! -z ${FOLDER+x} -a -d "$AUDIOFOLDERSPATH/$FOLDER" ]; the
             if [ $DEBUG == "true" ]; then echo "MPD not playing, start playing" >> $PATHDATA/../logs/debug.log; fi
             sudo $PATHDATA/playout_controls.sh -c=playerplay &>/dev/null
         fi
-    # if this is not a "second swipe", check if folder $FOLDER exists and play content
-    # the process is as such - because of the recursive play option:
-    # - each folder can be played. 
-    # - a single folder will create a playlist with the same name as the folder
-    # - because folders can live inside other folders, the relative path might contain
-    #   slashes (e.g. audiobooks/Moby Dick/)
-    # - because slashes can not be in the playlist name, slashes are replaced with " % "
-    # - the "recursive" option means that the content of the folder AND all subfolders
-    #   is being played
-    # - in this case, the playlist is related to the same folder name, which means we need
-    #   to make a different name for "recursive" playout
-    # - a recursive playlist has the suffix " %RCRSV%" - keeping it cryptic to avoid clashes
-    #   with a possible "real" name for a folder
-    # - with this new logic, there are no more SPECIALFORMAT playlists. Live streams and podcasts
-    #   are now all unfolded into the playlist
-    # - creating the playlist is now done in the php script with parameters:
-    #   $PATHDATA/playlist_recursive_by_folder.php folder="${FOLDER}" list='recursive'
     elif [ -d "$AUDIOFOLDERSPATH/$FOLDER" ]
     then
+        # if this is not a "second swipe", check if folder $FOLDER exists and play content
+        # the process is as such - because of the recursive play option:
+        # - each folder can be played. 
+        # - a single folder will create a playlist with the same name as the folder
+        # - because folders can live inside other folders, the relative path might contain
+        #   slashes (e.g. audiobooks/Moby Dick/)
+        # - because slashes can not be in the playlist name, slashes are replaced with " % "
+        # - the "recursive" option means that the content of the folder AND all subfolders
+        #   is being played
+        # - in this case, the playlist is related to the same folder name, which means we need
+        #   to make a different name for "recursive" playout
+        # - a recursive playlist has the suffix " %RCRSV%" - keeping it cryptic to avoid clashes
+        #   with a possible "real" name for a folder
+        # - with this new logic, there are no more SPECIALFORMAT playlists. Live streams and podcasts
+        #   are now all unfolded into the playlist
+        # - creating the playlist is now done in the php script with parameters:
+        #   $PATHDATA/playlist_recursive_by_folder.php folder="${FOLDER}" list='recursive'
 
         if [ $DEBUG == "true" ]; then echo "VAR FOLDER: $FOLDER"   >> $PATHDATA/../logs/debug.log; fi
         if [ $DEBUG == "true" ]; then echo "VAR PLAYLISTPATH: $PLAYLISTPATH"   >> $PATHDATA/../logs/debug.log; fi


### PR DESCRIPTION
* There was a silly bug in the playlist creation: the last track was not played because it did not finish with a line break. Which means: single files did not play at all. Fixed now.
* Also, there was this discussion about the 'second swipe': https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/201 I added this feature now and it can be set in the settings of the web app. The two options: either start from the beginning or toggle play / pause