### PR TITLE
Update Mopidy Iris to 3.54.2

### DIFF
--- a/requirements-spotify.txt
+++ b/requirements-spotify.txt
@@ -1,3 +1,3 @@
 # Spotify related requirements
  # You need to install these with `sudo pip install --upgrade --force-reinstall -r requirements-spotify.txt`
- Mopidy-Iris==3.45.0
+ Mopidy-Iris==3.54.2


### PR DESCRIPTION
As many fixes were done since 3.45.0 we pin Mopidy Iris to the latest version.

I don’t have Spotify, so I can’t test this.