### PR TITLE
chore: remove php-fpm

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -489,7 +489,7 @@ then
     sudo apt-get --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install raspberrypi-kernel-headers
 fi
 
-sudo apt-get --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install samba samba-common-bin gcc lighttpd php7.3-common php7.3-cgi php7.3 php7.3-fpm at mpd mpc mpg123 git ffmpeg resolvconf spi-tools
+sudo apt-get --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install samba samba-common-bin gcc lighttpd php7.3-common php7.3-cgi php7.3 at mpd mpc mpg123 git ffmpeg resolvconf spi-tools
 
 # restore backup of /etc/resolv.conf in case installation of resolvconf cleared it
 sudo cp /etc/resolv.conf.orig /etc/resolv.conf

--- a/scripts/installscripts/stretch-install-default.sh
+++ b/scripts/installscripts/stretch-install-default.sh
@@ -389,7 +389,7 @@ sudo iwconfig wlan0 power off
 
 # Install required packages
 sudo apt-get update
-sudo apt-get --yes --force-yes install apt-transport-https samba samba-common-bin gcc linux-headers-4.9 lighttpd php7.0-common php7.0-cgi php7.0 php7.0-fpm at mpd mpc mpg123 git ffmpeg
+sudo apt-get --yes --force-yes install apt-transport-https samba samba-common-bin gcc linux-headers-4.9 lighttpd php7.0-common php7.0-cgi php7.0 at mpd mpc mpg123 git ffmpeg
 
 # prepare for python2 and python3
 sudo apt-get --yes --force-yes install python-dev python-pip python-mutagen python-gpiozero python-spidev

--- a/scripts/installscripts/stretch-install-spotify.sh
+++ b/scripts/installscripts/stretch-install-spotify.sh
@@ -464,7 +464,7 @@ sudo iwconfig wlan0 power off
 
 # Install required packages
 sudo apt-get update
-sudo apt-get --yes --force-yes install apt-transport-https samba samba-common-bin gcc linux-headers-4.9 lighttpd php7.0-common php7.0-cgi php7.0 php7.0-fpm at mpd mpc mpg123 git ffmpeg
+sudo apt-get --yes --force-yes install apt-transport-https samba samba-common-bin gcc linux-headers-4.9 lighttpd php7.0-common php7.0-cgi php7.0 at mpd mpc mpg123 git ffmpeg
 
 # prepare for python2 and python3
 sudo apt-get --yes --force-yes install python-dev python-pip python-mutagen python-gpiozero python-spidev


### PR DESCRIPTION
This will remove FPM as it does not seem to be needed but uses precious system resources.

Please check thoroughly, but as far as I could see lighttpd only used the php-cgi in its implementation. After manually disabling the fpm package from my sons box everything (the phoniebox webinterface) still worked fine.