### PR TITLE
Move RC522 related setup to components folder

### DIFF
--- a/components/rfid-reader/PN532/requirements.txt
+++ b/components/rfid-reader/PN532/requirements.txt
@@ -1,3 +1,3 @@
 # PN532 related requirements
-# You need to install these with `sudo pip3 install -r requirements-pn532.txt`
+# You need to install these with `sudo python3 -m pip install -q -r requirements.txt`
 py532lib

--- a/components/rfid-reader/RC522/README.md
+++ b/components/rfid-reader/RC522/README.md
@@ -1,0 +1,13 @@
+# How to setup the RC522 RFID reader
+
+1. Install Python dependencies
+   - `sudo python3 -m pip install -q -r <phoniebox_dir>/components/rfid-reader/RC522/requirements.txt`
+
+2. Configure experimental reader
+   - `cd <phoniebox_dir>/scripts`
+   - `cp Reader.py.experimental Reader.py`
+   - Run `python3 RegisterDevice.py`
+   - Select 0 (MFRC522)
+
+3. Restart the phoniebox-rfid-reader service:
+   - `sudo systemctl restart phoniebox-rfid-reader.service`

--- a/components/rfid-reader/RC522/requirements.txt
+++ b/components/rfid-reader/RC522/requirements.txt
@@ -1,0 +1,5 @@
+# RC522 related requirements
+# You need to install these with `sudo python3 -m pip install -q -r requirements.txt`
+
+# pi-rc522 use latest version from Github
+git+git://github.com/ondryaso/pi-rc522.git#egg=pi-rc522

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,7 @@ youtube_dl
 pyserial
 # spidev - currently installed via apt-get
 RPi.GPIO
-# pi-rc522 use latest version from Github
-git+git://github.com/ondryaso/pi-rc522.git#egg=pi-rc522
+
 # Type checking for python
 # typing
 


### PR DESCRIPTION
As discussed in #948.

Not sure if anything is missing here.
* Should RPi.GPIO be moved to components/rfid-reader/RC522/requirements.txt as well?
* Is any other kind of setup necessary?

I won't be able to test this, since I don't have a RC522 compatible RFID reader.

Next step is a separate setup/installation script that can be started at the end of the main installation script to setup special components like RFID readers, displays and sound cards.