### PR TITLE
fix A B pin mix up

### DIFF
--- a/scripts/rotary-encoder.py
+++ b/scripts/rotary-encoder.py
@@ -14,13 +14,13 @@
 #
 # circuit diagram for one of two possible encoders (volume), use GPIOs from code below for the tracks
 # (capacitors are optionally)
-# KY-040 is just one example, typically the pins are named A nd B instead of Clock and Data
+# KY-040 is just one example, typically the pins are named A and B instead of Clock and Data
 #
 #       .---------------.                      .---------------.
 #       |               |                      |               |
-#       |           CLK |------o---------------| GPIO 5        |
+#       |        B / DT |------o---------------| GPIO 5        |
 #       |               |      |               |               |
-#       |           DT  |------)----o----------| GPIO 6        |
+#       |       A / CLK |------)----o----------| GPIO 6        |
 #       |               |      |    |          |               |
 #       |           SW  |------)----)----------| GPIO 3        |
 #       |               |      |    |          |               |
@@ -59,11 +59,11 @@ def rotaryChangeCWTrack(steps):
 def rotaryChangeCCWTrack(steps):
    check_call("./scripts/playout_controls.sh -c=playerprev", shell=True)
 
-APinVol = 5 
-BPinVol = 6
+APinVol = 6
+BPinVol = 5
 
-APinTrack = 22
-BPinTrack = 23
+APinTrack = 23
+BPinTrack = 22
 
 GPIO.setmode(GPIO.BCM)
 

--- a/scripts/rotary_encoder_base.py
+++ b/scripts/rotary_encoder_base.py
@@ -28,8 +28,8 @@ class Flags( ctypes.Union ):
 class RotaryEncoder:
 
     # select Enocder state bits
-    KeyIncr = 0b00000001
-    KeyDecr = 0b00000010
+    KeyIncr = 0b00000010
+    KeyDecr = 0b00000001
 
     tblEncoder = [
         0b00000011, 0b00000111, 0b00010011, 0b00000011,


### PR DESCRIPTION
Hi @MiczFlor, @Yordan1976 and @dvalob noted that I confused A and B pins of the rotary encoder in the code.
I fixed that now in code and documentation in a way that the pin out stays the same and no current installations are broken. Verified on my hardware.