### PR TITLE
Set Startup volume with idle-watchdog on system startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ settings/Max_Volume_Limit
 settings/Playlists_Folders_Path
 settings/rfid_trigger_play.conf
 settings/Second_Swipe
+settings/Startup_Volume
 htdocs/config.php
 scripts/gpio-buttons.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ settings/Latest_RFID
 settings/Max_Volume_Limit
 settings/Playlists_Folders_Path
 settings/rfid_trigger_play.conf
+settings/Second_Swipe
 htdocs/config.php
 scripts/gpio-buttons.py
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -26,6 +26,11 @@ This is a file containing a number, by default `100`.
 If one is **using an audio amplifier** (like the pHAT BEAT) without a physical volume limiter (like a potentiometer) your Phoniebox can get very loud "accidentally". The maximal volume can be set in `settings/Max_Volume_Limit`.
 Can be edited in the *Settings* page of the web app.
 
+### `settings/Startup_Volume`
+This is a file containing a number (between 1-100), by default not existing.
+If somebody wants to reset volume on system startup you
+can do it with this setting.
+
 ### `settings/Audio_Volume_Change_Step`
 This is a file containing a number, by default `3`.
 Changing this number affects the `volumeup` and `volumedown` function in the web app or triggered by RFID cards. Increasing the number will result in larger volume jumps. Decreasing the number will result in smaller changes of the volume.

--- a/scripts/daemon_rfid_reader.py
+++ b/scripts/daemon_rfid_reader.py
@@ -9,6 +9,18 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 
 print dir_path
 
+
+base_path = os.path.dirname(dir_path)
+
+try:
+   # clear last played folder and playlist to avoid that last card wasn't able to play after system reboot
+   subprocess.call(['echo "" >' + base_path + '/settings/Latest_Folder_Played'], shell=True)
+   subprocess.call(['echo "" >' + base_path + '/settings/Latest_Playlist_Played'], shell=True)
+except OSError as e:
+   print "Execution failed:"
+
+
+
 while True:
         # reading the card id
         cardid = reader.readCard()

--- a/scripts/idle-watchdog.sh
+++ b/scripts/idle-watchdog.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 #Remove old shutdown commands from all 'at' queues after boot to prevent immediate shutdown
 for i in `sudo atq | awk '{print $1}'`;do sudo atrm $i;done
-#Give the RPi enough time to get the correct time via network
-#Otherwise there may be an immediate shutdown because this script may set a shutdown time dated in the past
-#in the first loop. If the Pi gets a correct time via network, "at" suddenly detects a overdue job, which is:
-#shutting down the Pi.  
-sleep 60
 
 PATHDATA="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -16,6 +11,21 @@ if [ ! -f $PATHDATA/../settings/Idle_Time_Before_Shutdown ]; then
 fi
 # 2. then|or read value from file
 IDLETIME=`cat $PATHDATA/../settings/Idle_Time_Before_Shutdown`
+
+
+# Set Startup Volume to value from settingsfile
+if [ -f $PATHDATA/../settings/Startup_Volume ]; then
+    # read value from settings file
+    STARTUPVOLUME=`cat $PATHDATA/../settings/Startup_Volume`
+    # give volume setting to mpc
+    $PATHDATA/playout_controls.sh -c=setvolume -v=$STARTUPVOLUME
+fi
+
+#Give the RPi enough time to get the correct time via network
+#Otherwise there may be an immediate shutdown because this script may set a shutdown time dated in the past
+#in the first loop. If the Pi gets a correct time via network, "at" suddenly detects a overdue job, which is:
+#shutting down the Pi.
+sleep 60
 
 #Go into infinite loop if idle time is greater 0
 while [ $IDLETIME -gt 0 ]


### PR DESCRIPTION
With setting "Startup_Volume" you can set the audio volume on system startup, If file exists the volume will be set to this value. Option not inplemented in WebGUI yet (i have now glue how it works (too dynamic for me in this moment ;-))