### PR TITLE
Integrate scripts to install RC522 and PN532 reader

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Build Docker image and run tests
       run: |
         docker build . --file ./ci/Dockerfile.buster.test_install.amd64 --tag rpi-jukebox-rfid-buster:latest
-        docker run --rm -i rpi-jukebox-rfid-buster:latest --entrypoint /bin/bash /code/scripts/installscripts/tests/run_installation_tests.sh
+        docker run --rm -i rpi-jukebox-rfid-buster:latest /code/scripts/installscripts/tests/run_installation_tests.sh

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Build Docker image and run tests
       run: |
         docker build . --file ./ci/Dockerfile.buster.test_install.amd64 --tag rpi-jukebox-rfid-buster:latest
-        docker run --rm -i rpi-jukebox-rfid-buster:latest
+        docker run --rm -i rpi-jukebox-rfid-buster:latest --entrypoint /bin/bash /code/scripts/installscripts/tests/run_installation_tests.sh

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,3 +14,4 @@ jobs:
       run: |
         docker build . --file ./ci/Dockerfile.buster.test_install.amd64 --tag rpi-jukebox-rfid-buster:latest
         docker run --rm -i rpi-jukebox-rfid-buster:latest /code/scripts/installscripts/tests/run_installation_tests.sh
+        docker run --rm -i rpi-jukebox-rfid-buster:latest /code/scripts/installscripts/tests/run_installation_tests2.sh

--- a/ci/Dockerfile.buster.test_install.amd64
+++ b/ci/Dockerfile.buster.test_install.amd64
@@ -28,6 +28,4 @@ RUN export DEBIAN_FRONTEND=noninteractive ;\
   touch /boot/cmdlinetxt ;\
   rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
-ENTRYPOINT /code/scripts/installscripts/tests/run_installation_tests.sh
-
 USER pi

--- a/ci/Dockerfile.buster.test_install.amd64
+++ b/ci/Dockerfile.buster.test_install.amd64
@@ -7,7 +7,8 @@ RUN groupadd --gid 1000 pi ;\
   useradd -u 1000 -g 1000 -G sudo -d /home/pi -m -s /bin/bash -p '$1$iV7TOwOe$6ojkJQXyEA9bHd/SqNLNj0' pi ;\
   chown -R 1000:1000 /code /home/pi ;\
   chmod +x /code/scripts/installscripts/buster-install-default.sh ;\
-  chmod +x /code/scripts/installscripts/tests/run_installation_tests.sh
+  chmod +x /code/scripts/installscripts/tests/run_installation_tests.sh ;\
+  chmod +x /code/scripts/installscripts/tests/run_installation_tests2.sh
 
 RUN export DEBIAN_FRONTEND=noninteractive ;\
   apt-get update ;\

--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -1096,19 +1096,42 @@ finish_installation() {
     #####################################################
     # Register external device(s)
 
-    echo "If you are using an USB RFID reader, connect it to your RPi."
+    echo "If you are using an RFID reader, connect it to your RPi."
     echo "(In case your RFID reader required soldering, consult the manual.)"
     # Use -e to display response of user in the logfile
-    read -e -r -p "Have you connected your USB Reader? [Y/n] " response
+    read -e -r -p "Have you connected your RFID reader? [Y/n] " response
     case "$response" in
         [nN][oO]|[nN])
             ;;
         *)
-            cd "${jukebox_dir}"/scripts/ || exit
-            python3 RegisterDevice.py
-            sudo chown pi:www-data "${jukebox_dir}"/scripts/deviceName.txt
-            sudo chmod 644 "${jukebox_dir}"/scripts/deviceName.txt
-            ;;
+            echo  'Please select the RFID reader you want to use'
+            options=("USB-Reader (e.g. Neuftech)" "RC522" "PN532" "Manual configuration")
+            select opt in "${options[@]}"; do
+                case $opt in
+                    "USB-Reader (e.g. Neuftech)")
+                        cd "${jukebox_dir}"/scripts/ || exit
+                        python3 RegisterDevice.py
+                        sudo chown pi:www-data "${jukebox_dir}"/scripts/deviceName.txt
+                        sudo chmod 644 "${jukebox_dir}"/scripts/deviceName.txt
+                        break
+                        ;;
+                    "RC522")
+                        bash "${jukebox_dir}"/components/rfid-reader/RC522/setup_rc522.sh
+                        break
+                        ;;
+                    "PN532")
+                        bash "${jukebox_dir}"/components/rfid-reader/PN532/setup_pn532.sh
+                        break
+                        ;;
+                    "Manual configuration")
+                        echo "Please configure your reader manually."
+                        break
+                        ;;
+                    *)
+                        echo "This is not a number"
+                        ;;
+                esac
+            done
     esac
 
     echo

--- a/scripts/installscripts/tests/run_installation_tests2.sh
+++ b/scripts/installscripts/tests/run_installation_tests2.sh
@@ -3,7 +3,7 @@
 # Install Phoniebox and test it
 # Used e.g. for tests on Docker
 
-# Objective: Test installation with script using a simple configuration
+# Objective: Test installation with script using a RC522 reader
 
 # Print current path
 echo $PWD
@@ -21,11 +21,13 @@ export DEBIAN_FRONTEND=noninteractive
 # n no spotify
 # y configure mpd
 # y audio default location
-# n no RFID registration
+# y RFID registration
+# 2 use RC522 reader
+# yes, reader is connected
 # n No reboot
 
 # TODO check, how this behaves on branches other than develop
-GIT_BRANCH=develop bash ./scripts/installscripts/buster-install-default.sh <<< $'y\nn\n\ny\n\nn\n\ny\n\ny\n\ny\nn\nn\n'
+GIT_BRANCH=develop bash ./scripts/installscripts/buster-install-default.sh <<< $'y\nn\n\ny\n\nn\n\ny\n\ny\n\ny\ny\n2\ny\nn\n'
 
 # Rest installation
 ./scripts/installscripts/tests/test_installation.sh

--- a/scripts/installscripts/tests/test_installation.sh
+++ b/scripts/installscripts/tests/test_installation.sh
@@ -199,16 +199,18 @@ verify_pip_packages() {
         modules="${modules} ${modules_spotify}"
     fi
 
-    # RC522 reader is used
-    if grep -Fxq "${deviceName}" MFRC522
-    then
-        modules="${modules} ${modules_rc522}"
-    fi
+    if [[ -f "${deviceName}" ]]; then
+        # RC522 reader is used
+        if grep -Fxq "${deviceName}" MFRC522
+        then
+            modules="${modules} ${modules_rc522}"
+        fi
 
-    # PN532 reader is used
-    if grep -Fxq "${deviceName}" PN532
-    then
-        modules="${modules} ${modules_pn532}"
+        # PN532 reader is used
+        if grep -Fxq "${deviceName}" PN532
+        then
+            modules="${modules} ${modules_pn532}"
+        fi
     fi
 
     for module in ${modules}

--- a/scripts/installscripts/tests/test_installation.sh
+++ b/scripts/installscripts/tests/test_installation.sh
@@ -190,6 +190,7 @@ verify_pip_packages() {
     local modules_spotify="Mopidy-Iris"
     local modules_pn532="py532lib"
     local modules_rc522="pi-rc522"
+    local deviceName="${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
 
     printf "\nTESTING installed pip modules...\n\n"
 
@@ -198,7 +199,17 @@ verify_pip_packages() {
         modules="${modules} ${modules_spotify}"
     fi
 
-    # modules="${modules} ${modules_pn532}"
+    # RC522 reader is used
+    if grep -Fxq "${deviceName}" MFRC522
+    then
+        modules="${modules} ${modules_rc522}"
+    fi
+
+    # PN532 reader is used
+    if grep -Fxq "${deviceName}" PN532
+    then
+        modules="${modules} ${modules_pn532}"
+    fi
 
     for module in ${modules}
     do
@@ -207,21 +218,6 @@ verify_pip_packages() {
         else
             echo "  ERROR: pip module ${module} is not installed"
             ((failed_tests++))
-        fi
-        ((tests++))
-    done
-
-    # workaround, because currently it's not known, if modules have been installed manually
-    # TODO integrate in above check (similar to spotify modules)
-    optional_modules="${modules_rc522} ${modules_pn532}"
-
-    for module in ${optional_modules}
-    do
-        if [[ $(pip3 show "${module}") ]]; then
-            echo "  ${module} is installed"
-        else
-            echo "  WARNING: Optional pip module ${module} is not installed"
-            # doesnt count as error, because only manually installed or not
         fi
         ((tests++))
     done


### PR DESCRIPTION
This should make the installation more easy and avoid confusion, e.g. #1001 

I tested installation on a docker image (which worked fine), but not with real reader hardware, because I don't have any reader available.