### PR TITLE
Add setup scripts for PN532 RFID reader and PirateAudio HAT

### DIFF
--- a/components/audio/PirateAudioHAT/README.md
+++ b/components/audio/PirateAudioHAT/README.md
@@ -1,0 +1,12 @@
+# How to setup a Pimoroni PirateAudio HAT
+
+These instructions are for the following Pimoroni PirateAudio HATs:
+
+<https://shop.pimoroni.com/?q=pirate+audio>
+
+The PirateAudio HATs use the same DAC as the hifiberry, so some of the instructions
+from <https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/HiFiBerry-Soundcard-Details> can be applied as well.
+
+The `setup_pirateAudioHAT.sh` script can be used to set it up to work with Phoniebox.
+
+Getting the display to work with Phoniebox should not be too difficult, but it's still a work in progress.

--- a/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
+++ b/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+question() {
+    local question=$1
+    read -p "${question} (y/n)? " choice
+    case "$choice" in 
+      y|Y ) ;;
+      n|N ) exit 0;;
+      * ) echo "Error: invalid" ; question ${question};;
+    esac
+}
+
+printf "Please make sure that the Pirate Audio HAT is connected...\n"
+question "Continue"
+
+printf "Stopping and disabling GPIO button service...\n"
+#TODO this might not be necessary
+sudo systemctl stop phoniebox-gpio-buttons.service
+sudo systemctl disable phoniebox-gpio-buttons.service
+
+printf "Adding settings to /boot/config.txt...\n"
+sudo cp /boot/config.txt /boot/config.txt.bak
+
+echo "gpio=25=op,dhc" | sudo tee -a /boot/config.txt > /dev/null
+echo "dtoverlay=hifiberry-dac" | sudo tee -a /boot/config.txt > /dev/null
+
+printf "Adding settings to /etc/asound.conf...\n"
+# Create backup of /etc/asound.conf if it already exists
+if [[ -f /etc/asound.conf ]]; then
+    sudo cp /etc/asound.conf /etc/asound.conf.bak
+fi
+
+sudo tee /etc/asound.conf << EOF > /dev/null
+pcm.hifiberry {
+    type            softvol
+    slave.pcm       "plughw:CARD=sndrpihifiberry,DEV=0"
+    control.name    "Master"
+    control.card    1
+}
+pcm.!default {
+    type            plug
+    slave.pcm       "hifiberry"
+}
+ctl.!default {
+    type            hw
+    card            1
+}
+EOF
+
+# Create backup of /etc/mpd.conf if it already exists
+if [[ -f /etc/mpd.conf ]]; then
+    sudo cp /etc/mpd.conf /etc/mpd.conf.bak
+fi
+
+printf "Add hifiberry as audio_output in /etc/mpd.conf...\n"
+
+if ! grep -qe "HiFiBerry DAC+ Lite" /etc/mpd.conf; then
+    sudo sed -i "/# An example of an ALSA output:/ r /dev/stdin" /etc/mpd.conf <<'EOG'
+audio_output {
+        enabled         "yes"
+        type            "alsa"
+        name            "HiFiBerry DAC+ Lite"
+        device          "hifiberry"
+        auto_resample   "no"
+        auto_channels   "no"
+        auto_format     "no"
+        dop             "no"
+}
+EOG
+else
+    printf "/etc/mpd.conf is already configured. Skipping...\n"
+fi
+
+printf "Set mixer_control name in /etc/mpd.conf...\n"
+mixer_control_name="Master"
+sudo sed -i -E "s/^(\s*mixer_control\s*\")[^\"]*(\"\s*# optional)/\1\\${mixer_control_name}\2/" /etc/mpd.conf
+
+printf "You need to reboot to apply the settings.\n"
+question "Do you want to reboot now"
+sudo reboot

--- a/components/rfid-reader/PN532/README.md
+++ b/components/rfid-reader/PN532/README.md
@@ -9,31 +9,35 @@ Similar shields/breakout boards, based on the same chip might work, but have not
 It has been tested with the I2C interface. Using SPI might work as well, but it has not been tested.
 
 The following steps should be done before installing RPi-Jukebox-RFID. If RPi-Jukebox-RFIS is already
-installed, make sure to disable the phoniebox-rfid-reader service first (`sudo systemctl stop phoniebox-rfid-reader.service`).
+installed, make sure to stop the phoniebox-rfid-reader service first (`sudo systemctl stop phoniebox-rfid-reader.service`).
    
 
 1. Connect the PN532 RFID reader to the GPIO pins
 
-    | PN532 | Raspberry    | Raspi Pins |
+    | PN532 | Raspberry Pi | Raspi Pins |
     | ----- | ------------ | ---------- |
     | 5V    | 5V           |     4      |
     | GND   | GND          |     6      |
     | SDA   | GPIO 2 (SDA) |     3      |
     | SCL   | GPIO 3 (SCL) |     5      |
 
-2.  Activate the I2C interface of the Raspberry Pi
-    - `sudo raspi-config`
-    - Select "5 Interfacing Options" -> I2C -> yes  
+2. You can use the `setup_pn532.sh` script or follow the manual steps.
 
-3. Install I2C tools and libnfc
+3.  Activate the I2C interface of the Raspberry Pi
+    - `sudo raspi-config`
+    - Select "5 Interfacing Options" -> I2C -> yes
+    - or instead of using the UI, here is the CLI command:
+        `sudo raspi-config nonint do_i2c 0`
+
+4. Install I2C tools and libnfc
     - `sudo apt-get install i2c-tools libnfc-bin`
 
-4. Check that the reader is found trough I2C
+5. Check that the reader is found trough I2C
     - check `sudo i2cdetect -y 1`
     - output should look like this:
 
 
-    	         0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+                 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
             00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
             10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
             20: -- -- -- -- 24 -- -- -- -- -- -- -- -- -- -- -- 
@@ -42,11 +46,10 @@ installed, make sure to disable the phoniebox-rfid-reader service first (`sudo s
             50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
             60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
             70: -- -- -- -- -- -- -- -- 
-   
-   - if the table is empty, try switching I2C off and on again in raspi-config or reboot
-    
 
-5. Configure libnfc
+    - if the table is empty, try switching I2C off and on again in raspi-config or reboot
+
+6. Configure libnfc
 
     - `sudo nano /etc/nfc/libnfc.conf`
     - Add the following lines at the end of the file:
@@ -54,20 +57,18 @@ installed, make sure to disable the phoniebox-rfid-reader service first (`sudo s
           device.name = "_PN532_I2c"
           device.connstring = "pn532_i2c:/dev/i2c-1"
 
-6. Test libnfc config
+7. Test libnfc config (Note: even if nfc-list shows an error, the RFID reader might still work with Phoniebox.)
    - Run `nfc-list`
    - Output should be:
 
           nfc-list uses libnfc 1.7.1
           NFC device: pn532_i2c:/dev/i2c-1 opened
 
-
-7. Configure experimental reader
+8. Configure experimental reader
    - `cd scripts`
    - `cp Reader.py.experimental Reader.py`
    - Run `python3 RegisterDevice.py`
    - Select 2 (PN532)
 
-
-If you disabled the service, start it again:
-`sudo systemctl stop phoniebox-rfid-reader.service`
+If you stopped the phoniebox-rfid-reader service, start it again:
+`sudo systemctl start phoniebox-rfid-reader.service`

--- a/components/rfid-reader/PN532/reset_pn532.sh
+++ b/components/rfid-reader/PN532/reset_pn532.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+printf "Stopping phoniebox-rfid-reader service...\n"
+sudo systemctl stop phoniebox-rfid-reader.service
+
+printf "Switching I2C off and on again via raspi-config...\n"
+sudo raspi-config nonint do_i2c 1 #off
+sleep 10
+sudo raspi-config nonint do_i2c 0 #on
+#TODO: how to handle seg faults?
+
+printf "Checking if PN532 RFID reader is found through I2C...\n"
+if sudo i2cdetect -y 1 | grep "24" ; then
+    printf "  PN532 was found.\n"
+else
+    printf "  ERROR: PN532 was not found.\n"
+    # Run again to show possible error messages
+    sudo i2cdetect -y 1
+    exit 1
+fi
+
+printf "Starting phoniebox-rfid-reader service...\n"
+sudo systemctl start phoniebox-rfid-reader.service
+
+printf "Done.\n"

--- a/components/rfid-reader/PN532/setup_pn532.sh
+++ b/components/rfid-reader/PN532/setup_pn532.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+HOME_DIR="/home/pi"
+JUKEBOX_HOME_DIR="${HOME_DIR}/RPi-Jukebox-RFID"
+
+question() {
+    local question=$1
+    read -p "${question} (y/n)? " choice
+    case "$choice" in 
+      y|Y ) ;;
+      n|N ) exit 0;;
+      * ) echo "Error: invalid" ; question ${question};;
+    esac
+}
+
+printf "Please make sure that the PN532 reader is wired up correctly to the GPIO ports before continuing...\n"
+question "Continue"
+
+printf "Activating I2C interface...\n"
+sudo raspi-config nonint do_i2c 0
+
+printf "Installing i2c-tools and libnfc-bin...\n"
+sudo apt-get -qq -y install i2c-tools libnfc-bin
+
+printf "Checking if PN532 RFID reader is found through I2C...\n"
+if sudo i2cdetect -y 1 | grep "24" ; then
+    printf "  PN532 was found.\n"
+else
+    printf "  ERROR: PN532 was not found.\n"
+    # Run again to show possible error messages
+    sudo i2cdetect -y 1
+    exit 1
+fi
+
+#TODO: is this even necessary?
+printf "Configuring libnfc...\n"
+printf 'device.name = "_PN532_I2c"\ndevice.connstring = "pn532_i2c:/dev/i2c-1"' | sudo tee -a /etc/nfc/libnfc.conf
+
+printf "Installing Python requirements for PN532...\n"
+sudo python3 -m pip install -q -r "${JUKEBOX_HOME_DIR}"/components/rfid-reader/PN532/requirements.txt
+
+printf "Configure RFID reader in Phoniebox...\n"
+cp "${JUKEBOX_HOME_DIR}"/scripts/Reader.py.experimental "${JUKEBOX_HOME_DIR}"/scripts/Reader.py
+echo "PN532" > "${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
+sudo chown pi:www-data "${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
+sudo chmod 644 "${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
+
+printf "Restarting phoniebox-rfid-reader service...\n"
+sudo systemctl start phoniebox-rfid-reader.service
+
+printf "Done.\n"

--- a/scripts/Reader.py
+++ b/scripts/Reader.py
@@ -39,7 +39,7 @@ class Reader:
             sys.exit('Please run RegisterDevice.py first')
         else:
             with open(path + '/deviceName.txt', 'r') as f:
-                deviceName = f.read()
+                deviceName = f.read().rstrip()
             devices = get_devices()
             for device in devices:
                 if device.name == deviceName:

--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -731,7 +731,6 @@ install_main() {
     # Install more required packages
     echo "Installing additional Python packages..."
     sudo python3 -m pip install -q -r "${jukebox_dir}"/requirements.txt
-    sudo pip3 install -q -r "${jukebox_dir}"/components/rfid-reader/PN532/requirements.txt
 
     samba_config
 


### PR DESCRIPTION
* Add setup scripts to make installation and setup of the PN532 RFID reader and the Pimoroni PirateAudio HAT a lot easier.
* Fix issue in Reader.py with whitespaces/newlines when value is read from deviceName.txt file
* Do not Install Python requirements for PN532 RFID reader by default during a normal installation. Instead, install it on demand from the dedicated setup script.

PS.: Sound already works fine with the PiratedAudio HAT. The display on the HAT will require a bit more configuration and testing, before it works with Phoniebox. 