### PR TITLE
Bugfix/gpio control installscript

### DIFF
--- a/components/gpio_control/install.sh
+++ b/components/gpio_control/install.sh
@@ -5,6 +5,7 @@ if [[ $(id -u) != 0 ]]; then
    exit 1
 fi
 
+
 echo 'disable old services: phoniebox-gpio-buttons and phoniebox-rotary-encoder'
 systemctl stop phoniebox-rotary-encoder.service
 systemctl disable phoniebox-rotary-encoder.service
@@ -19,14 +20,12 @@ echo 'Installing GPIO_Control service'
 echo
 
 USER_HOME=$(eval echo ~${SUDO_USER})
-echo 'USER HOME',${USER_HOME}
-
 CONFIG_PATH=$USER_HOME/.config/phoniebox
+FILE=$CONFIG_PATH/gpio_settings.ini
 if [ ! -d $CONFIG_PATH ]; then
     mkdir -p $USER_HOME/.config/phoniebox/ ;
 fi;
 
-FILE=$CONFIG_PATH/gpio_settings.ini
 if test -f "$FILE"; then
     echo "$FILE exist"
     echo "Script will not install a configuration"
@@ -45,6 +44,7 @@ else
           echo "Copy file to $FILE"
           echo cp -v $opt $FILE
           cp -v $opt $FILE
+	  chown -R $(whoami) $FILE
           break
           ;;
         "Stop the script")
@@ -58,6 +58,8 @@ else
     done
 
 fi
+chown -R ${SUDO_USER}:${SUDO_USER} $FILE
+
 echo
 echo 'Installing GPIO_Control service, this will require to enter your password up to 3 times to enable the service'
 read -p "Press enter to continue " -n 1 -r


### PR DESCRIPTION
Hi
I installed a Raspbian lite system and could reproduce the issue with the gpio_control install script. 
The issue is caused by a strange behaviour when the script is executed. 
It asks for the root-user password instead of using the sudoer password of the 'pi' user. As the root password in not set, it cannot authenticate.
I changed the script in such a way that one execute it now using `sudo ./install.sh` . It required some additional changes to the script, as execution as sudo results in 'wrong' ownerships and pathes. Using the variable SUDO_USER I could find a way how to circumvent the issues.