### PR TITLE
Added check if the device is a keyboard

### DIFF
--- a/scripts/Reader.py
+++ b/scripts/Reader.py
@@ -5,12 +5,23 @@ import string
 import os.path
 import sys
 
-from evdev import InputDevice, categorize, ecodes, list_devices
+from evdev import InputDevice, categorize, ecodes, list_devices, ecodes
 from select import select
 class Reader:
+
+	def is_Keyboard(self, device):
+		device_key_list = device.capabilities()[ecodes.EV_KEY]
+
+		if self.mandatory_keys.issubset(device_key_list) and self.reserved_key.isdisjoint(device_key_list):
+			return True
+		else:
+			return False
+
 	def __init__(self):
 		path = os.path.dirname(os.path.realpath(__file__))
 		self.keys = "X^1234567890XXXXqwertzuiopXXXXasdfghjklXXXXXyxcvbnmXXXXXXXXXXXXXXXXXXXXXXX"
+		self.mandatory_keys = {i for i in range(ecodes.KEY_ESC, ecodes.KEY_D)}
+		self.reserved_key = {0}
 		if not os.path.isfile(path + '/deviceName.txt'):
 			sys.exit('Please run RegisterDevice.py first')
 		else: 
@@ -18,7 +29,7 @@ class Reader:
 				deviceName = f.read()
 			devices = [InputDevice(fn) for fn in list_devices()]
 			for device in devices:
-				if device.name == deviceName:
+				if device.name == deviceName and self.is_Keyboard(device):
 					self.dev = device
 					break 		
 			try:


### PR DESCRIPTION
Hi,
I hope I got forking, branching and generating pull requests right now.
I would like to introduce my fix for the issue#231.
The KKMOON RFID Reader appears twice in the devices list as HID 413d:2107. One device is a mouse device and the other one is the keyboard device (we are interested in that).
Unfortunately the current reader code will pick the mouse device which cannot work.
My fix will additionally check if the device is a keyboard.

Any thoughts on my solution? 
Best regards
Christoph

p.s.: I just could test the code against the KKMOON reader. Can anyone check the code with other usb readers as well?
