### PR TITLE
rotary encoder service sample: fix path to rotary_encoder.py

### DIFF
--- a/misc/sampleconfigs/phoniebox-rotary-encoder.service.stretch-default.sample
+++ b/misc/sampleconfigs/phoniebox-rotary-encoder.service.stretch-default.sample
@@ -7,7 +7,7 @@ User=pi
 Group=pi
 Restart=always
 WorkingDirectory=/home/pi/RPi-Jukebox-RFID
-ExecStart=/home/pi/RPi-Jukebox-RFID/scripts/rotary-encoder.py
+ExecStart=/home/pi/RPi-Jukebox-RFID/components/gpio_control/GPIODevices/rotary_encoder.py
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The path to rotary-encoder.py is outdated in the sample configuration of the service.

old path:
`/home/pi/RPi-Jukebox-RFID/scripts/rotary-encoder.py`

new path:
`/home/pi/RPi-Jukebox-RFID/components/gpio_control/GPIODevices/rotary_encoder.py`