### PR TITLE
(maint) inc.header.php: removes duplicate code -> better parameter overview

### DIFF
--- a/htdocs/inc.header.php
+++ b/htdocs/inc.header.php
@@ -63,7 +63,34 @@ sudo chgrp -R www-data htdocs/
 }
 include("config.php");
 
-$conf['url_abs']    = "http://".$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
+$url_abs = "http://".$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
+
+/**
+ * @param $exec
+ */
+function execAndRedirect($exec)
+{
+    global $debug;
+    global $url_abs;
+
+    if (!isset($exec)) {
+        return;
+    }
+
+    if ($debug == "true") {
+        print "Command: " . $exec;
+    } else {
+        exec($exec);
+        /* redirect to drop all the url parameters */
+        header("Location: " . $url_abs);
+        exit;
+    }
+}
+
+function fileGetContentOrDefault($filename, $defaultValue)
+{
+    return file_exists($filename) ? trim(file_get_contents($filename)) : $defaultValue;
+}
 
 include("func.php");
 
@@ -80,25 +107,13 @@ $conf['settings_abs'] = realpath(getcwd().'/../settings/');
 $Audio_Folders_Path = trim(file_get_contents($conf['settings_abs'].'/Audio_Folders_Path'));
 $Latest_Folder_Played = trim(file_get_contents($conf['settings_abs'].'/Latest_Folder_Played'));
 $Second_Swipe = trim(file_get_contents($conf['settings_abs'].'/Second_Swipe'));
-if(file_exists($conf['settings_abs'].'/ShowCover')) {
-    $ShowCover = trim(file_get_contents($conf['settings_abs'].'/ShowCover'));
-} else {
-    $ShowCover = "ON";
-}
+$ShowCover = fileGetContentOrDefault($conf['settings_abs'].'/ShowCover', "ON");
 $version = trim(file_get_contents($conf['settings_abs'].'/version'));
-if(file_exists(dirname(__FILE__).'/../settings/edition')) {
-    $edition = trim(file_get_contents(dirname(__FILE__).'/../settings/edition'));
-} else {
-    $edition = "classic";
-}
+$edition = fileGetContentOrDefault(dirname(__FILE__).'/../settings/edition', "classic");
 /*
 * load language strings
 */
-if(file_exists($conf['settings_abs'].'/Lang')) {
-    $conf['settings_lang'] = trim(file_get_contents($conf['settings_abs'].'/Lang'));
-} else {
-    $conf['settings_lang'] = "en-UK";
-}
+$conf['settings_lang'] = fileGetContentOrDefault($conf['settings_abs'].'/Lang', "en-UK");
 include("inc.langLoad.php");
 
 /*******************************************
@@ -109,201 +124,49 @@ $urlparams = array();
 /*
 * Firstly, collect via 'GET', later collect 'POST'
 */
-if(isset($_GET['play']) && trim($_GET['play']) != "") {
-    $urlparams['play'] = trim($_GET['play']);
-}
-if(isset($_GET['recursive']) && trim($_GET['recursive']) == "true") {
-    $urlparams['recursive'] = trim($_GET['recursive']);
-}
-
-if(isset($_GET['playpos']) && trim($_GET['playpos']) != "") {
-    $urlparams['playpos'] = trim($_GET['playpos']);
-}
-
-if(isset($_GET['player']) && trim($_GET['player']) != "") {
-    $urlparams['player'] = trim($_GET['player']);
-}
-
-if(isset($_GET['stop']) && trim($_GET['stop']) != "") {
-    $urlparams['stop'] = trim($_GET['stop']);
-}
-
-if(isset($_GET['volume']) && trim($_GET['volume']) != "") {
-    $urlparams['volume'] = trim($_GET['volume']);
-}
-
-if(isset($_GET['maxvolume']) && trim($_GET['maxvolume']) != "") {
-    $urlparams['maxvolume'] = trim($_GET['maxvolume']);
-}
-
-if(isset($_GET['volstep']) && trim($_GET['volstep']) != "") {
-    $urlparams['volstep'] = trim($_GET['volstep']);
+$nonEmptyCommands = array(
+    'play',
+    'playpos',
+    'player',
+    'stop',
+    'volume',
+    'maxvolume',
+    'volstep',
+    'shutdown',
+    'reboot',
+    'scan',
+    'idletime',
+    'shutdownafter',
+    'stopplayoutafter',
+    'enableresume',
+    'disableresume',
+    'enableshuffle',
+    'disableshuffle',
+);
+foreach ($nonEmptyCommands as $command) {
+    if(isset($_GET[$command]) && trim($_GET[$command]) != "") {
+        $urlparams[$command] = trim($_GET[$command]);
+    }
+    if(isset($_POST[$command]) && trim($_POST[$command]) != "") {
+        $urlparams[$command] = trim($_POST[$command]);
+    }
 }
 
-if(isset($_GET['mute']) && trim($_GET['mute']) == "true") {
-    $urlparams['mute'] = trim($_GET['mute']);
-}
-
-if(isset($_GET['volumeup']) && trim($_GET['volumeup']) == "true") {
-    $urlparams['volumeup'] = trim($_GET['volumeup']);
-}
-
-if(isset($_GET['volumedown']) && trim($_GET['volumedown']) == "true") {
-    $urlparams['volumedown'] = trim($_GET['volumedown']);
-}
-
-if(isset($_GET['shutdown']) && trim($_GET['shutdown']) != "") {
-    $urlparams['shutdown'] = trim($_GET['shutdown']);
-}
-
-if(isset($_GET['reboot']) && trim($_GET['reboot']) != "") {
-    $urlparams['reboot'] = trim($_GET['reboot']);
-}
-
-if(isset($_GET['scan']) && trim($_GET['scan']) != "") {
-    $urlparams['scan'] = trim($_GET['scan']);
-}
-
-if(isset($_GET['idletime']) && trim($_GET['idletime']) != "") {
-    $urlparams['idletime'] = trim($_GET['idletime']);
-}
-
-if(isset($_GET['shutdownafter']) && trim($_GET['shutdownafter']) != "") {
-    $urlparams['shutdownafter'] = trim($_GET['shutdownafter']);
-}
-
-if(isset($_GET['rfidstatus']) && trim($_GET['rfidstatus']) == "turnon") {
-    $urlparams['rfidstatus'] = trim($_GET['rfidstatus']);
-}
-
-if(isset($_GET['rfidstatus']) && trim($_GET['rfidstatus']) == "turnoff") {
-    $urlparams['rfidstatus'] = trim($_GET['rfidstatus']);
-}
-
-if(isset($_GET['gpiostatus']) && trim($_GET['gpiostatus']) == "turnon") {
-    $urlparams['gpiostatus'] = trim($_GET['gpiostatus']);
-}
-
-if(isset($_GET['gpiostatus']) && trim($_GET['gpiostatus']) == "turnoff") {
-    $urlparams['gpiostatus'] = trim($_GET['gpiostatus']);
-}
-
-if(isset($_GET['enableresume']) && trim($_GET['enableresume']) != "") {
-    $urlparams['enableresume'] = trim($_GET['enableresume']);
-}
-
-if(isset($_GET['disableresume']) && trim($_GET['disableresume']) != "") {
-    $urlparams['disableresume'] = trim($_GET['disableresume']);
-}
-
-if(isset($_GET['enableshuffle']) && trim($_GET['enableshuffle']) != "") {
-    $urlparams['enableshuffle'] = trim($_GET['enableshuffle']);
-}
-
-if(isset($_GET['disableshuffle']) && trim($_GET['disableshuffle']) != "") {
-    $urlparams['disableshuffle'] = trim($_GET['disableshuffle']);
-}
-
-/*
-* Now check for $_POST
-*/
-if(isset($_POST['play']) && trim($_POST['play']) != "") {
-    $urlparams['play'] = trim($_POST['play']);
-}
-if(isset($_POST['recursive']) && trim($_POST['recursive']) == "true") {
-    $urlparams['recursive'] = trim($_POST['recursive']);
-}
-
-if(isset($_POST['playpos']) && trim($_POST['playpos']) != "") {
-    $urlparams['playpos'] = trim($_POST['playpos']);
-}
-
-if(isset($_POST['player']) && trim($_POST['player']) != "") {
-    $urlparams['player'] = trim($_POST['player']);
-}
-
-if(isset($_POST['stop']) && trim($_POST['stop']) != "") {
-    $urlparams['stop'] = trim($_POST['stop']);
-}
-
-if(isset($_POST['volume']) && trim($_POST['volume']) != "") {
-    $urlparams['volume'] = trim($_POST['volume']);
-}
-
-if(isset($_POST['maxvolume']) && trim($_POST['maxvolume']) != "") {
-    $urlparams['maxvolume'] = trim($_POST['maxvolume']);
-}
-
-if(isset($_POST['volstep']) && trim($_POST['volstep']) != "") {
-    $urlparams['volstep'] = trim($_POST['volstep']);
-}
-
-if(isset($_POST['mute']) && trim($_POST['mute']) == "true") {
-    $urlparams['mute'] = trim($_POST['mute']);
-}
-
-if(isset($_POST['volumeup']) && trim($_POST['volumeup']) == "true") {
-    $urlparams['volumeup'] = trim($_POST['volumeup']);
-}
-
-if(isset($_POST['volumedown']) && trim($_POST['volumedown']) == "true") {
-    $urlparams['volumedown'] = trim($_POST['volumedown']);
-}
-
-if(isset($_POST['shutdown']) && trim($_POST['shutdown']) != "") {
-    $urlparams['shutdown'] = trim($_POST['shutdown']);
-}
-
-if(isset($_POST['reboot']) && trim($_POST['reboot']) != "") {
-    $urlparams['reboot'] = trim($_POST['reboot']);
-}
-
-if(isset($_POST['scan']) && trim($_POST['scan']) != "") {
-    $urlparams['scan'] = trim($_POST['scan']);
-}
-
-if(isset($_POST['idletime']) && trim($_POST['idletime']) != "") {
-    $urlparams['idletime'] = trim($_POST['idletime']);
-}
-
-if(isset($_POST['shutdownafter']) && trim($_POST['shutdownafter']) != "") {
-    $urlparams['shutdownafter'] = trim($_POST['shutdownafter']);
-}
-
-if(isset($_POST['stopplayoutafter']) && trim($_POST['stopplayoutafter']) != "") {
-    $urlparams['stopplayoutafter'] = trim($_POST['stopplayoutafter']);
-}
-
-if(isset($_POST['rfidstatus']) && trim($_POST['rfidstatus']) == "turnon") {
-    $urlparams['rfidstatus'] = trim($_POST['rfidstatus']);
-}
-
-if(isset($_POST['rfidstatus']) && trim($_POST['rfidstatus']) == "turnoff") {
-    $urlparams['rfidstatus'] = trim($_POST['rfidstatus']);
-}
-
-if(isset($_POST['gpiostatus']) && trim($_POST['gpiostatus']) == "turnon") {
-    $urlparams['gpiostatus'] = trim($_POST['gpiostatus']);
-}
-
-if(isset($_POST['gpiostatus']) && trim($_POST['gpiostatus']) == "turnoff") {
-    $urlparams['gpiostatus'] = trim($_POST['gpiostatus']);
-}
-
-if(isset($_POST['enableresume']) && trim($_POST['enableresume']) != "") {
-    $urlparams['enableresume'] = trim($_POST['enableresume']);
-}
-
-if(isset($_POST['disableresume']) && trim($_POST['disableresume']) != "") {
-    $urlparams['disableresume'] = trim($_POST['disableresume']);
-}
-
-if(isset($_POST['enableshuffle']) && trim($_POST['enableshuffle']) != "") {
-    $urlparams['enableshuffle'] = trim($_POST['enableshuffle']);
-}
-
-if(isset($_POST['disableshuffle']) && trim($_POST['disableshuffle']) != "") {
-    $urlparams['disableshuffle'] = trim($_POST['disableshuffle']);
+$commandsWithAllowedValues = array(
+    'recursive' => array('true'),
+    'mute' => array('true'),
+    'volumeup' => array('true'),
+    'volumedown' => array('true'),
+    'rfidstatus' => array('turnon', 'turnoff'),
+    'gpiostatus' => array('turnon', 'turnoff'),
+);
+foreach ($commandsWithAllowedValues as $command => $allowedValues) {
+    if(isset($_GET[$command]) && in_array(trim($_GET[$command]), $allowedValues)) {
+        $urlparams[$command] = trim($_GET[$command]);
+    }
+    if(isset($_POST[$command]) && in_array(trim($_POST[$command]), $allowedValues)) {
+        $urlparams[$command] = trim($_POST[$command]);
+    }
 }
 
 /*******************************************
@@ -350,213 +213,72 @@ if(isset($_GET['delete']) && $_GET['delete'] == "delete") {
 * ACTIONS
 *******************************************/
 
-// change volume
-if(isset($urlparams['volume'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setvolume -v=".$urlparams['volume'];
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// change max volume
-if(isset($urlparams['maxvolume'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setmaxvolume -v=".$urlparams['maxvolume'];
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// change volume step
-if(isset($urlparams['volstep'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setvolstep -v=".$urlparams['volstep'];
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-
-// volume mute (toggle)
-if(isset($urlparams['mute'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=mute";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// volume up
-if(isset($urlparams['volumeup'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=volumeup";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// volume down
-if(isset($urlparams['volumedown'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=volumedown";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// reboot the jukebox
-if(isset($urlparams['reboot']) && $urlparams['reboot'] == "true") {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=reboot > /dev/null 2>&1 &";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// shutdown the jukebox
-if(isset($urlparams['shutdown']) && $urlparams['shutdown'] == "true") {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=shutdown > /dev/null 2>&1 &";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// set idletime
-if(isset($urlparams['idletime'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setidletime -v=".$urlparams['idletime'];
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// set shutdownafter time (sleeptimer)
-if(isset($urlparams['shutdownafter'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=shutdownafter -v=".$urlparams['shutdownafter'];
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// set playerstopafter time (auto stop timer)
-if(isset($urlparams['stopplayoutafter'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerstopafter -v=".$urlparams['stopplayoutafter'];
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// start the rfid service
-if(isset($urlparams['rfidstatus']) && $urlparams['rfidstatus'] == "turnon") {
-    $exec = "/usr/bin/sudo /bin/systemctl start phoniebox-rfid-reader.service";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// stop the rfid service
-if(isset($urlparams['rfidstatus']) && $urlparams['rfidstatus'] == "turnoff") {
-    $exec = "/usr/bin/sudo /bin/systemctl stop phoniebox-rfid-reader.service";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// start the gpio button service
-if(isset($urlparams['gpiostatus']) && $urlparams['gpiostatus'] == "turnon") {
-    $exec = "/usr/bin/sudo /bin/systemctl start phoniebox-gpio-buttons.service";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// stop the gpio button service
-if(isset($urlparams['gpiostatus']) && $urlparams['gpiostatus'] == "turnoff") {
-    $exec = "/usr/bin/sudo /bin/systemctl stop phoniebox-gpio-buttons.service";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
+$commandToAction = array(
+    'volume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setvolume -v=%s",            // change volume
+    'maxvolume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setmaxvolume -v=%s",      // change max volume
+    'volstep' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setvolstep -v=%s",          // change volume step
+    'mute' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=mute",                         // volume mute (toggle)
+    'volumeup' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=volumeup",                 // volume up
+    'volumedown' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=volumedown",             // volume down
+    'idletime' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setidletime -v=%s",        // set idletime
+    'shutdownafter' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=shutdownafter -v=%s", // set shutdownafter time (sleeptimer)
+    'stopplayoutafter' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerstopafter -v=%s",// set playerstopafter time (auto stop timer)
+    'playpos' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerplay -v=%s",          // play from playlist position,
+    'scan' => array(
+        'true' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=scan > /dev/null 2>&1 &"   // scan the library
+    ),
+    'stop' => array(
+        'true' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerstop"                // stop playing
+    ),
+    'reboot' => array(
+        'true' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=reboot > /dev/null 2>&1 &" // reboot the jukebox
+    ),
+    'shutdown' => array(
+        'true' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=shutdown > /dev/null 2>&1 &"// shutdown the jukebox
+    ),
+    'rfidstatus' => array(
+        'turnon' => "/usr/bin/sudo /bin/systemctl start phoniebox-rfid-reader.service",                     // start the rfid service
+        'turnoff' => "/usr/bin/sudo /bin/systemctl stop phoniebox-rfid-reader.service"                      // stop the rfid service
+    ),
+    'gpiostatus' => array(
+        'turnon' => "/usr/bin/sudo /bin/systemctl start phoniebox-gpio-buttons.service",                    // start the gpio button service
+        'turnoff' => "/usr/bin/sudo /bin/systemctl stop phoniebox-gpio-buttons.service"                     // stop the gpio button service
+    ),
+    // control player through web interface
+    'player' => array(
+        "next" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playernext",
+        "prev" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playerprev",
+        "play" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playerplay",
+        "replay" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playerreplay",
+        "pause" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playerpause",
+        "repeat" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playerrepeat -v=playlist",
+        "single" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playerrepeat -v=single",
+        "repeatoff" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playerrepeat -v=off",
+        "seekBack" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playerseek -v=-15",
+        "seekAhead" => "/usr/bin/sudo " . $conf['scripts_abs'] . "/playout_controls.sh -c=playerseek -v=+15",
+    ),
+);
+foreach ($urlparams as $paramKey => $paramValue) {
+    if(isset($commandToAction[$paramKey]) && !is_array($commandToAction[$paramKey])) {
+        $exec = sprintf($commandToAction[$paramKey], $paramValue);
+        execAndRedirect($exec);
+    } elseif (isset($commandToAction[$paramKey]) && isset($commandToAction[$paramKey][$paramValue])) {
+        $exec = sprintf($commandToAction[$paramKey][$paramValue], $paramValue);
+        execAndRedirect($exec);
     }
 }
 
 // enable resume
 if(isset($urlparams['enableresume']) && $urlparams['enableresume'] != "" && is_dir(urldecode($Audio_Folders_Path."/".$urlparams['enableresume']))) {
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
+    if($debug == "true") {
+        print "Command: ".$exec;
+    } else {
     // pass folder to resume script
     // escape whitespaces with backslashes
     // SC added the following lines to make resume work again, changes affect the folder_string $urlparams['enableresume']
     // Note: This will allow normal function of the resume button in the webinterface for folder s with brackets in their name.
     // Brackets of type "(", ")", "[", "]" are supported as album names often apear in form of "albumname - (year) - albumtitle"
-    if($debug == "true") { 
+    if($debug == "true") {
         print "original_enableresume=".$urlparams['enableresume'] . PHP_EOL;
     }
     $modified_enableresume = preg_replace('/\s+/', '\ ',$urlparams['enableresume']); // replace whitespaces with " "
@@ -564,16 +286,16 @@ if(isset($urlparams['enableresume']) && $urlparams['enableresume'] != "" && is_d
     $modified_enableresume = preg_replace('/\)/', '\)',$modified_enableresume); // replace "(" with with "\)"
     $modified_enableresume = preg_replace('/\[/', '\[',$modified_enableresume); // replace "(" with with "\["
     $modified_enableresume = preg_replace('/\]/', '\]',$modified_enableresume); // replace "(" with with "\]"
-    if($debug == "true") { 
-        print "modified_enableresume=".$modified_enableresume . PHP_EOL; 
+    if($debug == "true") {
+        print "modified_enableresume=".$modified_enableresume . PHP_EOL;
     }
     $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/resume_play.sh -c=enableresume -d=".$modified_enableresume; // new and modified call of resume_play.sh
     //$exec = "/usr/bin/sudo ".$conf['scripts_abs']."/resume_play.sh -c=enableresume -d=".preg_replace('/\s+/', '\ ',$urlparams['enableresume']); // original call of resume_play.sh
     exec($exec);
 
     /* redirect to drop all the url parameters */
-    header("Location: ".$conf['url_abs']);
-    exit; 
+    header("Location: ".$url_abs);
+    exit;
     }
 }
 
@@ -591,14 +313,7 @@ if(isset($urlparams['disableresume']) && $urlparams['disableresume'] != "" && is
     $modified_disableresume = preg_replace('/\]/', '\]',$modified_disableresume); // replace "(" with with "\]"
     $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/resume_play.sh -c=disableresume -d=".$modified_disableresume; // new and modified call of resume_play.sh
     //$exec = "/usr/bin/sudo ".$conf['scripts_abs']."/resume_play.sh -c=disableresume -d=".preg_replace('/\s+/', '\ ',$urlparams['disableresume']); // original call of resume_play.sh
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
+    execAndRedirect($exec);
 }
 
 // enable shuffle
@@ -607,14 +322,7 @@ if(isset($urlparams['enableshuffle']) && $urlparams['enableshuffle'] != "" && is
     // escape whitespaces with backslashes
     $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/shuffle_play.sh -c=enableshuffle -d=".preg_replace('/\s+/', '\ ',$urlparams['enableshuffle']);
 
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
+    execAndRedirect($exec);
 }
 
 // disable shuffle
@@ -622,42 +330,7 @@ if(isset($urlparams['disableshuffle']) && $urlparams['disableshuffle'] != "" && 
     // pass folder to resume script
     // escape whitespaces with backslashes
     $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/shuffle_play.sh -c=disableshuffle -d=".preg_replace('/\s+/', '\ ',$urlparams['disableshuffle']);
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-    exec($exec);
-
-    /* redirect to drop all the url parameters */
-    header("Location: ".$conf['url_abs']);
-    exit; 
-    }
-}
-
-// scan the library
-if(isset($urlparams['scan']) && $urlparams['scan'] == "true") {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=scan > /dev/null 2>&1 &";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-
-// stop playing
-if(isset($urlparams['stop']) && $urlparams['stop'] == "true") {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerstop";
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
+    execAndRedirect($exec);
 }
 
 // play folder audio files
@@ -669,141 +342,6 @@ if(isset($urlparams['play']) && $urlparams['play'] != "" && is_dir(urldecode($Au
     if($urlparams['recursive'] == "true") {
         $exec .= ' -v="recursive"';
     }
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-// play from playlist position
-if(isset($urlparams['playpos'])) {
-    $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerplay -v=".$urlparams['playpos'];
-    if($debug == "true") { 
-        print "Command: ".$exec; 
-    } else { 
-        exec($exec);
-        /* redirect to drop all the url parameters */
-        header("Location: ".$conf['url_abs']);
-        exit; 
-    }
-}
-
-
-// control player through web interface
-if(isset($urlparams['player'])) {
-    if($urlparams['player'] == "next") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playernext";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
-    if($urlparams['player'] == "prev") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerprev";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
-    if($urlparams['player'] == "play") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerplay";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
-    if($urlparams['player'] == "replay") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerreplay";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
-    if($urlparams['player'] == "pause") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerpause";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
-    if($urlparams['player'] == "repeat") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerrepeat -v=playlist";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
-    if($urlparams['player'] == "single") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerrepeat -v=single";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
-    if($urlparams['player'] == "repeatoff") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerrepeat -v=off";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
-    if($urlparams['player'] == "seekBack") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerseek -v=-15";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
-    if($urlparams['player'] == "seekAhead") {
-        $exec = "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=playerseek -v=+15";
-        if($debug == "true") { 
-            print "Command: ".$exec; 
-        } else { 
-            exec($exec);
-            /* redirect to drop all the url parameters */
-            header("Location: ".$conf['url_abs']);
-            exit; 
-        }
-    }
+    execAndRedirect($exec);
 }
 ?>


### PR DESCRIPTION
This project is fantastic and I really want to push the code to a cleaner and more secure level.

It was really hard for me to get a quick overview of all possible commands.
The code was very verbose and full of duplicated patterns, that has grown naturally over time. My initial goal was to remove unnecessary sudo calls at least to `playout_controls.sh`. 

I decided to do this small refactoring:
- it checks GET and POST parameters and puts it into `$urlparams` variable
- all redirects happens in one place
- simple commands are defined in one array and handled directly in the logic under it

Next steps: 
Simplify remaining if constructs. Move all system calls to an own file.