### PR TITLE
Update daemon_rfid_reader.py

### DIFF
--- a/scripts/daemon_rfid_reader.py
+++ b/scripts/daemon_rfid_reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 
 import subprocess
-import os 
+import os, time
 from Reader import Reader
 
 reader = Reader()
@@ -9,7 +9,10 @@ reader = Reader()
 # get absolute path of this script
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-print dir_path
+# vars for ensuring delay between same-card-swipes
+same_id_delay = 0
+previous_id = ""
+previous_time = time.time()
 
 while True:
         # reading the card id
@@ -22,8 +25,11 @@ while True:
         # https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/551
         cardid = reader.reader.readCard()
         try:
-            # start the player script and pass on the cardid
-            if cardid != None:
+            # start the player script and pass on the cardid (but only if new card or otherwise "same_id_delay" seconds have passed)
+            if cardid != None and (cardid != previous_id or (time.time()-previous_time) >= same_id_delay):
                 subprocess.call([dir_path + '/rfid_trigger_play.sh --cardid=' + cardid], shell=True)
+                previous_id = cardid
+                previous_time = time.time()
+
         except OSError as e:
-            print "Execution failed:" 
+            print "Execution failed:"


### PR DESCRIPTION
I implemented a (customizable) delay for same-card-swipes as I had some issues with my 1,5year old daughter who swipes differently than me... She leaves the card on the reader while moving it slightly resulting in "same card" recognition over and over again. A customizable delay between actions for same-card swipes fixed that without much code modification. I left the initial delay to 0 seconds to not make a difference for other users while allowing users like me to modify this setting if need be.