### PR TITLE
typo en-UK to en-GB

### DIFF
--- a/htdocs/inc.header.php
+++ b/htdocs/inc.header.php
@@ -113,7 +113,7 @@ $edition = fileGetContentOrDefault(dirname(__FILE__).'/../settings/edition', "cl
 /*
 * load language strings
 */
-$conf['settings_lang'] = fileGetContentOrDefault($conf['settings_abs'].'/Lang', "en-UK");
+$conf['settings_lang'] = fileGetContentOrDefault($conf['settings_abs'].'/Lang', "en-GB");
 include("inc.langLoad.php");
 
 /*******************************************

--- a/htdocs/inc.langLoad.php
+++ b/htdocs/inc.langLoad.php
@@ -14,7 +14,7 @@ if(isset($_POST['lang']) && trim($_POST['lang']) != "") {
 /*
 * Lang files default (the complete set)
 */
-include("lang/lang-en-UK.php");
+include("lang/lang-en-GB.php");
 $langDef = $lang;
 /*
 * see if we load a sepcific language file
@@ -22,7 +22,7 @@ $langDef = $lang;
 if(
     isset($conf['settings_lang'])
     && $conf['settings_lang'] != ""
-    && $conf['settings_lang'] != "en-UK"
+    && $conf['settings_lang'] != "en-GB"
     && file_exists('lang/lang-'.$conf['settings_lang'].'.php')
     ) {
     include('lang/lang-'.$conf['settings_lang'].'.php');

--- a/htdocs/inc.setLanguage.php
+++ b/htdocs/inc.setLanguage.php
@@ -13,7 +13,7 @@ called in inc.header.php
 if(
     isset($_POST['lang']) 
     && trim($_POST['lang']) != ""
-    && trim($_POST['lang']) != "en-UK"
+    && trim($_POST['lang']) != "en-GB"
     ) {
     /**/
 

--- a/htdocs/lang/lang-de-DE.php
+++ b/htdocs/lang/lang-de-DE.php
@@ -165,7 +165,7 @@ $lang['settingsWebInterface'] = "Web-Oberfläche";
 $lang['settingsCoverInfo'] = "Willst du Cover neben den Alben und Playlisten auf der Hauptseite anzeigen?";
 $lang['settingsShowCoverON'] = "Cover anzeigen";
 $lang['settingsShowCoverOFF'] = "Kein Cover anzeigen";
-$lang['settingsMessageLangfileNewItems'] = "Es gibt neue Sprachelemente in der originalen Sprachdatei <em>lang-en-UK.php</em>. Möglicherweise möchtest du deine Sprachdatei aktualisieren und Ihre Änderungen in den Phoniebox-Code übernehmen? :)";
+$lang['settingsMessageLangfileNewItems'] = "Es gibt neue Sprachelemente in der originalen Sprachdatei <em>lang-en-GB.php</em>. Möglicherweise möchtest du deine Sprachdatei aktualisieren und Ihre Änderungen in den Phoniebox-Code übernehmen? :)";
 
 /*
 * System info

--- a/htdocs/lang/lang-en-GB.php
+++ b/htdocs/lang/lang-en-GB.php
@@ -165,7 +165,7 @@ $lang['settingsWebInterface'] = "Web Interface";
 $lang['settingsCoverInfo'] = "Do you want to show covers beside the albums and playlists on the main page?";
 $lang['settingsShowCoverON'] = "Show cover";
 $lang['settingsShowCoverOFF'] = "Don't show cover";
-$lang['settingsMessageLangfileNewItems'] = "There are new language items in the original <em>lang-en-UK.php</em> file. Your language file has been updated and now contains these (in English). You might want to update your language file and commit your changes to the Phoniebox code :)";
+$lang['settingsMessageLangfileNewItems'] = "There are new language items in the original <em>lang-en-GB.php</em> file. Your language file has been updated and now contains these (in English). You might want to update your language file and commit your changes to the Phoniebox code :)";
 
 /*
 * System info


### PR DESCRIPTION
Regarding [rfc5646](https://tools.ietf.org/html/rfc5646) and [this](https://datahub.io/core/language-codes/r/3.html) I would like to rename _en-UK_ to _en-GB_

Thanks for this great project 💙 