### PR TITLE
Added customizable poweroff command

### DIFF
--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -178,6 +178,16 @@ fi
 IDLETIMESHUTDOWN=`cat $PATHDATA/../settings/Idle_Time_Before_Shutdown`
 
 ##############################################
+# Poweroff_Command
+# 1. create a default if file does not exist
+if [ ! -f $PATHDATA/../settings/Poweroff_Command ]; then
+    echo "sudo poweroff" > $PATHDATA/../settings/Poweroff_Command
+    chmod 777 $PATHDATA/../settings/Poweroff_Command
+fi
+# 2. then|or read value from file
+POWEROFFCMD=`cat $PATHDATA/../settings/Poweroff_Command`
+
+##############################################
 # ShowCover
 # 1. create a default if file does not exist
 if [ ! -f $PATHDATA/../settings/ShowCover ]; then
@@ -274,6 +284,7 @@ CMDSEEKBACK=`grep 'CMDSEEKBACK' $PATHDATA/../settings/rfid_trigger_play.conf|tai
 # AUDIOVOLSTARTUP
 # VOLCHANGEIDLE
 # IDLETIMESHUTDOWN
+# POWEROFFCMD
 # SHOWCOVER
 # MAILWLANIPYN
 # MAILWLANIPADDR
@@ -305,6 +316,7 @@ echo "AUDIOVOLMINLIMIT=\"${AUDIOVOLMINLIMIT}\"" >> "${PATHDATA}/../settings/glob
 echo "AUDIOVOLSTARTUP=\"${AUDIOVOLSTARTUP}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "VOLCHANGEIDLE=\"${VOLCHANGEIDLE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "IDLETIMESHUTDOWN=\"${IDLETIMESHUTDOWN}\"" >> "${PATHDATA}/../settings/global.conf"
+echo "POWEROFFCMD=\"${POWEROFFCMD}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SHOWCOVER=\"${SHOWCOVER}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "READWLANIPYN=\"${READWLANIPYN}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "EDITION=\"${EDITION}\"" >> "${PATHDATA}/../settings/global.conf"

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -213,7 +213,7 @@ case $COMMAND in
         sleep 1
         /usr/bin/mpg123 ${PATHDATA}/../shared/shutdownsound.mp3
         sleep 3
-        sudo poweroff
+        ${POWEROFFCMD}
         ;;
     shutdownsilent)
         # doesn't play a shutdown sound
@@ -237,7 +237,7 @@ case $COMMAND in
         #remove shuffle mode if active
         SHUFFLE_STATUS=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep -o -P '(?<=random: ).*')
         if [ "$SHUFFLE_STATUS" == 1 ] ; then  mpc random off; fi
-        sudo poweroff
+        ${POWEROFFCMD}
         ;;
     shutdownafter)
         # remove shutdown times if existent


### PR DESCRIPTION
Adds an option to configure the poweroff command executed when
triggering a shutdown. Poweroff command to use is read from file
`settings/Poweroff_Command`, default `sudo poweroff`.

Scenario:
- You are powering you Pi via an extension board, e.g. MoPi 2,
that cannot detect a regular poweroff and stays powered-on itself. Via a
customizable poweroff command you can trigger the extension board to
power off the Pi in the prefered way which finally also turns-off the
extension board.
- You like to add some extras, e.g. LED illumination, on power off. A
customizable poweroff command provides the "user" a nice hook for whatever
stuff he likes to add before the actual power off :-)