### PR TITLE
Fix broken rfidoff_action in gpio-buttons.py

### DIFF
--- a/misc/sampleconfigs/gpio-buttons.py.sample
+++ b/misc/sampleconfigs/gpio-buttons.py.sample
@@ -66,7 +66,7 @@ def recordstop_action(channel):
     check_call("./scripts/playout_controls.sh -c=recordstop", shell=True)
 def recordplaylatest_action(channel):
     check_call("./scripts/playout_controls.sh -c=recordplaylatest", shell=True)
-def rfidoff_action():
+def rfidoff_action(channel):
     check_call("./scripts/playout_controls.sh -c=playerpauseforce", shell=True)
 
 # Handlers that handle special behavior of the push of a button


### PR DESCRIPTION
rfidoff_action wasn't working for me. See https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/869
Now it's working.