### PR TITLE
Fix spotify mopidy3 for buster

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -467,31 +467,22 @@ sudo iwconfig wlan0 power off
 sudo apt-get update
 sudo apt-get --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install libspotify-dev apt-transport-https samba samba-common-bin python-dev python-pip gcc raspberrypi-kernel-headers lighttpd php7.3-common php7.3-cgi php7.3 php7.3-fpm at mpd mpc mpg123 git ffmpeg python-mutagen python3-gpiozero resolvconf spi-tools python-spidev python3-spidev
 
+# use python3.7 as default
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
 # Install required spotify packages
 if [ $SPOTinstall == "YES" ]
 then
 	wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
 	sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/buster.list
 	sudo apt-get update
-	sudo apt-get --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install mopidy
+	sudo apt-get --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install mopidy mopidy-mpd mopidy-local mopidy-spotify
 	sudo apt-get --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install libspotify12 python-cffi python-ply python-pycparser python-spotify
-	sudo rm -rf /usr/lib/python2.7/dist-packages/mopidy_spotify*
-	sudo rm -rf /usr/lib/python2.7/dist-packages/Mopidy_Spotify-*
-	cd
-	sudo rm -rf mopidy-spotify
-	git clone -b fix/web_api_playlists --single-branch https://github.com/princemaxwell/mopidy-spotify.git
-	cd mopidy-spotify
-	sudo python setup.py install
-	cd
-	# should be removed, if Mopidy-Iris can be installed normally
-	# pylast >= 3.0.0 removed the python2 support
-	sudo pip install pylast==2.4.0
-	sudo pip install Mopidy-Iris
 fi
 
 # Get github code
 cd /home/pi/
 git clone https://github.com/MiczFlor/RPi-Jukebox-RFID.git
+
 
 # Jump into the Phoniebox dir
 cd RPi-Jukebox-RFID


### PR DESCRIPTION
# Changelog
- Use python3.7 as the default python
- Remove mopidy-iris (only temporarily until it supports python3. See for progress https://github.com/jaedb/Iris/issues/356)
- Remove custom mopidy-spotify
- Install mopidy-spotify, mopidy-mpd and mopidy-local from the mopidy repo

# Setup used for testing
- Raspbian Buster
- Neuftech USB Reader
- HifiBerry MiniAmp
- Play/Pause, Next, Prev, VolUp, VolDown GPIO Buttons

Maybe there are other setups which will break when using python3 as the default.
