### PR TITLE
Enable volume normalization

### DIFF
--- a/misc/sampleconfigs/mpd.conf.buster-default.sample
+++ b/misc/sampleconfigs/mpd.conf.buster-default.sample
@@ -395,7 +395,7 @@ audio_output {
 # result in the volume of all playing audio to be adjusted so the output has
 # equal "loudness". This setting is disabled by default.
 #
-#volume_normalization		"no"
+volume_normalization		"yes"
 #
 ###############################################################################
 


### PR DESCRIPTION
See #685, thanks to @belinea4071.

Currently only for MPD in classic edition, couldn't find a setting so far in mopidy.