### PR TITLE
Set volume at startup (without Webinterface till now)

### DIFF
--- a/misc/sampleconfigs/phoniebox-startup-sound.service.stretch-default.sample
+++ b/misc/sampleconfigs/phoniebox-startup-sound.service.stretch-default.sample
@@ -1,6 +1,6 @@
 [Unit]
 Description=Phoniebox Startup Sound
-After=alsa-state.service
+After=multi-user.target
 
 [Service]
 User=pi
@@ -8,7 +8,8 @@ Group=pi
 Type=oneshot
 RemainAfterExit=true
 WorkingDirectory=/home/pi/RPi-Jukebox-RFID
-ExecStart=/usr/bin/mpg123 /home/pi/RPi-Jukebox-RFID/shared/startupsound.mp3
+ExecStartPre=/home/pi/RPi-Jukebox-RFID/scripts/playout_controls.sh -c=setvolumetostartup
+ExecStart=/bin/sleep 2
+ExecStartPost=/usr/bin/mpg123 /home/pi/RPi-Jukebox-RFID/shared/startupsound.mp3
 
 [Install]
-WantedBy=multi-user.target

--- a/misc/sampleconfigs/phoniebox-startup-sound.service.stretch-default.sample
+++ b/misc/sampleconfigs/phoniebox-startup-sound.service.stretch-default.sample
@@ -1,6 +1,6 @@
 [Unit]
 Description=Phoniebox Startup Sound
-After=multi-user.target
+After=mpd.service
 
 [Service]
 User=pi
@@ -13,3 +13,4 @@ ExecStart=/bin/sleep 2
 ExecStartPost=/usr/bin/mpg123 /home/pi/RPi-Jukebox-RFID/shared/startupsound.mp3
 
 [Install]
+WantedBy=multi-user.target

--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -106,6 +106,16 @@ fi
 AUDIOVOLMINLIMIT=`cat $PATHDATA/../settings/Min_Volume_Limit`
 
 ##############################################
+# Startup_Volume
+# 1. create a default if file does not exist
+if [ ! -f $PATHDATA/../settings/Startup_Volume ]; then
+    echo "50" > $PATHDATA/../settings/Startup_Volume
+    chmod 777 $PATHDATA/../settings/Startup_Volume
+fi
+# 2. then|or read value from file
+AUDIOVOLSTARTUP=`cat $PATHDATA/../settings/Startup_Volume`
+
+##############################################
 # Change_Volume_Idle
 # Change volume during idle (or only change it during Play and in the WebApp)
 #TRUE=Change Volume during all Time (Default; FALSE=Change Volume only during "Play"; OnlyDown=It is possible to decrease Volume during Idle; OnlyUp=It is possible to increase Volume during Idle

--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -186,6 +186,7 @@ VERSION=`cat $PATHDATA/../settings/version`
 # AUDIOVOLCHANGESTEP
 # AUDIOVOLMAXLIMIT
 # AUDIOVOLMINLIMIT
+# AUDIOVOLSTARTUP
 # VOLCHANGEIDLE
 # IDLETIMESHUTDOWN
 # SHOWCOVER
@@ -203,6 +204,7 @@ echo "AUDIOIFACENAME=\"${AUDIOIFACENAME}\"" >> "${PATHDATA}/../settings/global.c
 echo "AUDIOVOLCHANGESTEP=\"${AUDIOVOLCHANGESTEP}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOVOLMAXLIMIT=\"${AUDIOVOLMAXLIMIT}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOVOLMINLIMIT=\"${AUDIOVOLMINLIMIT}\"" >> "${PATHDATA}/../settings/global.conf"
+echo "AUDIOVOLSTARTUP=\"${AUDIOVOLSTARTUP}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "VOLCHANGEIDLE=\"${VOLCHANGEIDLE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "IDLETIMESHUTDOWN=\"${IDLETIMESHUTDOWN}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SHOWCOVER=\"${SHOWCOVER}\"" >> "${PATHDATA}/../settings/global.conf"

--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -109,7 +109,7 @@ AUDIOVOLMINLIMIT=`cat $PATHDATA/../settings/Min_Volume_Limit`
 # Startup_Volume
 # 1. create a default if file does not exist
 if [ ! -f $PATHDATA/../settings/Startup_Volume ]; then
-    echo "50" > $PATHDATA/../settings/Startup_Volume
+    echo "0" > $PATHDATA/../settings/Startup_Volume
     chmod 777 $PATHDATA/../settings/Startup_Volume
 fi
 # 2. then|or read value from file

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -28,6 +28,7 @@ NOW=`date +%Y-%m-%d.%H:%M:%S`
 # setvolume
 # setmaxvolume
 # setstartupvolume
+# getstartupvolume
 # setvolumetostartup
 # volumeup
 # volumedown
@@ -301,17 +302,18 @@ case $COMMAND in
         echo $AUDIOVOLCHANGESTEP
         ;;
     setstartupvolume)
-        # read volume in percent
-        VOLPERCENT=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep -o -P '(?<=volume: ).*')
-        # if volume of the box is greater than wanted maxvolume, set volume to maxvolume 
-        if [ $VOLPERCENT -gt $VALUE ];
+        # if value is greater than wanted maxvolume, set value to maxvolume 
+        if [ $VALUE -gt $AUDIOVOLMAXLIMIT ];
         then
-            echo -e setvol $VALUE | nc -w 1 localhost 6600
+            $VALUE=$AUDIOVOLMAXLIMIT;
         fi
         # write new value to file
         echo "$VALUE" > $PATHDATA/../settings/Startup_Volume       
         # create global config file because individual setting got changed
         . $PATHDATA/inc.writeGlobalConfig.sh
+        ;;
+        getstartupvolume)
+        echo $AUDIOVOLSTARTUP
         ;;
     setvolumetostartup)
         #increase volume only if VOLPERCENT is below the max volume limit and above min volume limit

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -284,6 +284,12 @@ case $COMMAND in
         then
             echo -e setvol $VALUE | nc -w 1 localhost 6600
         fi
+        # if startupvolume is greater than wanted maxvolume, set startupvolume to maxvolume
+        if [ $AUDIOVOLSTARTUP -gt $VALUE ];
+        then
+            # write new value to file
+            echo "$VALUE" > $PATHDATA/../settings/Startup_Volume
+        fi
         # write new value to file
         echo "$VALUE" > $PATHDATA/../settings/Max_Volume_Limit       
         # create global config file because individual setting got changed

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -305,7 +305,7 @@ case $COMMAND in
         # if value is greater than wanted maxvolume, set value to maxvolume 
         if [ $VALUE -gt $AUDIOVOLMAXLIMIT ];
         then
-            $VALUE=$AUDIOVOLMAXLIMIT;
+            VALUE=$AUDIOVOLMAXLIMIT;
         fi
         # write new value to file
         echo "$VALUE" > $PATHDATA/../settings/Startup_Volume       
@@ -317,27 +317,12 @@ case $COMMAND in
         ;;
     setvolumetostartup)
         # check if startup-volume is disabled
-        if [ $AUDIOVOLSTARTUP == 0];
+        if [ "$AUDIOVOLSTARTUP" == 0 ];
         then
             exit 1;
         fi
-        #increase volume only if VOLPERCENT is below the max volume limit and above min volume limit
-        if [ $VALUE -le $AUDIOVOLMAXLIMIT ] && [ $VALUE -ge $AUDIOVOLMINLIMIT ];
-        then
-            # set volume level in percent
-            echo -e setvol $AUDIOVOLSTARTUP\\nclose | nc -w 1 localhost 6600
-        else
-            if [ $VALUE -gt $AUDIOVOLMAXLIMIT ];
-            then
-                # if we are over the max volume limit, set the volume to maxvol
-                echo -e setvol $AUDIOVOLMAXLIMIT\\nclose | nc -w 1 localhost 6600
-            fi
-            if [ $VALUE -lt $AUDIOVOLMINLIMIT ];
-            then
-                # if we are unter the min volume limit, set the volume to minvol
-                echo -e setvol $AUDIOVOLMINLIMIT\\nclose | nc -w 1 localhost 6600
-            fi
-        fi
+        # set volume level in percent
+        echo -e setvol $AUDIOVOLSTARTUP\\nclose | nc -w 1 localhost 6600
         ;;
     playerstop)
         # stop the player

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -312,10 +312,15 @@ case $COMMAND in
         # create global config file because individual setting got changed
         . $PATHDATA/inc.writeGlobalConfig.sh
         ;;
-        getstartupvolume)
+    getstartupvolume)
         echo $AUDIOVOLSTARTUP
         ;;
     setvolumetostartup)
+        # check if startup-volume is disabled
+        if [ $AUDIOVOLSTARTUP == 0];
+        then
+            exit 1;
+        fi
         #increase volume only if VOLPERCENT is below the max volume limit and above min volume limit
         if [ $VALUE -le $AUDIOVOLMAXLIMIT ] && [ $VALUE -ge $AUDIOVOLMINLIMIT ];
         then


### PR DESCRIPTION
I have added commands to playout_controls.sh to set and get a startupvolume-value.
I also added  a command to set volume to the defined startupvolume.
To inc.wirte inc.writeGlobalConfig.sh i added startupvolume for saving the values. (0 == reset to startupvolume is disabled)

I also edited the phoniebox-startup-sound.service to execute the "setvolumetostartup" command. I am not shure, if this is a good place for this.
