### PR TITLE
Comment Line in buster-install-default.sh

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -493,7 +493,7 @@ fi
 cd /home/pi/
 git clone https://github.com/MiczFlor/RPi-Jukebox-RFID.git
 
-move into the Phoniebox dir
+# Jump into the Phoniebox dir
 cd RPi-Jukebox-RFID
 
 # Install more required packages


### PR DESCRIPTION
Comment Line 496. Otherwise you get a warning during installation:

`./buster-install-default.sh: line 496: move: command not found`