### PR TITLE
Rotary encoder not working anymore

### DIFF
--- a/scripts/rotary_encoder_base.py
+++ b/scripts/rotary_encoder_base.py
@@ -14,7 +14,7 @@ c_uint8 = ctypes.c_uint8
 
 
 class Flags_bits(ctypes.LittleEndianStructure):
-    fields_ = [
+    _fields_ = [
                  ("A", c_uint8, 1),  # asByte & 1
                  ("B", c_uint8, 1),  # asByte & 2
                 ]


### PR DESCRIPTION
corrected failure message "AttributeError: type object 'Flags_bits' has no attribute '_fields_'" with python 3.7.3