### PR TITLE
Activate amplifier & held gpio buttons

### DIFF
--- a/misc/sampleconfigs/gpio-buttons.py.sample
+++ b/misc/sampleconfigs/gpio-buttons.py.sample
@@ -3,6 +3,9 @@ from gpiozero import Button
 from signal import pause
 from subprocess import check_call
 
+# 2018-10-31
+# Added the function on holding volume + - buttons to change the volume in 0.3s interval
+#
 # 2018-10-15
 # this script has the `pull_up=True` for all pins. See the following link for additional info: 
 # https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/259#issuecomment-430007446
@@ -36,8 +39,8 @@ def def_halt():
 
 shut = Button(3, hold_time=2)
 vol0 = Button(13,pull_up=True)
-volU = Button(16,pull_up=True)
-volD = Button(19,pull_up=True)
+volU = Button(16,pull_up=True,hold_time=0.3,hold_repeat=True)
+volD = Button(19,pull_up=True,hold_time=0.3,hold_repeat=True)
 next = Button(26,pull_up=True)
 prev = Button(20,pull_up=True)
 halt = Button(21,pull_up=True)
@@ -45,7 +48,11 @@ halt = Button(21,pull_up=True)
 shut.when_held = def_shutdown
 vol0.when_pressed = def_vol0
 volU.when_pressed = def_volU
+#When the Volume Up button was held for more than 0.3 seconds every 0.3 seconds he will call a ra$
+volU.when_held = def_volU
 volD.when_pressed = def_volD
+#When the Volume Down button was held for more than 0.3 seconds every 0.3 seconds he will lower t$
+volD.when_held = def_volD
 next.when_pressed = def_next
 prev.when_pressed = def_prev
 halt.when_pressed = def_halt

--- a/misc/sampleconfigs/phoniebox-activate-amplifier.service.stretch-default.sample
+++ b/misc/sampleconfigs/phoniebox-activate-amplifier.service.stretch-default.sample
@@ -1,0 +1,11 @@
+[Unit]
+Description=Phoniebox Aplifier Activation Service
+After=network.target iptables.service firewalld.service
+
+[Service]
+Restart=always
+WorkingDirectory=/home/pi/RPi-Jukebox-RFID
+ExecStart=/home/pi/RPi-Jukebox-RFID/scripts/activate-amplifier.py
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/activate-amplifier.py
+++ b/scripts/activate-amplifier.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+
+# While running this script the PAM8403 gets a ON signal so amplifier has power. Else it is
+# switched of. This helps me
+# The application uses the GPIO Zero library (https://gpiozero.readthedocs.io/en/stable/)
+# The PAM8403 PIN 12 is connected to one of the Pi's GPIO ports, then is defined as an Output device
+# in GPIO Zero: https://gpiozero.readthedocs.io/en/stable/api_output.html#outputdevice
+
+import sys
+import time
+from signal import pause
+import gpiozero
+
+# change this value based on which GPIO port the PAM8403 PIN 12 is connected to
+PIN = 23
+
+# create a relay object.
+# Triggered by the output pin going low: active_high=False.
+# Initially off: initial_value=False
+amplifier = gpiozero.OutputDevice(PIN, active_high=True, initial_value=False)
+
+
+def set_amplifier(status):
+    if status:
+        print("Setting amplifier: ON")
+        amplifier.on()
+    else:
+        print("Setting amplifier: OFF")
+        amplifier.off()
+
+
+def toggle_amplifier():
+    print("toggling amplifier")
+    amplifier.toggle()
+
+if __name__ == "__main__":
+    try:
+        set_amplifier(True)
+	pause()
+    except KeyboardInterrupt:
+        # turn the relay off
+        set_amplifier(False)
+        print("\nExiting application\n")
+        # exit the application
+        sys.exit(0)
+


### PR DESCRIPTION
Hi,
hopefully I have done everything right now with branching and pulling. ;-) . It is late and I had many fun.

1) Added an service for activating my amplifier. I have a PAM8403 and with a little hardware hack on the PCB I was able to switch the amplifier on via GPIO and default is it off. 
I need to write a little bit of documentation for that hw hack but now it's to late. The HW modification is on this picutre.
![pam8403](https://user-images.githubusercontent.com/20782695/47759621-b55e2180-dcb0-11e8-9a21-c467705ae358.jpg)

2) I've implemented a function when holding the e.g. Volume Up button for more then 0.3 seconds it will raise in 0.3 second intervals the volume based on configured volume steps.

Kind regards
Marco
