### PR TITLE
switch cmd to let clean-shutdown.sh detect halt

### DIFF
--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -148,7 +148,7 @@ case $COMMAND in
         sleep 1
         /usr/bin/mpg123 $PATHDATA/../shared/shutdownsound.mp3 
         sleep 3
-        sudo halt
+        sudo poweroff
         ;;
     shutdownsilent)
         # doesn't play a shutdown sound
@@ -156,7 +156,7 @@ case $COMMAND in
         #remove shuffle mode if active
         SHUFFLE_STATUS=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep -o -P '(?<=random: ).*')
         if [ "$SHUFFLE_STATUS" == 1 ] ; then  mpc random off; fi
-	sudo halt
+	sudo poweroff
         ;;
     shutdownafter)
         # remove shutdown times if existent


### PR DESCRIPTION
Some hardware mods (like [pimoroni's OnOff SHIM](https://shop.pimoroni.de/products/onoff-shim#description) - got it for 4 Euro some days ago) needs the [clean-shutdown](https://github.com/pimoroni/clean-shutdown) script to work. It's triggerd by the command 'poweroff'
Phonies playout-control script uses 'halt' to poweroff the box. AFAICS switching to 'poweroff' is possible without loosing some functionallity. 'halt --poweroff' and 'poweroff' triggers the same system cmd.

Note: The OnOff SHIM completely cut off the power from the RPi so that you can power-off and power-on from a button. Neat solution to power the box with a powerbank.