### PR TITLE
use raspberrypi-kernel-headers comaptible with raspberry-kernel (binaries)

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -468,7 +468,7 @@ sudo iwconfig wlan0 power off
 
 # Install required packages
 sudo apt-get update
-sudo apt-get --yes --force-yes install apt-transport-https samba samba-common-bin python-dev python-pip gcc linux-headers-4.9 lighttpd php7.3-common php7.3-cgi php7.3 php7.3-fpm at mpd mpc mpg123 git ffmpeg python-mutagen python3-gpiozero resolvconf spi-tools python-spidev python3-spidev
+sudo apt-get --yes --force-yes install apt-transport-https samba samba-common-bin python-dev python-pip gcc raspberrypi-kernel-headers lighttpd php7.3-common php7.3-cgi php7.3 php7.3-fpm at mpd mpc mpg123 git ffmpeg python-mutagen python3-gpiozero resolvconf spi-tools python-spidev python3-spidev
 
 # Install required spotify packages
 if [ $SPOTinstall == "YES" ]


### PR DESCRIPTION
use raspberry-kernel-headers for better compatibility with kernel binaries.