### PR TITLE
Add RPi throttling info to web interface

### DIFF
--- a/htdocs/lang/lang-de-DE.php
+++ b/htdocs/lang/lang-de-DE.php
@@ -247,6 +247,7 @@ $lang['settingsWlanReadOFF'] = "Nein, Wlan IP nicht vorlesen.";
 */
 $lang['infoOsDistrib'] = "Betriebssystem";
 $lang['infoOsCodename'] = "Codename";
+$lang['infoOsThrottle'] = "Drosselung";
 $lang['infoStorageUsed'] = "Speicherverbrauch";
 $lang['infoMopidyStatus'] = "Mopidy Server Status";
 $lang['infoMPDStatus'] = "MPD Server Status";

--- a/htdocs/lang/lang-en-UK.php
+++ b/htdocs/lang/lang-en-UK.php
@@ -248,6 +248,7 @@ $lang['settingsWlanReadOFF'] = "No, do not read wlan IP.";
 */
 $lang['infoOsDistrib'] = "OS Distribution";
 $lang['infoOsCodename'] = "Codename";
+$lang['infoOsThrottle'] = "Throttling";
 $lang['infoStorageUsed'] = "Storage usage";
 $lang['infoMopidyStatus'] = "Mopidy Server Status";
 $lang['infoMPDStatus'] = "MPD Server Status";

--- a/htdocs/lang/lang-nl-NL.php
+++ b/htdocs/lang/lang-nl-NL.php
@@ -180,6 +180,7 @@ $lang['settingsMessageLangfileNewItems'] = "Er zijn nieuwe taalitems in het oors
 */
 $lang['infoOsDistrib'] = "OS-distributie";
 $lang['infoOsCodename'] = "Codenaam";
+$lang['infoOsThrottle'] = "Beperking";
 $lang['infoStorageUsed'] = "Opslag gebruik";
 $lang['infoMopidyStatus'] = "Mopidy Server Status";
 $lang['infoMPDStatus'] = "MPD Server Status";


### PR DESCRIPTION
As phonieboxes are mostly powered by power banks undervoltage issues might become an issue. This PR features showing the current and historic throttling state of the RPi on the web interface.

By running `vcgencmd get_throttled` you will get an error code that needs to be binary-decoded for further analyzation. Offical documentation: https://www.raspberrypi.org/documentation/raspbian/applications/vcgencmd.md

**Why is this useful?**
I'm using an onOffShim by Pimoroni and somehow it made my phoniebox instable in the last weeks. Random reboots that took some time to find the cause. Finally found out that undervoltage warnings are present on my RPi so I tried powering the RPi directly and not through the onOffShim and the undervoltage warning disappeared. Might be some cabeling issue or something else I've yet to figure out but nevertheless: I think it's a good idea to show if the RPi is or was in throttled mode and why. Would've saved me some time researching.