### PR TITLE
Add "rewind playlist" functionality.

### DIFF
--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -320,7 +320,8 @@ case $COMMAND in
         ;;
     playerrewind)
         # play the first track in playlist (==folder)
-	mpc play
+	mpc play 1
+        ;;
     playerpause)
         # pause current track
         # mpc knows "pause", which pauses only, and "toggle" which pauses and unpauses, whatever is needed

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -318,6 +318,9 @@ case $COMMAND in
         # play previous track in playlist (==folder)
         mpc prev
         ;;
+    playerrewind)
+        # play the first track in playlist (==folder)
+	mpc play
     playerpause)
         # pause current track
         # mpc knows "pause", which pauses only, and "toggle" which pauses and unpauses, whatever is needed

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -149,6 +149,7 @@ if [ "$CARDID" ]; then
         $CMDREWIND)
             # play the first track in playlist (==folder)
             sudo $PATHDATA/playout_controls.sh -c=playerrewind
+            ;;
         $CMDSEEKFORW)
             # jump 15 seconds ahead
             $PATHDATA/playout_controls.sh -c=playerseek -v=+15

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -146,6 +146,9 @@ if [ "$CARDID" ]; then
             sudo $PATHDATA/playout_controls.sh -c=playerprev
             #/usr/bin/sudo /home/pi/RPi-Jukebox-RFID/scripts/playout_controls.sh -c=playerprev
             ;;
+        $CMDREWIND)
+            # play the first track in playlist (==folder)
+            sudo $PATHDATA/playout_controls.sh -c=playerrewind
         $CMDSEEKFORW)
             # jump 15 seconds ahead
             $PATHDATA/playout_controls.sh -c=playerseek -v=+15

--- a/settings/rfid_trigger_play.conf.sample
+++ b/settings/rfid_trigger_play.conf.sample
@@ -28,6 +28,8 @@ CMDREBOOT="%CMDREBOOT%"
 # next and prev play the preivous or next track in the playlist (== folder & spotify)
 CMDNEXT="%CMDNEXT%"
 CMDPREV="%CMDPREV%"
+# The following command restarts the playlist from the beginning
+CMDREWIND="%CMDREWIND%"
 # seek ahead or back 15 seconds
 CMDSEEKFORW="%CMDSEEKFORW%"
 CMDSEEKBACK="%CMDSEEKBACK%"


### PR DESCRIPTION
Sometimes I would like to restart a playlist from the beginning. This is especially interesting for folders that have "Resume" activated. These patches implement this functionality: one can assign a card to "CMDREWIND" and that card will play the current playlist from the beginning.