### PR TITLE
Fix incorrect ownership of ~/.config/phoniebox

### DIFF
--- a/components/gpio_control/install.sh
+++ b/components/gpio_control/install.sh
@@ -58,7 +58,7 @@ else
     done
 
 fi
-chown -R ${SUDO_USER}:${SUDO_USER} $FILE
+chown -R ${SUDO_USER}:${SUDO_USER} $USER_HOME/.config/phoniebox/
 
 echo
 echo 'Installing GPIO_Control service, this will require to enter your password up to 3 times to enable the service'


### PR DESCRIPTION
The `chown` command in line 61 changes the ownership of the gpio_settings.ini to the correct user. Because the script is run with sudo command root is the of ~/.config/phoniebox  which leads to an error in gpio_control.py. The altered `chown` command leads to the folder and the the .ini to be owned by the correct user.