### PR TITLE
Manage multiple WiFis with different priorities

### DIFF
--- a/htdocs/lang/lang-de-DE.php
+++ b/htdocs/lang/lang-de-DE.php
@@ -65,6 +65,7 @@ $lang['globalRepeat'] = "Wiederholen";
 $lang['globalLoop'] = "Schleife";
 $lang['globalLang'] = "Sprache";
 $lang['globalLanguageSettings'] = "Spracheinstellungen";
+$lang['globalPriority'] = "Priorität";
 
 // Player title HTML
 $lang['playerSeekBack'] = "seek back";
@@ -168,6 +169,8 @@ $lang['settingsMaxVol'] = "Max. Lautstärke";
 $lang['settingsWifiRestart'] = "Die Änderungen an der WiFi-Verbindung erfordern einen Neustart, um wirksam zu werden";
 $lang['settingsWifiSsidPlaceholder'] = "z.B. PhonieHomie";
 $lang['settingsWifiSsidHelp'] = "Der Name, unter dem dein WiFi als 'verfügbares Netzwerk' angezeigt wird";
+$lang['settingsWifiPassHelp'] = "Das Passwort für dein WiFi (mindestens 8 Zeichen)";
+$lang['settingsWifiPrioHelp'] = "Die Priorität deines WiFi (0-100). Wenn mehr als ein WiFi gefunden wird, verbindet sich die Box mit dem, das die höhere Priorität hat";
 $lang['settingsSecondSwipe'] = "Erneute Aktivierung";
 $lang['settingsSecondSwipeInfo'] = "Aktion, wenn dieselbe Karte ein weiteres Mal aktiviert wird:";
 $lang['settingsSecondSwipeRestart'] = "Wiedergabeliste neu starten";

--- a/htdocs/lang/lang-en-UK.php
+++ b/htdocs/lang/lang-en-UK.php
@@ -65,6 +65,7 @@ $lang['globalRepeat'] = "Repeat";
 $lang['globalLoop'] = "Loop";
 $lang['globalLang'] = "Language";
 $lang['globalLanguageSettings'] = "Language Settings";
+$lang['globalPriority'] = "Priority";
 
 // Player title HTML
 $lang['playerSeekBack'] = "seek back";
@@ -169,6 +170,8 @@ $lang['settingsMaxVol'] = "Maximum Volume";
 $lang['settingsWifiRestart'] = "The changes applied to your WiFi connection require a restart to take effect.";
 $lang['settingsWifiSsidPlaceholder'] = "e.g.: PhonieHomie";
 $lang['settingsWifiSsidHelp'] = "The name under which your WiFi shows up as 'available network'";
+$lang['settingsWifiPassHelp'] = "The password of your WiFi (8 characters at least)";
+$lang['settingsWifiPrioHelp'] = "Your WiFi's priority (0-100). If more than  one WiFi is found the box will connect to the one with the higher priority";
 $lang['settingsSecondSwipe'] = "Second Swipe";
 $lang['settingsSecondSwipeInfo'] = "When you swipe the same RFID a second time, what happens? Start the playlist again? Toggle pause/play?";
 $lang['settingsSecondSwipeRestart'] = "Re-start playlist";


### PR DESCRIPTION
Added the possibility to add and manage multiple WiFis with different
priorities. This feature should be handy if the box is used at different
locations.

The priority allows to prioritize a temporary mobile hotspot over
stationary WiFis for configuration.

Configurations can be deleted by deleting the SSID value.