### PR TITLE
Urgent update! Fix for local playlist issue! Merge to develop and master!!!

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -27,9 +27,9 @@ We introduce Phoniebox Editions. To distinguish them, we call them "Phoniebox Cl
 
 ~~~
 cd /home/pi/RPi-Jukebox-RFID
-git checkout develop
+git checkout master
 git fetch origin
-git reset --hard origin/develop
+git reset --hard origin/master
 git pull
 sudo systemctl stop mpd
 sudo systemctl stop mopidy

--- a/htdocs/inc.navigation.php
+++ b/htdocs/inc.navigation.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-default">
+<nav class="navbar navbar-default" style="position: -webkit-sticky; position: sticky; top: 0; z-index: 1000;">
   <div class="container-fluid">
     <!-- Brand and toggle get grouped for better mobile display -->
     <div class="navbar-header">

--- a/htdocs/manageFilesFolders.php
+++ b/htdocs/manageFilesFolders.php
@@ -111,7 +111,7 @@ if ($_POST['ACTION'] == "fileUpload") {
         // hang on, does that folder exist already?
         if(!file_exists($Audio_Folders_Path . "/" . $moveFolder)) {
             // no, so create the folder
-            $exec = 'mkdir "' . $moveFolder . '"; chown -R pi:www-data "' . $moveFolder . '"; chmod 775 "' . $moveFolder . '"';
+            $exec = 'mkdir "' . $moveFolder . '"; chown -R pi:www-data "' . $moveFolder . '"; chmod 777 "' . $moveFolder . '"';
             exec($exec);   
             $messageAction .= "Will create new folder and move files to: '" . $moveFolder . "'";
         } else {
@@ -122,7 +122,7 @@ if ($_POST['ACTION'] == "fileUpload") {
     /*
     * see if any valid folder has been chosen
     */
-    print "if(".realpath($moveFolder)." == ".realpath($Audio_Folders_Path).") {";
+    //print "if(".realpath($moveFolder)." == ".realpath($Audio_Folders_Path).") {";
     if(realpath($moveFolder) == realpath($Audio_Folders_Path)) {
         $messageWarning .= $lang['manageFilesFoldersErrorNoNewFolder'];
     }
@@ -132,7 +132,7 @@ if ($_POST['ACTION'] == "fileUpload") {
         // move files to folder
         foreach ($uFiles['ufile'] as $key => $values) {
             $targetName = $moveFolder . '/' . $values['name'];
-            $exec = 'mv "' . $values['tmp_name'] . '" "' . $targetName . '"; sudo chown -R pi:www-data "' . $targetName . '"; chmod 775 "' . $targetName . '"';
+            $exec = 'mv "' . $values['tmp_name'] . '" "' . $targetName . '"; chown -R pi:www-data "' . $targetName . '"; chmod 777 "' . $targetName . '"';
             exec($exec);
         }
         $messageSuccess = "<p>Files were successfully uploaded.</p>";
@@ -162,7 +162,7 @@ if ($_POST['ACTION'] == "folderCreateNew") {
         /*
         * create folder
         */        
-        $exec = 'mkdir "'.$Audio_Folders_Path.'/'.$newDirPathRel.'"; chmod 775 "'.$Audio_Folders_Path.'/'.$newDirPathRel.'"; chown -R pi:www-data "' . $Audio_Folders_Path.'/'.$newDirPathRel . '"';
+        $exec = 'mkdir "'.$Audio_Folders_Path.'/'.$newDirPathRel.'"; chmod 777 "'.$Audio_Folders_Path.'/'.$newDirPathRel.'"; chown -R pi:www-data "' . $Audio_Folders_Path.'/'.$newDirPathRel . '"';
         exec($exec);
         $messageSuccess = "<p>".$lang['manageFilesFoldersSuccessNewFolder']." '".$newDirPathRel."'</p>";
         


### PR DESCRIPTION
@MiczFlor 
I think i fixed the f***ing playlist issues. It was a simple CHMOD setting, which was wrong and the result was that uploaded files had CHMOD 600 and were not readable by Mopidy. I had no problems, because i uploaded all my files with FTP. So now, all files uploaded via WebUI should run after my fix is installed.

### Please check the need of CHOWN in "manageFilesFolders.php". Uploaded files are getting www-data:www-data by default from PHP. The exec of chown pi:www-data is not working. Is this really needed??

### EVERYONE HAS TO RUN THIS COMMAND ONCE AFTER INSTALLING THIS FIX INTO 1.1.8-beta:

Depending of the location of audiofolder (this is for default location):
`sudo chmod -R 777 /home/pi/RPi-Jukebox-RFID/shared/audiofolders/`

### SCAN MUSIC LIBRARY

After these steps, renew your database under Folders & Files.
