### PR TITLE
fix: pylint activate-amplifier.py

### DIFF
--- a/misc/sampleconfigs/phoniebox-activate-amplifier.service.stretch-default.sample
+++ b/misc/sampleconfigs/phoniebox-activate-amplifier.service.stretch-default.sample
@@ -7,7 +7,7 @@ User=pi
 Group=pi
 Restart=always
 WorkingDirectory=/home/pi/RPi-Jukebox-RFID
-ExecStart=/home/pi/RPi-Jukebox-RFID/scripts/activate-amplifier.py
+ExecStart=/home/pi/RPi-Jukebox-RFID/scripts/activate_amplifier.py
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/activate_amplifier.py
+++ b/scripts/activate_amplifier.py
@@ -1,35 +1,36 @@
 #!/usr/bin/python3
 
 import sys
-import time
 from signal import pause
 import RPi.GPIO as GPIO
 
-# script to activate and deactivate an amplifier, power led, etc. using a GPIO pin on power up / down
+# script to activate and deactivate an amplifier, power led, etc. using a GPIO
+# pin on power up / down
 
-# see for an example implementation with a PAM8403 digital amplifier (PAM pin 12 connected to GPIO 26)
+# see for an example implementation with a PAM8403 digital amplifier
+# (PAM pin 12 connected to GPIO 26)
 # https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/Hardware-Hack-PAM8403-Poweroff
 
 # change this value based on which GPIO port the amplifier or other devices are connected to
 # Flexible Pinout
-ampGPIO = 26
+AMP_GPIO = 26
 # Classic Pinout
-# ampGPIO = 23
+# AMP_GPIO = 23
 
 # setup RPi lib to control output pin
 # we do not cleanup the GPIO because we want the pin low = off after program exit
 # the resulting warning can be ignored
 GPIO.setwarnings(False)
 GPIO.setmode(GPIO.BCM)
-GPIO.setup(ampGPIO, GPIO.OUT)
+GPIO.setup(AMP_GPIO, GPIO.OUT)
 
 def set_amplifier(status):
     if status:
         print("Setting amplifier: ON")
-        GPIO.output(ampGPIO, GPIO.HIGH)
+        GPIO.output(AMP_GPIO, GPIO.HIGH)
     else:
         print("Setting amplifier: OFF")
-        GPIO.output(ampGPIO, GPIO.LOW)
+        GPIO.output(AMP_GPIO, GPIO.LOW)
 
 if __name__ == "__main__":
     try:
@@ -41,4 +42,3 @@ if __name__ == "__main__":
         print("\nExiting amplifier control\n")
         # exit the application
         sys.exit(0)
-


### PR DESCRIPTION
Renamed to activate_amplifier.py as the name was one of the complaints.

This script is still not perfect in the eyes of pylint, though - it 
misses docstrings badly and wasn't able to import RPi.GPIO on my 
machine.