### PR TITLE
fix: fixed all complaints of shellcheck

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -27,7 +27,7 @@ All these are optional and can also be done later
 manually.
 
 If you are ready, hit ENTER"
-read INPUT
+read -r INPUT
 
 ##################################################### 
 # CONFIG FILE
@@ -40,7 +40,7 @@ read INPUT
 rm PhonieboxInstall.conf
 # Create empty config file
 touch PhonieboxInstall.conf
-echo "# Phoniebox config" > $PATHDATA/PhonieboxInstall.conf
+echo "# Phoniebox config" > "${PATHDATA}/PhonieboxInstall.conf"
 
 ##################################################### 
 # Ask if wifi config
@@ -61,33 +61,33 @@ case "$response" in
     	WIFIconfig=NO
     	echo "You want to configure WiFi later."
     	echo "Hit ENTER to proceed to the next step."
-        read INPUT
+        read -r INPUT
         # append variables to config file
-        echo "WIFIconfig=$WIFIconfig" >> $PATHDATA/PhonieboxInstall.conf
+        echo "WIFIconfig=$WIFIconfig" >> "${PATHDATA}/PhonieboxInstall.conf"
         # make a fallback for WiFi Country Code, because we need that even without WiFi config
-        echo "WIFIcountryCode=DE" >> $PATHDATA/PhonieboxInstall.conf
+        echo "WIFIcountryCode=DE" >> "${PATHDATA}/PhonieboxInstall.conf"
         ;;
     *)
     	WIFIconfig=YES
         #Ask for ssid
         echo "* Type SSID name"
-        read INPUT
+        read -r INPUT
         WIFIssid="$INPUT"
         #Ask for wifi country code
         echo "* WiFi Country Code (e.g. DE, GB, CZ or US)"
-        read INPUT
+        read -r INPUT
         WIFIcountryCode="$INPUT"
         #Ask for password
         echo "* Type password"
-        read INPUT
+        read -r INPUT
         WIFIpass="$INPUT"
         #Ask for IP
         echo "* Static IP (e.g. 192.168.1.199)"
-        read INPUT
+        read -r INPUT
         WIFIip="$INPUT"
         #Ask for Router IP
         echo "* Router IP (e.g. 192.168.1.1)"
-        read INPUT
+        read -r INPUT
         WIFIipRouter="$INPUT"
         echo "Your WiFi config:"
         echo "SSID      : $WIFIssid"
@@ -100,16 +100,16 @@ case "$response" in
             [nN][oO]|[nN])
             	echo "The values are incorrect."
             	echo "Hit ENTER to exit and start over."
-                read INPUT; exit
+                read -r INPUT; exit
                 ;;
             *)
                 # append variables to config file
-                echo "WIFIconfig=\"$WIFIconfig\"" >> $PATHDATA/PhonieboxInstall.conf
-                echo "WIFIcountryCode=\"$WIFIcountryCode\"" >> $PATHDATA/PhonieboxInstall.conf
-                echo "WIFIssid=\"$WIFIssid\"" >> $PATHDATA/PhonieboxInstall.conf
-                echo "WIFIpass=\"$WIFIpass\"" >> $PATHDATA/PhonieboxInstall.conf
-                echo "WIFIip=\"$WIFIip\"" >> $PATHDATA/PhonieboxInstall.conf
-                echo "WIFIipRouter=\"$WIFIipRouter\"" >> $PATHDATA/PhonieboxInstall.conf
+                echo "WIFIconfig=\"$WIFIconfig\"" >> "${PATHDATA}/PhonieboxInstall.conf"
+                echo "WIFIcountryCode=\"$WIFIcountryCode\"" >> "${PATHDATA}/PhonieboxInstall.conf"
+                echo "WIFIssid=\"$WIFIssid\"" >> "${PATHDATA}/PhonieboxInstall.conf"
+                echo "WIFIpass=\"$WIFIpass\"" >> "${PATHDATA}/PhonieboxInstall.conf"
+                echo "WIFIip=\"$WIFIip\"" >> "${PATHDATA}/PhonieboxInstall.conf"
+                echo "WIFIipRouter=\"$WIFIipRouter\"" >> "${PATHDATA}/PhonieboxInstall.conf"
                 ;;
         esac
         ;;
@@ -124,7 +124,7 @@ EXISTINGuse=NO
 
 # The install will be in the home dir of user pi
 # Move to home directory now to check
-cd
+cd ~ || exit
 if [ -d /home/pi/RPi-Jukebox-RFID ]; then
     # Houston, we found something!
     clear
@@ -151,7 +151,7 @@ echo "#####################################################
     	    echo "Phoniebox will be a fresh install. The existing version will be dropped."
     	    echo "Hit ENTER to proceed to the next step."
             sudo rm -rf RPi-Jukebox-RFID
-            read INPUT
+            read -r INPUT
             ;;
         *)
     	    EXISTINGuse=YES
@@ -183,7 +183,7 @@ echo "#####################################################
                     ;;
             esac
             # append variables to config file
-            echo "EXISTINGuseRfidConf=$EXISTINGuseRfidConf" >> $PATHDATA/PhonieboxInstall.conf
+            echo "EXISTINGuseRfidConf=$EXISTINGuseRfidConf" >> "${PATHDATA}/PhonieboxInstall.conf"
 
             read -r -p "RFID shortcuts to play audio folders? [Y/n] " response
             case "$response" in
@@ -195,7 +195,7 @@ echo "#####################################################
                     ;;
             esac
             # append variables to config file
-            echo "EXISTINGuseRfidLinks=$EXISTINGuseRfidLinks" >> $PATHDATA/PhonieboxInstall.conf
+            echo "EXISTINGuseRfidLinks=$EXISTINGuseRfidLinks" >> "${PATHDATA}/PhonieboxInstall.conf"
 
             read -r -p "Audio folders: use existing? [Y/n] " response
             case "$response" in
@@ -207,7 +207,7 @@ echo "#####################################################
                     ;;
             esac
             # append variables to config file
-            echo "EXISTINGuseAudio=$EXISTINGuseAudio" >> $PATHDATA/PhonieboxInstall.conf
+            echo "EXISTINGuseAudio=$EXISTINGuseAudio" >> "${PATHDATA}/PhonieboxInstall.conf"
 
             read -r -p "GPIO: use existing file? [Y/n] " response
             case "$response" in
@@ -219,7 +219,7 @@ echo "#####################################################
                     ;;
             esac
             # append variables to config file
-            echo "EXISTINGuseGpio=$EXISTINGuseGpio" >> $PATHDATA/PhonieboxInstall.conf
+            echo "EXISTINGuseGpio=$EXISTINGuseGpio" >> "${PATHDATA}/PhonieboxInstall.conf"
 
             read -r -p "Sound effects: use existing startup / shutdown sounds? [Y/n] " response
             case "$response" in
@@ -231,17 +231,17 @@ echo "#####################################################
                     ;;
             esac
             # append variables to config file
-            echo "EXISTINGuseSounds=$EXISTINGuseSounds" >> $PATHDATA/PhonieboxInstall.conf
+            echo "EXISTINGuseSounds=$EXISTINGuseSounds" >> "${PATHDATA}/PhonieboxInstall.conf"
 
             echo "Thanks. Got it."
             echo "The existing install can be found in the BACKUP directory."
             echo "Hit ENTER to proceed to the next step."
-            read INPUT
+            read -r INPUT
             ;;
     esac
 fi
 # append variables to config file
-echo "EXISTINGuse=$EXISTINGuse" >> $PATHDATA/PhonieboxInstall.conf
+echo "EXISTINGuse=$EXISTINGuse" >> "${PATHDATA}/PhonieboxInstall.conf"
 
 ##################################################### 
 # Audio iFace
@@ -263,7 +263,7 @@ read -r -p "Use PCM as iFace? [Y/n] " response
 case "$response" in
     [nN][oO]|[nN])
     	echo "Type the iFace name you want to use:"
-        read INPUT
+        read -r INPUT
         AUDIOiFace="$INPUT"
         ;;
     *)
@@ -271,10 +271,10 @@ case "$response" in
         ;;
 esac
 # append variables to config file
-echo "AUDIOiFace=\"$AUDIOiFace\"" >> $PATHDATA/PhonieboxInstall.conf
+echo "AUDIOiFace=\"$AUDIOiFace\"" >> "${PATHDATA}/PhonieboxInstall.conf"
 echo "Your iFace is called'$AUDIOiFace'"
 echo "Hit ENTER to proceed to the next step."
-read INPUT
+read -r INPUT
 
 ##################################################### 
 # Configure spotify
@@ -304,7 +304,7 @@ case "$response" in
     	SPOTinstall=NO
     	echo "You don't want spotify support."
     	echo "Hit ENTER to proceed to the next step."
-        read INPUT
+        read -r INPUT
         ;;
     *)
     	SPOTinstall=YES
@@ -328,31 +328,34 @@ case "$response" in
 "
 		echo ""
     	echo "Type your Spotify username:"
-        read INPUT
+        read -r INPUT
         SPOTIuser="$INPUT"
 		echo ""
     	echo "Type your Spotify password:"
-        read INPUT
+        read -r INPUT
         SPOTIpass="$INPUT"
 		echo ""
     	echo "Type your client_id:"
-        read INPUT
+        read -r INPUT
         SPOTIclientid="$INPUT"
 		echo ""
     	echo "Type your client_secret:"
-        read INPUT
+        read -r INPUT
         SPOTIclientsecret="$INPUT"
 		echo ""
     	echo "Hit ENTER to proceed to the next step."
-        read INPUT
+        read -r INPUT
         ;;
 esac
 # append variables to config file
-echo "SPOTinstall=\"$SPOTinstall\"" >> $PATHDATA/PhonieboxInstall.conf
-echo "SPOTIuser=\"$SPOTIuser\"" >> $PATHDATA/PhonieboxInstall.conf
-echo "SPOTIpass=\"$SPOTIpass\"" >> $PATHDATA/PhonieboxInstall.conf
-echo "SPOTIclientid=\"$SPOTIclientid\"" >> $PATHDATA/PhonieboxInstall.conf
-echo "SPOTIclientsecret=\"$SPOTIclientsecret\"" >> $PATHDATA/PhonieboxInstall.conf
+{
+  echo "SPOTinstall=\"$SPOTinstall\"";
+  echo "SPOTIuser=\"$SPOTIuser\"";
+  echo "SPOTIpass=\"$SPOTIpass\"";
+  echo "SPOTIclientid=\"$SPOTIclientid\"";
+  echo "SPOTIclientsecret=\"$SPOTIclientsecret\""
+} >> "${PATHDATA}/PhonieboxInstall.conf"
+
 
 ##################################################### 
 # Configure MPD
@@ -373,17 +376,17 @@ case "$response" in
     	MPDconfig=NO
     	echo "You want to configure MPD later."
     	echo "Hit ENTER to proceed to the next step."
-        read INPUT
+        read -r INPUT
         ;;
     *)
     	MPDconfig=YES
     	echo "MPD will be set up with default values."
     	echo "Hit ENTER to proceed to the next step."
-        read INPUT
+        read -r INPUT
         ;;
 esac
 # append variables to config file
-echo "MPDconfig=\"$MPDconfig\"" >> $PATHDATA/PhonieboxInstall.conf
+echo "MPDconfig=\"$MPDconfig\"" >> "${PATHDATA}/PhonieboxInstall.conf"
 
 ##################################################### 
 # Folder path for audio files 
@@ -411,7 +414,7 @@ case "$response" in
     	echo "Please type the absolute path here (no trailing slash)."
     	echo "Default would be for example:"
     	echo "/home/pi/RPi-Jukebox-RFID/shared/audiofolders"
-        read INPUT
+        read -r INPUT
         DIRaudioFolders="$INPUT"
         ;;
     *)
@@ -419,11 +422,11 @@ case "$response" in
         ;;
 esac
 # append variables to config file
-echo "DIRaudioFolders=\"$DIRaudioFolders\"" >> $PATHDATA/PhonieboxInstall.conf
+echo "DIRaudioFolders=\"$DIRaudioFolders\"" >> "${PATHDATA}/PhonieboxInstall.conf"
 echo "Your audio folders live in this dir:"
 echo $DIRaudioFolders
 echo "Hit ENTER to proceed to the next step."
-read INPUT
+read -r INPUT
 
 clear
 
@@ -446,7 +449,7 @@ case "$response" in
     [nN][oO]|[nN])
     	echo "Exiting the installation."
     	echo "Your configuration data was saved in this file:"
-    	echo $PATHDATA/PhonieboxInstall.conf
+    	echo "${PATHDATA}/PhonieboxInstall.conf"
     	echo
         exit
         ;;
@@ -458,7 +461,8 @@ esac
 # Read install config as written so far
 # (this might look stupid so far, but makes sense once
 # the option to install from config file is introduced.)
-. $PATHDATA/PhonieboxInstall.conf
+# shellcheck source=scripts/installscripts/tests/ShellCheck/PhonieboxInstall.conf
+. "${PATHDATA}/PhonieboxInstall.conf"
 
 # power management of wifi: switch off to avoid disconnecting
 sudo iwconfig wlan0 power off
@@ -502,7 +506,7 @@ then
 fi
 
 # Get github code
-cd /home/pi/
+cd /home/pi/ || exit
 
 # Must be changed to the correct branch!!!
 # Change to master when merging develop with master!!!
@@ -515,7 +519,7 @@ sudo rm RegisterDevice.py
 wget https://raw.githubusercontent.com/MiczFlor/RPi-Jukebox-RFID/develop/scripts/RegisterDevice.py
 
 # Jump into the Phoniebox dir
-cd RPi-Jukebox-RFID
+cd RPi-Jukebox-RFID || exit
 
 # Install more required packages
 sudo pip install -r requirements.txt
@@ -745,13 +749,13 @@ then
         
         # Read the existing RFID config file line by line and use
         # only lines which are separated (IFS) by '='.
-        while IFS== read -r key val ; do
+        while IFS='=' read -r key val ; do
             # $var should be stripped of possible leading or trailing "
             val=${val%\"}
             val=${val#\"} 
             key=${key}
             # Additional error check: key should not start with a hash and not be empty.
-            if ([ ! ${key:0:1} == '#' ] && [ ! -z "$key" ])
+            if [ ! "${key:0:1}" == '#' ] && [ -n "$key" ]
             then
                 # Replace the matching value in the newly created conf file
                 sed -i 's/%'"$key"'%/'"$val"'/' /home/pi/RPi-Jukebox-RFID/settings/rfid_trigger_play.conf
@@ -854,7 +858,7 @@ case "$response" in
     [nN][oO]|[nN])
         ;;
     *)
-        cd /home/pi/RPi-Jukebox-RFID/scripts/
+        cd /home/pi/RPi-Jukebox-RFID/scripts/ || exit
         python3 RegisterDevice.py
         sudo chown pi:www-data /home/pi/RPi-Jukebox-RFID/scripts/deviceName.txt
         sudo chmod 644 /home/pi/RPi-Jukebox-RFID/scripts/deviceName.txt

--- a/scripts/installscripts/tests/ShellCheck/PhonieboxInstall.conf
+++ b/scripts/installscripts/tests/ShellCheck/PhonieboxInstall.conf
@@ -1,0 +1,16 @@
+# Phoniebox config
+WIFIconfig="YES"
+WIFIcountryCode="EN"
+WIFIssid="GatewayToTheWorld"
+WIFIpass="NotSoRandomString"
+WIFIip="192.168.0.2"
+WIFIipRouter="192.168.0.1"
+EXISTINGuse=NO
+AUDIOiFace="PCM"
+SPOTinstall="YES"
+SPOTIuser="notsorandomusername"
+SPOTIpass="notsorandompassword"
+SPOTIclientid="notsorandomclientid"
+SPOTIclientsecret="notsorandomclientsecret"
+MPDconfig="YES"
+DIRaudioFolders="/home/pi/RPi-Jukebox-RFID/shared/audiofolders"


### PR DESCRIPTION
I ran shellcheck and fixed all of the complaints it had about this 
script. Though at the moment I do not have a RPi to test the script is 
working correctly after my changes (I don't doubt it does run fine, but 
better be safe than sorry).

Example for shellcheck:

    docker run --rm -ti -v $PWD:/code -w /code pipelinecomponents/shellcheck:latest \
        shellcheck -x scripts/installscripts/buster-install-default.sh