### PR TITLE
use latest version of pi-rc522 from Github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ youtube_dl
 pyserial
 # spidev - currently installed via apt-get
 RPi.GPIO
-pi-rc522
-
+# pi-rc522 use latest version from Github
+git+git://github.com/ondryaso/pi-rc522.git@#egg=pi-rc522
 # Type checking for python
 # typing
 


### PR DESCRIPTION
in #912 issues in pi-rc522 were found, which are fixed on their master branch. However we use the package on https://pypi.org/project/pi-rc522/ which wasn't updated since 2017.

I opened this PR to start a discussion, if we want to install from Github to get the latest update. Disadvantage is that their master branch may be unstable.