### PR TITLE
Make URLs protocol independent

### DIFF
--- a/htdocs/cardEdit.php
+++ b/htdocs/cardEdit.php
@@ -11,7 +11,8 @@ include("inc.header.php");
 
 /* NO CHANGES BENEATH THIS LINE ***********/
 
-$conf['url_abs']    = "http://".$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
+$protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://';
+$conf['url_abs']    = $protocol.$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
 
 
 /*******************************************

--- a/htdocs/cardRegisterNew.php
+++ b/htdocs/cardRegisterNew.php
@@ -12,7 +12,8 @@ include("inc.header.php");
 
 /* NO CHANGES BENEATH THIS LINE ***********/
 
-$conf['url_abs']    = "http://".$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
+$protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://';
+$conf['url_abs']    = $protocol.$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
 
 /*******************************************
 * START HTML

--- a/htdocs/inc.header.php
+++ b/htdocs/inc.header.php
@@ -63,7 +63,8 @@ sudo chgrp -R www-data htdocs/
 }
 include("config.php");
 
-$url_abs = "http://".$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
+$protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://';
+$url_abs = $protocol.$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
 
 /**
  * @param $exec

--- a/htdocs/rss-mp3.php
+++ b/htdocs/rss-mp3.php
@@ -56,7 +56,8 @@ if(isset($_GET['rss'])) {
 
 function phoniepodcastxml($filesMp3, $title) {
   global $sortby;
-  $conf['url_abs']    = "http://".$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
+  $protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://';
+  $conf['url_abs']    = $protocol.$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
   // get "now" time for timestamp in xml feed, because the publishing time will order the list e.g. on iOS Podcast
   $now = time();
   header('Content-type: text/xml', true);

--- a/htdocs/test.php
+++ b/htdocs/test.php
@@ -16,7 +16,8 @@ if(file_exists("config.php")) {
     print "File 'config.php' not found.\n";
 }
 
-$conf['url_abs']    = "http://".$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
+$protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://';
+$conf['url_abs']    = $protocol.$_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']; // URL to PHP_SELF
 
 print "\nVariable \$conf['url_abs'] = ".$conf['url_abs']."\n";
 


### PR DESCRIPTION
I host my phoniebox web server via https and found that site reloads are based on hard-coded "http://...." URLs.