### PR TITLE
Fixed Mopidy-Iris installation (Issue #434)

### DIFF
--- a/scripts/installscripts/stretch-install-spotify.sh
+++ b/scripts/installscripts/stretch-install-spotify.sh
@@ -474,6 +474,9 @@ then
 	cd mopidy-spotify
 	sudo python setup.py install
 	cd
+	# should be removed, if Mopidy-Iris can be installed normally
+	# pylast >= 3.0.0 removed the python2 support
+	sudo pip install pylast==2.4.0
 	sudo pip install Mopidy-Iris
 fi
 


### PR DESCRIPTION
pylast in version 3.0.0 removed support for python 2.x. So Mopidy-Iris will require pylast > 1.6 so it is tried to install the latest one, which can not run in python 2.x.

I didn't put this in the requirements.txt, because it is only needed for spotify version. 