### PR TITLE
Fixing command not found in buster install script

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -493,7 +493,7 @@ fi
 cd /home/pi/
 git clone https://github.com/MiczFlor/RPi-Jukebox-RFID.git
 
-move into the Phoniebox dir
+# Move into the Phoniebox dir
 cd RPi-Jukebox-RFID
 
 # Install more required packages


### PR DESCRIPTION
While installing I saw 
```
./buster-install-default.sh: line 496: move: command not found
```

This is just a comment without the `#`. So I added it.