### PR TITLE
Update Reader.py.experimental

### DIFF
--- a/scripts/Reader.py.experimental
+++ b/scripts/Reader.py.experimental
@@ -13,6 +13,7 @@ import RPi.GPIO as GPIO
 import logging
 
 from evdev import InputDevice, categorize, ecodes, list_devices
+# Workaround: when using RC522 reader with pirc522 pkg the py532lib pkg may not be installed and vice-versa
 try:
     import pirc522
     from py532lib.i2c import *

--- a/scripts/Reader.py.experimental
+++ b/scripts/Reader.py.experimental
@@ -13,9 +13,12 @@ import RPi.GPIO as GPIO
 import logging
 
 from evdev import InputDevice, categorize, ecodes, list_devices
-import pirc522
-from py532lib.i2c import *
-from py532lib.mifare import *
+try:
+    import pirc522
+    from py532lib.i2c import *
+    from py532lib.mifare import *
+except ImportError:
+    pass
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
If you run 
bash /home/pi/RPi-Jukebox-RFID/components/rfid-reader/RC522/setup_rc522.sh
the the import of Lib pirc522 will fail and you can not register the RFID Reader RC522