### PR TITLE
changed "After" to alsa-state instead of default.target

### DIFF
--- a/misc/sampleconfigs/phoniebox-startup-sound.service.stretch-default.sample
+++ b/misc/sampleconfigs/phoniebox-startup-sound.service.stretch-default.sample
@@ -1,6 +1,6 @@
 [Unit]  
 Description=Phoniebox Startup Sound
-After=default.target
+After=alsa-state.service
 
 [Service]
 User=pi


### PR DESCRIPTION
make sure startup sound also works on heedless installations. Fixes #681 