### PR TITLE
WIP: added support for files with embedded chapters metada (like m4a)

### DIFF
--- a/scripts/playout_controls_chapter.php
+++ b/scripts/playout_controls_chapter.php
@@ -1,0 +1,45 @@
+<?php
+$inputCommand = $argv[1];
+$inputValue = $argv[2];
+$inputChaptersFile = $argv[3];
+$inputElapsedTime = $argv[4];
+
+if(!in_array($inputCommand, ["playernext", "playerprev"]) || !file_exists($inputChaptersFile) || filesize($inputChaptersFile) === 0) {
+    echo $inputCommand.";".$inputValue;
+    exit;
+}
+
+$chapters = array_map(function($chaptertime) {return (float)$chaptertime;}, file($inputChaptersFile));
+$elapsedTime = (float)$inputElapsedTime;
+
+$prevToleranceSeconds = 5;
+$prevChapter = reset($chapters);
+$nextChapter = end($chapters);
+
+if($inputElapsedTime > $nextChapter && $inputCommand === "playernext") {
+    echo $inputCommand.";".$inputValue;
+    exit;
+}
+
+foreach($chapters as $chapter) {
+    if($chapter <= $elapsedTime - $prevToleranceSeconds && $chapter > $prevChapter) {
+        $prevChapter = $chapter;
+    } else if($chapter >= $elapsedTime && $chapter < $nextChapter) {
+        $nextChapter = $chapter;
+        break;
+    }
+}
+
+
+if($inputCommand === "playerprev") {
+    echo "playerseek;".($prevChapter);
+    exit;
+}
+
+if($inputCommand === "playernext") {
+    echo "playerseek;".($nextChapter);
+    exit;
+}
+
+echo $inputCommand.";".$inputValue;
+


### PR DESCRIPTION
I would like to discuss a new feature by submitting this pull request... (to have something to talk about)

At the moment the web player does not support embedded chapters in files (when using `m4b` files or `mp3` files with embedded chapters by chapter frame addendum - e.g. podcasts), meaning that the `previous` and `next` buttons do not jump to the next chapter, but to the next file, regardless if there are chapters present.

I hacked (!) a little script, that: 
- Extracts the chapter positions of the current file using `/usr/bin/ffprobe` and caches the result, because this takes a while
- if only one chapter is present, it does not do anything
- if there are chapters, the script finds the previous and next chapter positions relative to the elapsed time and rewrites the `COMMAND` and `VALUE` to `seek` and the position of the chapter

So if there are chapters in a currently playing file, the player does not skip the whole track but jumps to the next or previous chapter.

Caveats:
- Detecting chapters is currently active for ALL files, which makes the player unresponsive on first (uncached) action for a playing file - this should be improved by skipping short files or a general config setting to enable chapter support
- The scripts are pretty hackish - I'm not proud of the current solution and the pull request should not be merged as is but only show a proof of concept
