### PR TITLE
Fixing code to pass Action Python package

### DIFF
--- a/scripts/daemon_rfid_reader.py
+++ b/scripts/daemon_rfid_reader.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
-import subprocess
-import os, time
-from Reader import Reader
 import logging
+import os
+import subprocess
+import time
+
+from Reader import Reader
+
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()
@@ -12,42 +15,41 @@ formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(messag
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
-
-
 reader = Reader()
 
 # get absolute path of this script
 dir_path = os.path.dirname(os.path.realpath(__file__))
-logger.info(f'Dir_PATH: {dir_path}')
-
-print(dir_path)
+logger.info('Dir_PATH: {dir_path}'.format(dir_path=dir_path))
 
 # vars for ensuring delay between same-card-swipes
 same_id_delay = 0
 previous_id = ""
 previous_time = time.time()
 
-
 while True:
-        # reading the card id
-        # NOTE: it's been reported that KKMOON Reader might need the following line altered.
-        # Instead of:
-        # cardid = reader.reader.readCard()
-        # change the line to:
-        # cardid = reader.readCard()
-        # See here for (German ;) details:
-        # https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/551
-        cardid = reader.reader.readCard()
-        try:
-            # start the player script and pass on the cardid (but only if new card or otherwise "same_id_delay" seconds have passed)
-            if cardid != None:
-                if (cardid != previous_id or (time.time()-previous_time) >= same_id_delay):
-                    logger.info(f'Trigger Play Cardid={cardid}')
-                    subprocess.call([dir_path + '/rfid_trigger_play.sh --cardid=' + cardid], shell=True)
-                    previous_id = cardid
-                    previous_time = time.time()
-                else:
-                    logger.debug(f'Ignoring Card id {cardid} due to same-card-delay, delay: {same_id_delay}')
+    # reading the card id
+    # NOTE: it's been reported that KKMOON Reader might need the following line altered.
+    # Instead of:
+    # cardid = reader.reader.readCard()
+    # change the line to:
+    # cardid = reader.readCard()
+    # See here for (German ;) details:
+    # https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/551
+    cardid = reader.reader.readCard()
+    try:
+        # start the player script and pass on the cardid (but only if new card or otherwise
+        # "same_id_delay" seconds have passed)
+        if cardid is not None:
+            if cardid != previous_id or (time.time() - previous_time) >= same_id_delay:
+                logger.info('Trigger Play Cardid={cardid}'.format(cardid=cardid))
+                subprocess.call([dir_path + '/rfid_trigger_play.sh --cardid=' + cardid], shell=True)
+                previous_id = cardid
+                previous_time = time.time()
+            else:
+                logger.debug('Ignoring Card id {cardid} due to same-card-delay, delay: {same_id_delay}'.format(
+                    cardid=cardid,
+                    same_id_delay=same_id_delay
+                ))
 
-        except OSError as e:
-            logger.error(f"Execution failed: {e}" )
+    except OSError as e:
+        logger.error('Execution failed: {e}'.format(e=e))

--- a/scripts/python-phoniebox/PhonieboxConfigChanger.py
+++ b/scripts/python-phoniebox/PhonieboxConfigChanger.py
@@ -66,16 +66,12 @@ class PhonieboxConfigChanger(Phoniebox):
             config_file = self.config.get("phoniebox", "card_assignments_file")
         except ValueError:
             parser = self.config
-            config_file = configFilePath
         # update value
         try:
             parser.set(section, key, value)
             self.debug("Set {} = {} in section {}".format(key, value, section))
         except configparser.NoSectionError as e:
-            raise(configparser.NoSectionError, e)
-        # write to file
-        # with open(config_file, 'w') as f:
-        #     parser.write(f)
+            raise e
 
     def get(self, section, t="ini"):
         try:


### PR DESCRIPTION
In my fork, I got a few times the error 
`  Downloading pyflakes-2.1.1-py2.py3-none-any.whl (59 kB)
Installing collected packages: mccabe, pycodestyle, entrypoints, pyflakes, flake8
Successfully installed entrypoints-0.3 flake8-3.7.9 mccabe-0.6.1 pycodestyle-2.5.0 pyflakes-2.1.1
./scripts/python-phoniebox/PhonieboxConfigChanger.py:69:27: F821 undefined name 'configFilePath'
            config_file = configFilePath
                          ^
1     F821 undefined name 'configFilePath'
1
##[error]Process completed with exit code 1.`

it seems that this part was not required  is actually not required, as the config file is not written during execution of the set command in the PhonieboxConfigChanger.
Therefore i removed that part of the code.
@laclaro : Please check if you are fine with that change