### PR TITLE
Fix volume of startup sound

### DIFF
--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -150,7 +150,7 @@ AUDIOVOLMINLIMIT=`cat $PATHDATA/../settings/Min_Volume_Limit`
 # Startup_Volume
 # 1. create a default if file does not exist
 if [ ! -f $PATHDATA/../settings/Startup_Volume ]; then
-    echo "0" > $PATHDATA/../settings/Startup_Volume
+    echo "30" > $PATHDATA/../settings/Startup_Volume
     chmod 777 $PATHDATA/../settings/Startup_Volume
 fi
 # 2. then|or read value from file


### PR DESCRIPTION
Fixes #1167.

Default value was 0, so users would assume startup sound doesn't work.