### PR TITLE
After system reboot last used RFID card doesn't work fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ settings/Latest_RFID
 settings/Max_Volume_Limit
 settings/Playlists_Folders_Path
 settings/rfid_trigger_play.conf
+settings/Second_Swipe
 htdocs/config.php
 scripts/gpio-buttons.py
 

--- a/scripts/daemon_rfid_reader.py
+++ b/scripts/daemon_rfid_reader.py
@@ -9,6 +9,18 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 
 print dir_path
 
+
+base_path = os.path.dirname(dir_path)
+
+try:
+   # clear last played folder and playlist to avoid that last card wasn't able to play after system reboot
+   subprocess.call(['echo "" >' + base_path + '/settings/Latest_Folder_Played'], shell=True)
+   subprocess.call(['echo "" >' + base_path + '/settings/Latest_Playlist_Played'], shell=True)
+except OSError as e:
+   print "Execution failed:"
+
+
+
 while True:
         # reading the card id
         cardid = reader.readCard()


### PR DESCRIPTION
Hi,
I had to clear the Last Played Playlist/Folder on system boot
after this the secondswipe not longer prevent me from using my card.

Kind regards
Marco