### PR TITLE
Add option to ConfigParser to support inline-comments

### DIFF
--- a/components/gpio_control/gpio_control.py
+++ b/components/gpio_control/gpio_control.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     logger = logging.getLogger()
     logger.setLevel('INFO')
 
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(inline_comment_prefixes=";")
     config_path = os.path.expanduser('~/.config/phoniebox/gpio_settings.ini')
     config.read(config_path)
 


### PR DESCRIPTION
When using the gpis_settings.ini in its current form I was getting these error when running gpio_control.py. 
```
File "/usr/lib/python3.7/configparser.py", line 802, in _get
    return conv(self.get(section, option, **kwargs))
ValueError: could not convert string to float: '0.1 ; only for rotary encoder'
```
I read a little about the topic and it seems that configparser does not support inline comments in its default state. Therefore the config argument was added.
Works on my machine, but not extensively tested beyond that.