### PR TITLE
Fix link stream not possible

### DIFF
--- a/htdocs/inc.processAddNewStream.php
+++ b/htdocs/inc.processAddNewStream.php
@@ -1,7 +1,10 @@
 <?php
 // create new folder
 $streamfolder = $Audio_Folders_Path."/".$post['audiofolderNew']."/";
-$exec = "sudo mkdir -p '".$streamfolder."'";
+$exec = "mkdir -p '".$streamfolder."'";
+exec($exec);
+// New folder is created so we link a RFID to it. Write $post['audiofolderNew'] to cardID file in shortcuts
+$exec = "rm ".$fileshortcuts."; echo '".$post['audiofolderNew']."' > ".$fileshortcuts."; chmod 777 ".$fileshortcuts;
 exec($exec);
 
 // figure out $streamfile depending on $post['streamType']
@@ -19,6 +22,6 @@ switch($post['streamType']) {
         $streamfile = "url.txt";
 }
 
-// write $post['streamURL'] to $filestream and make accessible to anyone
+// write $post['streamURL'] to $streamfile and make accessible to anyone
 $exec = "echo '".$post['streamURL']."' > '".$streamfolder."/".$streamfile."'; sudo chmod -R 777 '".$streamfolder."'";
 exec($exec);

--- a/htdocs/inc.processAddNewStream.php
+++ b/htdocs/inc.processAddNewStream.php
@@ -1,6 +1,6 @@
 <?php
 // create new folder
-$streamfolder = $Audio_Folders_Path."/".$post['audifolderNew']."/";
+$streamfolder = $Audio_Folders_Path."/".$post['audiofolderNew']."/";
 $exec = "sudo mkdir -p '".$streamfolder."'";
 exec($exec);
 


### PR DESCRIPTION
Hi folks,
I created Issue #939 and have a fix here.

- corrected a typo which led to empty _audiofolderNew_ value
- added missing creation of shortcut entries

Not sure if this is your preferred location to add the missing creation of shortcut entries. Chose to go the same way as done in `RPi-Jukebox-RFID/htdocs/inc.processAddYT.php`.

It is not quite clear to me, whether you might prefer to handle the creation of shortcuts within more central `RPi-Jukebox-RFID/htdocs/inc.processCheckCardEditRegister.php` where this step is handled for other non-stream media.

Cheers :-)