### PR TITLE
Ignore scan of same RFID id within 2 seconds

### DIFF
--- a/scripts/daemon_rfid_reader.py
+++ b/scripts/daemon_rfid_reader.py
@@ -22,7 +22,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 logger.info('Dir_PATH: {dir_path}'.format(dir_path=dir_path))
 
 # vars for ensuring delay between same-card-swipes
-same_id_delay = 0
+same_id_delay = 2
 previous_id = ""
 previous_time = time.time()
 
@@ -44,12 +44,14 @@ while True:
                 logger.info('Trigger Play Cardid={cardid}'.format(cardid=cardid))
                 subprocess.call([dir_path + '/rfid_trigger_play.sh --cardid=' + cardid], shell=True)
                 previous_id = cardid
-                previous_time = time.time()
+                
             else:
                 logger.debug('Ignoring Card id {cardid} due to same-card-delay, delay: {same_id_delay}'.format(
                     cardid=cardid,
                     same_id_delay=same_id_delay
                 ))
+
+            previous_time = time.time()
 
     except OSError as e:
         logger.error('Execution failed: {e}'.format(e=e))


### PR DESCRIPTION
Solves https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/910

This allows you to leave an RFID card on the reader without triggering any unwanted action - especially not the "second swipe" action. 
Without this change you have to set the second swipe option to do nothing if you want to have the ability (or phoniebox case form factor that does not prevent you) to leave the card on the reader.

The time of 2 seconds between swipes is chosen at random. Possibly this could be controlled via a setting. For RC522 readers, this is more than enough since it (or its library) reports the scanned ID ever 100ms or so..