### PR TITLE
fix: handling of FOLDER in playlistaddplay

### DIFF
--- a/scripts/inc.settingsFolderSpecific.sh
+++ b/scripts/inc.settingsFolderSpecific.sh
@@ -12,8 +12,12 @@ NOW=`date +%Y-%m-%d.%H:%M:%S`
 if [ "$DEBUG" == "true" ]; then echo "  #START### SCRIPT inc.settingsFolderSpecific.sh ($NOW) ##" >> $PATHDATA/../logs/debug.log; fi
 
 # Get folder name of currently played audio 
-FOLDER=$(cat $PATHDATA/../settings/Latest_Folder_Played)
-if [ "$DEBUG" == "true" ]; then echo "  # VAR FOLDER from settings/Latest_Folder_Played: $FOLDER" >> $PATHDATA/../logs/debug.log; fi
+if [ "x${FOLDER}" == "x" ]
+then
+  FOLDER=$(cat $PATHDATA/../settings/Latest_Folder_Played)
+
+  if [ "$DEBUG" == "true" ]; then echo "  # VAR FOLDER from settings/Latest_Folder_Played: $FOLDER" >> $PATHDATA/../logs/debug.log; fi
+fi
 
 if [ -e "$AUDIOFOLDERSPATH/$FOLDER/folder.conf" ]
 then


### PR DESCRIPTION
The code in `inc.settingsFolderSpecific.sh` should read the value for 
`FOLDER` only from `Latest_Folder_Played` if it is not set by its parent 
script.
Otherwise this might return with no value at all for example on the 
first media played and with wrong settings if changing playlists.

fixes #514