### PR TITLE
Add RPi's temperature info to web interface

### DIFF
--- a/htdocs/lang/lang-de-DE.php
+++ b/htdocs/lang/lang-de-DE.php
@@ -247,6 +247,7 @@ $lang['settingsWlanReadOFF'] = "Nein, Wlan IP nicht vorlesen.";
 */
 $lang['infoOsDistrib'] = "Betriebssystem";
 $lang['infoOsCodename'] = "Codename";
+$lang['infoOsTemperature'] = "Temperatur";
 $lang['infoStorageUsed'] = "Speicherverbrauch";
 $lang['infoMopidyStatus'] = "Mopidy Server Status";
 $lang['infoMPDStatus'] = "MPD Server Status";

--- a/htdocs/lang/lang-en-UK.php
+++ b/htdocs/lang/lang-en-UK.php
@@ -248,6 +248,7 @@ $lang['settingsWlanReadOFF'] = "No, do not read wlan IP.";
 */
 $lang['infoOsDistrib'] = "OS Distribution";
 $lang['infoOsCodename'] = "Codename";
+$lang['infoOsTemperature'] = "Temperature";
 $lang['infoStorageUsed'] = "Storage usage";
 $lang['infoMopidyStatus'] = "Mopidy Server Status";
 $lang['infoMPDStatus'] = "MPD Server Status";

--- a/htdocs/lang/lang-nl-NL.php
+++ b/htdocs/lang/lang-nl-NL.php
@@ -180,6 +180,7 @@ $lang['settingsMessageLangfileNewItems'] = "Er zijn nieuwe taalitems in het oors
 */
 $lang['infoOsDistrib'] = "OS-distributie";
 $lang['infoOsCodename'] = "Codenaam";
+$lang['infoOsTemperature'] = "Temperatuur";
 $lang['infoStorageUsed'] = "Opslag gebruik";
 $lang['infoMopidyStatus'] = "Mopidy Server Status";
 $lang['infoMPDStatus'] = "MPD Server Status";

--- a/htdocs/systemInfo.php
+++ b/htdocs/systemInfo.php
@@ -25,6 +25,7 @@ $distributor = substr($res[0],strpos($res[0],":")+1,strlen($res[0])-strpos($res[
 $description = substr($res[1],strpos($res[1],":")+1,strlen($res[1])-strpos($res[1],":"));
 $release = substr($res[2],strpos($res[2],":")+1,strlen($res[2])-strpos($res[2],":"));
 $codename = substr($res[3],strpos($res[3],":")+1,strlen($res[3])-strpos($res[3],":"));
+$rpi_temperature = explode("=", exec("sudo vcgencmd measure_temp"))[1];
 
 ?>
 <div class="panel-group">
@@ -53,6 +54,10 @@ $codename = substr($res[3],strpos($res[3],":")+1,strlen($res[3])-strpos($res[3],
           <label class="col-md-4 control-label" for=""><?php print $lang['infoOsCodename']; ?></label> 
           <div class="col-md-6"><?php echo trim($codename); ?></div>
         </div>     
+        <div class="row">
+          <label class="col-md-4 control-label" for=""><?php print $lang['infoOsTemperature']; ?></label>
+          <div class="col-md-6"><?php echo trim($rpi_temperature); ?></div>
+        </div>
 	</div><!-- /.panel-body -->
   </div><!-- /.panel panel-default-->
 </div><!-- /.panel-group -->


### PR DESCRIPTION
As phonieboxes might lack of a proper cooling solution, temperature should be visible in the web interface. Great to have as an indicator in case of issues or simply for monitoring temperature in hot environments (kids room under the roof etc).