### PR TITLE
Pin mopidy-iris to last version working with python 2

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -503,7 +503,7 @@ then
 	 sudo python2.7 -m pip install pylast==2.4.0
 	# not sure tornado still needs to be downgraded now that Mopidy 3 is not installed and tornado seems to be 5.1
  	sudo python2.7 -m pip install 'tornado==5.0'
-	sudo python2.7 -m pip install Mopidy-Iris
+	sudo python2.7 -m pip install Mopidy-Iris=3.43.0
 fi
 
 # Get github code

--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -503,7 +503,7 @@ then
 	 sudo python2.7 -m pip install pylast==2.4.0
 	# not sure tornado still needs to be downgraded now that Mopidy 3 is not installed and tornado seems to be 5.1
  	sudo python2.7 -m pip install 'tornado==5.0'
-	sudo python2.7 -m pip install Mopidy-Iris=3.43.0
+	sudo python2.7 -m pip install Mopidy-Iris==3.43.0
 fi
 
 # Get github code

--- a/scripts/installscripts/stretch-install-spotify.sh
+++ b/scripts/installscripts/stretch-install-spotify.sh
@@ -468,7 +468,10 @@ then
 	wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
 	sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/stretch.list
 	sudo apt-get update
-	sudo apt-get --yes --force-yes install mopidy
+	
+	sudo apt-get install --yes mopidy=2.2.2-1
+	sudo python2.7 -m pip install Mopidy==2.2.*
+	
 	sudo apt-get --yes --force-yes install libspotify12 python-cffi python-ply python-pycparser python-spotify
 	sudo rm -rf /usr/lib/python2.7/dist-packages/mopidy_spotify*
 	sudo rm -rf /usr/lib/python2.7/dist-packages/Mopidy_Spotify-*
@@ -481,7 +484,9 @@ then
 	# should be removed, if Mopidy-Iris can be installed normally
 	# pylast >= 3.0.0 removed the python2 support
 	sudo pip install pylast==2.4.0
-	sudo pip install Mopidy-Iris
+	# not sure tornado still needs to be downgraded now that Mopidy 3 is not installed and tornado seems to be 5.1
+ 	sudo python2.7 -m pip install 'tornado==5.0'
+	sudo python2.7 -m pip install Mopidy-Iris==3.43.0
 fi
 
 # Get github code


### PR DESCRIPTION
Mopidy-Iris dropped python 2 and mopidy 2 support after 3.43.0, see https://github.com/jaedb/iris/releases

Pin used version to 3.43.0