### PR TITLE
hotfix: installer shall use master

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -511,8 +511,8 @@ cd /home/pi/
 
 # Must be changed to the correct branch!!!
 # Change to master when merging develop with master!!!
-git clone https://github.com/MiczFlor/RPi-Jukebox-RFID.git 
-#--branch develop
+# this needs to be replaced on develop
+git clone --branch master https://github.com/MiczFlor/RPi-Jukebox-RFID.git
 cd /home/pi/RPi-Jukebox-RFID/misc/sampleconfigs/
 
 # The following lines are just for development.

--- a/scripts/installscripts/stretch-install-default.sh
+++ b/scripts/installscripts/stretch-install-default.sh
@@ -391,7 +391,8 @@ sudo apt-get --yes --force-yes install apt-transport-https samba samba-common-bi
 
 # Get github code
 cd /home/pi/
-git clone https://github.com/MiczFlor/RPi-Jukebox-RFID.git
+# this needs to be replaced on develop
+git clone --branch master https://github.com/MiczFlor/RPi-Jukebox-RFID.git
 # the following three lines are needed as long as this is not the master branch:
 cd RPi-Jukebox-RFID
 git fetch

--- a/scripts/installscripts/stretch-install-spotify.sh
+++ b/scripts/installscripts/stretch-install-spotify.sh
@@ -486,7 +486,8 @@ fi
 
 # Get github code
 cd /home/pi/
-git clone https://github.com/MiczFlor/RPi-Jukebox-RFID.git
+# this needs to be replaced on develop
+git clone --branch master https://github.com/MiczFlor/RPi-Jukebox-RFID.git
 # the following three lines are needed as long as this is not the master branch:
 cd RPi-Jukebox-RFID
 git fetch

--- a/scripts/python-phoniebox/PhonieboxConfigChanger.py
+++ b/scripts/python-phoniebox/PhonieboxConfigChanger.py
@@ -63,7 +63,7 @@ class PhonieboxConfigChanger(Phoniebox):
             config_file = self.config.get("phoniebox","card_assignments_file")
         except ValueError:
             parser = self.config
-            config_file = configFilePath
+            config_file = self.configFilePath
         # update value
         try:
             parser.set(section,key,value)


### PR DESCRIPTION
With this fix, flake8 checks also work and should catch more issues (e.g. f-strings not in Python3.5 on stretch)