### PR TITLE
fix: generate locales before installation of software

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -464,6 +464,8 @@ esac
 sudo iwconfig wlan0 power off
 
 # Install required packages
+sudo locale-gen $LANG
+
 sudo apt-get update
 sudo apt-get --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install libspotify-dev apt-transport-https samba samba-common-bin python-dev python-pip gcc raspberrypi-kernel-headers lighttpd php7.3-common php7.3-cgi php7.3 php7.3-fpm at mpd mpc mpg123 git ffmpeg python-mutagen python3-gpiozero resolvconf spi-tools python-spidev python3-spidev
 


### PR DESCRIPTION
doing this avoids those nasty messages complaining about locales not 
being correctly set:

    perl: warning: Setting locale failed.
    perl: warning: Please check that your locale settings:
    	LANGUAGE = (unset),
    	LC_ALL = (unset),
    	LC_TIME = "de_DE.UTF-8",
    	LC_MONETARY = "de_DE.UTF-8",
    	LC_ADDRESS = "de_DE.UTF-8",
    	LC_TELEPHONE = "de_DE.UTF-8",
    	LC_NAME = "de_DE.UTF-8",
    	LC_MEASUREMENT = "de_DE.UTF-8",
    	LC_IDENTIFICATION = "de_DE.UTF-8",
    	LC_NUMERIC = "de_DE.UTF-8",
    	LC_PAPER = "de_DE.UTF-8",
    	LANG = "en_GB.UTF-8"
        are supported and installed on your system.
    perl: warning: Falling back to a fallback locale ("en_GB.UTF-8").
    locale: Cannot set LC_ALL to default locale: No such file or directory