### PR TITLE
Fix for getting infos from Spotify (now supporting album + artist URLs)

### DIFF
--- a/htdocs/inc.viewFolderTree.php
+++ b/htdocs/inc.viewFolderTree.php
@@ -112,7 +112,9 @@ foreach($subfolders as $key => $subfolder) {
             $temp['type'] = "spotify";
             $titlefile = $subfolder."/title.txt";
             $coverfile = $subfolder."/cover.jpg";
-
+			
+		/* routine 1 (deprecated): getting spotify informations from mopidy API
+		
             // get title from Spotify if wasn't previously stored
             if (!file_exists($titlefile)) {
                 $uri = file_get_contents($subfolder."/spotify.txt");
@@ -159,6 +161,31 @@ foreach($subfolders as $key => $subfolder) {
                 
                 file_put_contents($coverfile, $cover);
 			}
+			*/
+			
+			
+			// routine 2: this is a new and easier way for loading spotify informations!
+			$uri = file_get_contents($subfolder."/spotify.txt");
+			$url = "https://open.spotify.com/oembed/?url=".trim($uri)."&format=json";
+			
+			if (!file_exists($coverfile)) {
+				$str = file_get_contents($url);
+				$json  = json_decode($str, true);
+
+				$cover = $json['thumbnail_url'];
+				$coverdl = file_get_contents($cover);
+				file_put_contents($coverfile, $coverdl);
+			}
+			
+			if (!file_exists($titlefile)) {
+				$str = file_get_contents($url);
+				$json  = json_decode($str, true);
+
+				$title = $json['title'];
+				file_put_contents($titlefile, $title);
+			}
+			
+			
         } else {
             $temp['type'] = "generic";
         }

--- a/htdocs/inc.viewFolderTree.php
+++ b/htdocs/inc.viewFolderTree.php
@@ -113,58 +113,7 @@ foreach($subfolders as $key => $subfolder) {
             $titlefile = $subfolder."/title.txt";
             $coverfile = $subfolder."/cover.jpg";
 			
-		/* routine 1 (deprecated): getting spotify informations from mopidy API
-		
-            // get title from Spotify if wasn't previously stored
-            if (!file_exists($titlefile)) {
-                $uri = file_get_contents($subfolder."/spotify.txt");
-
-                // check for mediatype ("track" / "playlist") because following Mopidy API request needs differing parameters
-                $mediatype = explode(':' , $uri)[1];
-
-                if ($mediatype == "playlist"){
-                    // request media info via Mopidy's API
-                    $method = 'core.playlists.lookup';
-                    $params = '{
-                            "uri": "'.trim($uri).'"
-                        }';
-                    $json = mopidyApiCall($method, $params);
-
-                    $title = $json["result"]["name"];
-
-                } elseif ($mediatype == "track") {
-                    // request media info via Mopidy's API
-                    $method = 'core.library.lookup';
-                    $params = '{
-                            "uris": ["'.trim($uri).'"]
-                        }';
-                    $json = mopidyApiCall($method, $params);
-
-                    $title = $json["result"][trim($uri)][0]["name"];
-                }
-                file_put_contents($titlefile, $title);
-			}
-
-            // get cover from Spotify if wasn't previously stored
-            if (!file_exists($coverfile)) {
-                $uri = file_get_contents($subfolder."/spotify.txt");
-
-                // request media-related images via Mopidy's API
-                $method = 'core.library.get_images';
-                $params = '{
-                        "uris": ["'.trim($uri).'"]
-                    }';
-                $json = mopidyApiCall($method, $params);
-
-                $coveruri = $json["result"][trim($uri)][0]["uri"];
-                $cover = file_get_contents($coveruri);
-                
-                file_put_contents($coverfile, $cover);
-			}
-			*/
-			
-			
-			// routine 2: this is a new and easier way for loading spotify informations!
+			// this is a new and easier way for loading spotify informations!
 			$uri = file_get_contents($subfolder."/spotify.txt");
 			$url = "https://open.spotify.com/oembed/?url=".trim($uri)."&format=json";
 			


### PR DESCRIPTION
For explanation: My solution uses the webUI of open.spotify.com and so, this is a complete other but better way of getting informations like before with the Mopidy.Core.API because the webUI is creating the "title" dynamically based on the given mediatype (see examples). I didn't find a way to get the "name" if using mediatype "artist" or "album" in the LibraryController or PlaylistController.

Additionally i use this JSON-URL to get the cover.
Both informations are retrieved ONCE for each URL. If they're saved, they will not be retrieved again, unless they were deleted.

If someone please can test my pull request and if it's working, the old code could be removed in reorga.

Examples:
Artist: https://open.spotify.com/oembed/?url=spotify:artist:0H39MdGGX6dbnnQPt6NQkZ&format=json
Album: https://open.spotify.com/oembed?url=spotify:album:06vukn88R2dOCd6sfMaogd&format=json
Track: https://open.spotify.com/oembed?url=spotify:track:19Obji278XTwlK0Egnv1ps&format=json
Playlist: https://open.spotify.com/oembed?url=spotify:playlist:37i9dQZF1DWVWiyE9VDkCO&format=json

The example links are given the JSON output, including TITLE and COVER-URL.