### PR TITLE
Wait until server is running

### DIFF
--- a/htdocs/ajax.loadMopidyStatus.php
+++ b/htdocs/ajax.loadMopidyStatus.php
@@ -1,4 +1,9 @@
 <?php
-$mopidystatus = exec("systemctl status mopidy | grep 'Active: '| sed 's/Active: //g'");
+$mopidyserverstatus = exec("echo -e status\\nclose | nc -w 1 localhost 6600 | grep 'OK MPD'| sed 's/^.*$/ACTIVE/'");
+if ($mopidyserverstatus == "ACTIVE") {
+$mopidystatus = "Mopidy.Server: Connected<br>Mopidy.Service: " . exec("systemctl status mopidy | grep 'Active: '| sed 's/Active: //g'");
+} else {
+$mopidystatus = "Mopidy.Server: Disconnected!<br>Mopidy.Service: " . exec("systemctl status mopidy | grep 'Active: '| sed 's/Active: //g'");
+}
 ?>
           <div class="col-md-6"><?php echo trim($mopidystatus); ?></div>

--- a/scripts/startup-scripts.sh
+++ b/scripts/startup-scripts.sh
@@ -26,14 +26,17 @@ sudo chmod -R 777 ${AUDIOFOLDERSPATH}
 sudo chmod -R 777 ${PLAYLISTSFOLDERPATH}
 sudo chmod -R 777 $PATHDATA/../shared/shortcuts
 
+#########################################
+# wait until mopidy/MPD server is running
+STATUS=0
+while [ "$STATUS" != "ACTIVE" ]; do STATUS=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep 'OK MPD'| sed 's/^.*$/ACTIVE/'); done
+
 ####################################
 # check if and set volume on startup
 /home/pi/RPi-Jukebox-RFID/scripts/playout_controls.sh -c=setvolumetostartup
 
 ####################
 # play startup sound
-# after some sleep
-/bin/sleep 2
 /usr/bin/mpg123 /home/pi/RPi-Jukebox-RFID/shared/startupsound.mp3
 
 #######################


### PR DESCRIPTION
The problem is, that mopidy.SERVICE (Spotify) is starting very quick. But while the SERVICE is already running, mopidy is establishing the SERVER connection to localhost:6600 in the background. This needs ~ 30-60 seconds, depending on how much playlists the user has.

Only when the server is running, you can give commands (volume, starting songs from spotify, ...)

- I added seperate informations about service and server to the info-tab.
- Adding a while-loop for checking the mopidy/MPD server status in the startup-script.

Fixes #1024 
