### PR TITLE
Allow seeking via GPIO buttons

### DIFF
--- a/components/gpio_control/function_calls.py
+++ b/components/gpio_control/function_calls.py
@@ -69,6 +69,14 @@ def functionCallPlayerStop(*args):
     function_call("{command} -c=playerstop".format(command=playout_control),
             shell=True)
 
+def functionCallPlayerSeekFwd(*args):
+    function_call("{command} -c=playerseek -v=+10".format(command=playout_control), shell=True)
+
+
+def functionCallPlayerSeekBack(*args):
+    function_call("{command} -c=playerseek -v=-10".format(command=playout_control), shell=True)
+
+
 
 def getFunctionCall(functionName):
     logger.error('Get FunctionCall: {} {}'.format(functionName, functionName in locals()))


### PR DESCRIPTION
This addition allows seeking forward and backward via GPIO buttons.
A sample configuration would look like:

`[Forward]`
`enabled: True`
`Type: Button`
`Pin: 19`
`pull_up: True`
`functionCall: functionCallPlayerSeekFwd`

`[Back]`
`enabled: True`
`Type: Button`
`Pin: 20`
`pull_up: True`
`functionCall: functionCallPlayerSeekBack`

Unfortunately, there seems to be an open issue in Music Player Daemon preventing the "seek back" functionality.
See also issue #1031 