### PR TITLE
Add test_installation.sh script

### DIFF
--- a/scripts/installscripts/tests/test_installation.sh
+++ b/scripts/installscripts/tests/test_installation.sh
@@ -38,7 +38,7 @@ check_file_contains_string() {
     local file="$2"
 
     # sudo is required for checking /etc/mopidy/mopidy.conf
-    if [[ ! $(sudo grep -i "${string}" "${file}") ]]; then
+    if [[ ! $(sudo grep -iw "${string}" "${file}") ]]; then
         echo "  ERROR: '${string}' not found in ${file}"
         ((failed_tests++))
     fi
@@ -76,15 +76,15 @@ verify_conf_file() {
     # check that PhonieboxInstall.conf exists and is not empty
 
     # check if config file exists
-    if [[ ! -f ${install_conf} ]]; then
+    if [[ ! -f "${install_conf}" ]]; then
         echo "  ERROR: ${install_conf} does not exist!"
         exit 1
     fi
 
     # Source config file
     if [[ -f "${install_conf}" ]]; then
-        source ${install_conf}
-        cat ${install_conf}
+        source "${install_conf}"
+        cat "${install_conf}"
         echo ""
     fi
 
@@ -230,15 +230,15 @@ verify_spotify_config() {
 
     printf "\nTESTING spotify config...\n\n"
 
-    check_file_contains_string "username = ${spotify_username}" "${etc_mopidy_conf}"
-    check_file_contains_string "password = ${spotify_password}" "${etc_mopidy_conf}"
-    check_file_contains_string "client_id = ${spotify_client_id}" "${etc_mopidy_conf}"
-    check_file_contains_string "client_secret = ${spotify_client_secret}" "${etc_mopidy_conf}"
+    check_file_contains_string "username = ${SPOTIuser}" "${etc_mopidy_conf}"
+    check_file_contains_string "password = ${SPOTIpass}" "${etc_mopidy_conf}"
+    check_file_contains_string "client_id = ${SPOTIclientid}" "${etc_mopidy_conf}"
+    check_file_contains_string "client_secret = ${SPOTIclientsecret}" "${etc_mopidy_conf}"
 
-    check_file_contains_string "username = ${spotify_username}" "${mopidy_conf}"
-    check_file_contains_string "password = ${spotify_password}" "${mopidy_conf}"
-    check_file_contains_string "client_id = ${spotify_client_id}" "${mopidy_conf}"
-    check_file_contains_string "client_secret = ${spotify_client_secret}" "${mopidy_conf}"
+    check_file_contains_string "username = ${SPOTIuser}" "${mopidy_conf}"
+    check_file_contains_string "password = ${SPOTIpass}" "${mopidy_conf}"
+    check_file_contains_string "client_id = ${SPOTIclientid}" "${mopidy_conf}"
+    check_file_contains_string "client_secret = ${SPOTIclientsecret}" "${mopidy_conf}"
 
     # check that mopidy service is enabled
     check_service_enablement mopidy enabled
@@ -309,6 +309,6 @@ if [[ "${failed_tests}" -gt 0 ]]; then
     echo "${failed_tests} Test(s) failed (of ${tests} tests) (in ${m}m ${s}s)."
     exit 1
 else
-    echo "{tests} tests done in ${m}m ${s}s."
+    echo "${tests} tests done in ${m}m ${s}s."
 fi
 

--- a/scripts/installscripts/tests/test_installation.sh
+++ b/scripts/installscripts/tests/test_installation.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+
+# Test to verify that the installation script works as expected.
+# This script needs to be adapted, if new packages, etc are added to the install script
+
+printf "\nTesting installation:\n"
+
+tests=0
+failed_tests=0
+
+home_dir="/home/pi"
+
+jukebox_dir="${home_dir}/RPi-Jukebox-RFID"
+install_conf="${home_dir}/PhonieboxInstall.conf"
+
+# Tool functions
+
+check_chmod_chown() {
+    local mod_expected=$1
+    local user_expected=$2
+    local group_expected=$3
+    local dir=$4
+    local files=$5
+
+    for file in ${files};
+    do
+        mod_actual=$(stat --format '%a' "${dir}/${file}")
+        user_actual=$(stat -c '%U' "${dir}/${file}")
+        group_actual=$(stat -c '%G' "${dir}/${file}")
+        test ! "${mod_expected}" -eq "${mod_actual}" && echo "  ERROR: ${file} actual mod (${mod_actual}) differs from expected (${mod_expected})!"
+        test ! "${user_expected}" == "${user_actual}" && echo "  ERROR: ${file} actual owner (${user_actual}) differs from expected (${user_expected})!"
+        test ! "${group_expected}" == "${group_actual}" && echo "  ERROR: ${file} actual group (${group_actual}) differs from expected (${group_expected})!"
+    done
+}
+
+check_file_contains_string() {
+    local string="$1"
+    local file="$2"
+
+    # sudo is required for checking /etc/mopidy/mopidy.conf
+    if [[ ! $(sudo grep -i "${string}" "${file}") ]]; then
+        echo "  ERROR: '${string}' not found in ${file}"
+        ((failed_tests++))
+    fi
+    ((tests++))
+}
+
+check_service_state() {
+    local service="$1"
+    local desired_state="$2"
+
+    local actual_state=$(systemctl show -p ActiveState --value "${service}")
+    if [[ ! "${actual_state}" == "${desired_state}" ]]; then
+        echo "  ERROR: service ${service} is not ${desired_state} (state: ${actual_state})."
+        ((failed_tests++))
+    fi
+    ((tests++))
+}
+
+check_service_enablement() {
+    local service="$1"
+    local desired_enablement="$2"
+
+    local actual_enablement=$(systemctl is-enabled "${service}")
+    if [[ ! "${actual_enablement}" == "${desired_enablement}" ]]; then
+        echo "  ERROR: service ${service} is not ${desired_enablement} (state: ${actual_enablement})."
+        ((failed_tests++))
+    fi
+    ((tests++))
+}
+
+# Verify functions
+
+verify_conf_file() {
+    printf "\nTESTING PhonieboxInstall.conf file...\n\n"
+    # check that PhonieboxInstall.conf exists and is not empty
+
+    # check if config file exists
+    if [[ ! -f ${install_conf} ]]; then
+        echo "  ERROR: ${install_conf} does not exist!"
+        exit 1
+    fi
+
+    # Source config file
+    if [[ -f "${install_conf}" ]]; then
+        source ${install_conf}
+        cat ${install_conf}
+        echo ""
+    fi
+
+    if [[ -z "${WIFIconfig+x}" ]]; then
+        echo "  ERROR: \$WIFIconfig is unset"
+    else
+        echo "\$WIFIconfig is set to '$WIFIconfig'"
+        if [[ "$WIFIconfig" == "YES" ]]; then
+            test -z "${WIFIcountryCode+x}" && echo "  ERROR: \$WIFIcountryCode is missing!"
+            test -z "${WIFIssid+x}" && echo "  ERROR: \$WIFIssid is missing!"
+            test -z "${WIFIpass+x}" && echo "  ERROR: \$WIFIpass is missing!"
+            test -z "${WIFIip+x}" && echo "  ERROR: \$WIFIip is missing!"
+            test -z "${WIFIipRouter+x}" && echo "  ERROR: \$WIFIipRouter is missing!"
+        fi
+    fi
+    test -z "${EXISTINGuse+x}" && echo "  ERROR: \$EXISTINGuse is missing!"
+    test -z "${AUDIOiFace+x}" && echo "  ERROR: \$AUDIOiFace is missing!"
+
+    if [[ -z "${SPOTinstall+x}" ]]; then
+        echo "  ERROR: \$SPOTinstall is unset"
+    else
+        echo "\$SPOTinstall is set to '$SPOTinstall'"
+        if [ "$SPOTinstall" == "YES" ]; then
+            test -z "${SPOTIuser+x}" && echo "  ERROR: \$SPOTIuser is missing!"
+            test -z "${SPOTIpass+x}" && echo "  ERROR: \$SPOTIpass is missing!"
+            test -z "${SPOTIclientid+x}" && echo "  ERROR: \$SPOTIclientid is missing!"
+            test -z "${SPOTIclientsecret+x}" && echo "  ERROR: \$SPOTIclientsecret is missing!"
+        fi
+    fi
+    test -z "${MPDconfig+x}" && echo "  ERROR: \$MPDconfig is missing!"
+    test -z "${DIRaudioFolders+x}" && echo "  ERROR: \$DIRaudioFolders is missing!"
+}
+
+verify_wifi_settings() {
+    local dhcpcd_conf="/etc/dhcpcd.conf"
+    local wpa_supplicant_conf="/etc/wpa_supplicant/wpa_supplicant.conf"
+    printf "\nTESTING WiFi settings...\n"
+
+    # check conf files
+    check_file_contains_string "static ip_address=${WIFIip}/24" "${dhcpcd_conf}"
+    check_file_contains_string "static routers=${WIFIipRouter}" "${dhcpcd_conf}"
+    check_file_contains_string "static domain_name_servers=8.8.8.8 ${WIFIipRouter}" "${dhcpcd_conf}"
+
+    check_file_contains_string "country=${WIFIcountryCode}" "${wpa_supplicant_conf}"
+    check_file_contains_string "ssid=\"${WIFIssid}\"" "${wpa_supplicant_conf}"
+    check_file_contains_string "psk=\"${WIFIpass}\"" "${wpa_supplicant_conf}"
+
+    # check owner and permissions
+    check_chmod_chown 664 root netdev "/etc" "dhcpcd.conf"
+    check_chmod_chown 664 root netdev "/etc/wpa_supplicant" "wpa_supplicant.conf"
+    
+    # check that dhcpcd service is enabled and started
+    check_service_state dhcpcd active
+    check_service_enablement dhcpcd enabled
+}
+
+verify_apt_packages(){
+    local packages="apt-transport-https libspotify-dev raspberrypi-kernel-headers samba
+samba-common-bin gcc lighttpd php7.3-common php7.3-cgi php7.3 at mpd mpc mpg123 git ffmpeg
+resolvconf spi-tools python3 python3-dev python3-pip python3-mutagen python3-gpiozero
+python3-spidev"
+    local packages_spotify="mopidy mopidy-mpd mopidy-local mopidy-spotify libspotify12
+python3-cffi python3-ply python3-pycparser python3-spotify"
+
+    printf "\nTESTING installed packages...\n\n"
+
+    # also check for spotify packages if it has been installed
+    if [[ "${SPOTinstall}" == "YES" ]]; then
+        packages="${packages} ${packages_spotify}"
+    fi
+
+    for package in ${packages}
+    do
+        if [[ $(apt -qq list "${package}" 2>/dev/null | grep 'installed') ]]; then
+            echo "  ${package} is installed"
+        else
+            echo "  ERROR: ${package} is not installed"
+            ((failed_tests++))
+        fi
+        ((tests++))
+    done
+}
+
+verify_pip_packages() {
+    local modules="evdev spi-py youtube_dl pyserial RPi.GPIO pi-rc522"
+    local modules_spotify="Mopidy-Iris"
+    local modules_pn532="py532lib"
+
+    printf "\nTESTING installed pip modules...\n\n"
+
+    # also check for spotify pip modules if it has been installed
+    if [[ "${SPOTinstall}" == "YES" ]]; then
+        modules="${modules} ${modules_spotify}"
+    fi
+
+    modules="${modules} ${modules_pn532}"
+
+    for module in ${modules}
+    do
+        if [[ $(pip3 show "${module}") ]]; then
+            echo "  ${module} is installed"
+        else
+            echo "  ERROR: pip module ${module} is not installed"
+            ((failed_tests++))
+        fi
+        ((tests++))
+    done
+}
+
+verify_samba_config() {
+    printf "\nTESTING samba config...\n\n"
+    check_chmod_chown 644 root root "/etc/samba" "smb.conf"
+
+    check_file_contains_string "path=${DIRaudioFolders}" "/etc/samba/smb.conf"
+}
+
+verify_webserver_config() {
+    printf "\nTESTING webserver config...\n\n"
+    check_chmod_chown 644 root root "/etc/lighttpd" "lighttpd.conf"
+    check_chmod_chown 644 root root "/etc/lighttpd/conf-available" "15-fastcgi-php.conf"
+    check_chmod_chown 644 root root "/etc/php/7.3/cgi" "php.ini"
+    check_chmod_chown 440 root root "/etc" "sudoers"
+
+    # Bonus TODO: check that fastcgi and fastcgi-php mods are enabled
+}
+
+verify_systemd_services() {
+    printf "\nTESTING systemd services...\n\n"
+    # check that services exist
+    check_chmod_chown 644 root root "/etc/systemd/system" "phoniebox-rfid-reader.service phoniebox-startup-sound.service phoniebox-gpio-buttons.service phoniebox-idle-watchdog.service phoniebox-rotary-encoder.service"
+
+    # check that phoniebox services are enabled
+    check_service_enablement phoniebox-idle-watchdog enabled
+    check_service_enablement phoniebox-rfid-reader enabled
+    check_service_enablement phoniebox-startup-sound enabled
+    check_service_enablement phoniebox-gpio-buttons enabled
+    check_service_enablement phoniebox-rotary-encoder enabled
+}
+
+verify_spotify_config() {
+    local etc_mopidy_conf="/etc/mopidy/mopidy.conf"
+    local mopidy_conf="$HOME/.config/mopidy/mopidy.conf"
+
+    printf "\nTESTING spotify config...\n\n"
+
+    check_file_contains_string "username = ${spotify_username}" "${etc_mopidy_conf}"
+    check_file_contains_string "password = ${spotify_password}" "${etc_mopidy_conf}"
+    check_file_contains_string "client_id = ${spotify_client_id}" "${etc_mopidy_conf}"
+    check_file_contains_string "client_secret = ${spotify_client_secret}" "${etc_mopidy_conf}"
+
+    check_file_contains_string "username = ${spotify_username}" "${mopidy_conf}"
+    check_file_contains_string "password = ${spotify_password}" "${mopidy_conf}"
+    check_file_contains_string "client_id = ${spotify_client_id}" "${mopidy_conf}"
+    check_file_contains_string "client_secret = ${spotify_client_secret}" "${mopidy_conf}"
+
+    # check that mopidy service is enabled
+    check_service_enablement mopidy enabled
+    # check that mpd service is disabled
+    check_service_enablement mpd disabled
+}
+
+verify_mpd_config() {
+    local mpd_conf="/etc/mpd.conf"
+
+    printf "\nTESTING mpd config...\n\n"
+
+    check_file_contains_string "^[[:blank:]]\+mixer_control[[:blank:]]\+\"${AUDIOiFace}\"" "${mpd_conf}"
+    check_file_contains_string "^music_directory[[:blank:]]\+\"${DIRaudioFolders}\"" "${mpd_conf}"
+
+    check_chmod_chown 640 mpd audio "/etc" "mpd.conf"
+
+    # check that mpd service is enabled, when Spotify support is not installed
+    if [[ "${SPOTinstall}" == "NO" ]]; then
+        check_service_enablement mpd enabled
+    fi
+}
+
+verify_folder_access() {
+    printf "\nTESTING folder access...\n\n"
+
+    # check owner and permissions
+    check_chmod_chown 775 pi www-data "${jukebox_dir}" "playlists shared htdocs settings"
+    # ${DIRaudioFolders} => "testing" "audiofolders"
+    check_chmod_chown 775 pi www-data "${DIRaudioFolders}/.." "audiofolders"
+
+    #find .sh and .py scripts that are NOT executable
+    local count=$(find . -maxdepth 1 -type f \( -name "*.sh" -o -name "*.py" \) ! -executable | wc -l)
+    if [[ "${count}" -gt 0 ]]; then
+        echo "  ERROR: found ${count} '*.sh' and/or '*.py' files that are NOT executable:"
+        find . -maxdepth 1 -type f \( -name "*.sh" -o -name "*.py" \) ! -executable
+        ((failed_tests++))
+    fi
+    ((tests++))
+}
+
+main() {
+    verify_conf_file
+    if [[ "$WIFIconfig" == "YES" ]]; then
+        verify_wifi_settings
+    fi
+    verify_apt_packages
+    verify_pip_packages
+    verify_samba_config
+    verify_webserver_config
+    verify_systemd_services
+    if [[ "${SPOTinstall}" == "YES" ]]; then
+        verify_spotify_config
+    fi
+    verify_mpd_config
+    verify_folder_access
+}
+
+start=$(date +%s)
+main
+end=$(date +%s)
+
+runtime=$((end-start))
+((m=($runtime%3600)/60))
+((s=$runtime%60))
+ 
+if [[ "${failed_tests}" -gt 0 ]]; then
+    echo "${failed_tests} Test(s) failed (of ${tests} tests) (in ${m}m ${s}s)."
+    exit 1
+else
+    echo "{tests} tests done in ${m}m ${s}s."
+fi
+


### PR DESCRIPTION
This script allows to determine if the buster-install-default.sh installation script works as expected. It does not check *everything*, but most of the important parts.