### PR TITLE
Enhance docker buster image

### DIFF
--- a/ci/Dockerfile.buster.amd64
+++ b/ci/Dockerfile.buster.amd64
@@ -8,6 +8,8 @@ RUN groupadd --gid 1000 pi ;\
   chown -R 1000:1000 /code /home/pi ;\
   chmod +x /code/scripts/installscripts/buster-install-default.sh
 
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN apt-get update ;\
   apt-get -y install curl gnupg sudo nano;\
   echo 'deb http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi' > /etc/apt/sources.list.d/raspi.list ;\

--- a/ci/Dockerfile.buster.armv7
+++ b/ci/Dockerfile.buster.armv7
@@ -8,6 +8,8 @@ RUN groupadd --gid 1000 pi ;\
   chown -R 1000:1000 /code /home/pi ;\
   chmod +x /code/scripts/installscripts/buster-install-default.sh
 
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN apt-get update ;\
   apt-get -y install curl gnupg sudo nano;\
   echo 'deb http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi' >> /etc/apt/sources.list.d/raspi.list ;\

--- a/ci/Dockerfile.stretch.amd64
+++ b/ci/Dockerfile.stretch.amd64
@@ -8,6 +8,8 @@ RUN groupadd --gid 1000 pi ;\
   chown -R 1000:1000 /code /home/pi ;\
   chmod +x /code/scripts/installscripts/stretch-install-default.sh
 
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN apt-get update ;\
   apt-get -y install curl gnupg sudo nano;\
   echo 'deb http://raspbian.raspberrypi.org/raspbian/ stretch main contrib non-free rpi' > /etc/apt/sources.list.d/raspi.list ;\

--- a/ci/Dockerfile.stretch.armv7
+++ b/ci/Dockerfile.stretch.armv7
@@ -8,6 +8,8 @@ RUN groupadd --gid 1000 pi ;\
   chown -R 1000:1000 /code /home/pi ;\
   chmod +x /code/scripts/installscripts/stretch-install-default.sh
 
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN apt-get update ;\
   apt-get -y install curl gnupg sudo nano;\
   echo 'deb http://raspbian.raspberrypi.org/raspbian/ stretch main contrib non-free rpi' >> /etc/apt/sources.list.d/raspi.list ;\


### PR DESCRIPTION
while installing RPi-Jukebox-RFID in docker I get a lot of
`debconf: falling back to frontend: Readline`
Messages.

Found a fix and implemented it:
https://github.com/phusion/baseimage-docker/issues/58#issuecomment-47995343

Linked issue: #715 