### PR TITLE
Improve player.php performance

### DIFF
--- a/htdocs/api/common.php
+++ b/htdocs/api/common.php
@@ -36,7 +36,21 @@ function execSuccessfully($command) {
         echo "Execution failed\nCommand: {$command}\nOutput: {$formattedOutput}\nRC: .${rc}";
         http_response_code(500);
         exit();
-    }
+    }  
     return $output;
 }
+
+function execMPDCommand($command) {    
+    $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+    $stream = socket_connect($socket,"localhost" ,6600);
+    socket_write($socket, $command, strlen($command));
+    socket_shutdown ($socket,1);
+    $output = array();
+    while ($out = socket_read($socket, 2048)) {
+        $output = array_merge($output,explode("\n", $out));        
+    }
+    socket_close($socket);  
+    return $output;
+}
+
 ?>

--- a/htdocs/api/common.php
+++ b/htdocs/api/common.php
@@ -47,9 +47,10 @@ function execMPDCommand($command) {
     socket_shutdown ($socket,1);
     $output = array();
     while ($out = socket_read($socket, 2048)) {
-        $output = array_merge($output,explode("\n", $out));        
+         $outputTemp .= $out;
     }
-    socket_close($socket);  
+    $output = array_merge($output,explode("\n", $outputTemp));
+    socket_close($socket);
     return $output;
 }
 

--- a/htdocs/api/player.php
+++ b/htdocs/api/player.php
@@ -53,9 +53,7 @@ function handlePut() {
 
 function handleGet() {
     global $debugLoggingConf;
-    global $globalConf;
-    //$statusCommand = "echo 'status\ncurrentsong\nclose' | nc -w 1 localhost 6600";    
-    //$commandResponseList = execSuccessfully($statusCommand);
+    global $globalConf;    
     $statusCommand = "status\ncurrentsong\nclose";
     $commandResponseList = execMPDCommand($statusCommand);
     $responseList = array();

--- a/htdocs/api/player.php
+++ b/htdocs/api/player.php
@@ -13,7 +13,6 @@ include 'common.php';
 */
 $debugLoggingConf = parse_ini_file("../../settings/debugLogging.conf");
 $globalConf = parse_ini_file("../../settings/global.conf");
-$globalConf['ENABLE_CHAPTERS_FOR_EXTENSIONS'] = "mp4,m4a,m4b,m4r";
 
 if ($debugLoggingConf['DEBUG_WebApp_API'] == "TRUE") {
     file_put_contents("../../logs/debug.log", "\n# WebApp API # " . __FILE__, FILE_APPEND | LOCK_EX);
@@ -73,7 +72,7 @@ function handleGet() {
 
     // get chapter info if file extension indicates supports
     $fileExtension = pathinfo ( $responseList['file'], PATHINFO_EXTENSION);         
-    if (in_array($fileExtension, explode(',', $globalConf['ENABLE_CHAPTERS_FOR_EXTENSIONS']))) {
+    if (in_array($fileExtension, explode(',', $globalConf['CHAPTEREXTENSIONS']))) {
         $command = "playout_controls.sh -c=getchapters";
         $output = execScript($command);
         $jsonChapters = trim(implode("\n", $output));

--- a/htdocs/api/player.php
+++ b/htdocs/api/player.php
@@ -12,6 +12,8 @@ include 'common.php';
 * DEBUG_WebApp_API="TRUE"
 */
 $debugLoggingConf = parse_ini_file("../../settings/debugLogging.conf");
+$globalConf = parse_ini_file("../../settings/global.conf");
+$globalConf['ENABLE_CHAPTERS_FOR_EXTENSIONS'] = "mp4,m4a,m4b,m4r";
 
 if ($debugLoggingConf['DEBUG_WebApp_API'] == "TRUE") {
     file_put_contents("../../logs/debug.log", "\n# WebApp API # " . __FILE__, FILE_APPEND | LOCK_EX);
@@ -51,8 +53,11 @@ function handlePut() {
 
 function handleGet() {
     global $debugLoggingConf;
-    $statusCommand = "echo 'status\ncurrentsong\nclose' | nc -w 1 localhost 6600";
-    $commandResponseList = execSuccessfully($statusCommand);
+    global $globalConf;
+    //$statusCommand = "echo 'status\ncurrentsong\nclose' | nc -w 1 localhost 6600";    
+    //$commandResponseList = execSuccessfully($statusCommand);
+    $statusCommand = "status\ncurrentsong\nclose";
+    $commandResponseList = execMPDCommand($statusCommand);
     $responseList = array();
     forEach ($commandResponseList as $commandResponse) {
         preg_match("/(?P<key>.+?): (?P<value>.*)/", $commandResponse, $match);
@@ -60,16 +65,24 @@ function handleGet() {
             $responseList[strtolower($match['key'])] = $match['value'];
         }
     }
+    
     // get volume separately from mpd, because we might use amixer to control volume
-    $command = "playout_controls.sh -c=getvolume";
-    $output = execScript($command);
-    $responseList['volume'] = implode('\n', $output);
+    if ($globalConf['VOLUMEMANAGER'] != "mpd"){
+        $command = "playout_controls.sh -c=getvolume";
+        $output = execScript($command);
+        $responseList['volume'] = implode('\n', $output);
+    }
 
-    $command = "playout_controls.sh -c=getchapters";
-    $output = execScript($command);
-    $jsonChapters = trim(implode("\n", $output));
-    $chapters = @json_decode($jsonChapters, true);
-
+    // get chapter info if file extension indicates supports
+    $fileExtension = pathinfo ( $responseList['file'], PATHINFO_EXTENSION);         
+    if (in_array($fileExtension, explode(',', $globalConf['ENABLE_CHAPTERS_FOR_EXTENSIONS']))) {
+        $command = "playout_controls.sh -c=getchapters";
+        $output = execScript($command);
+        $jsonChapters = trim(implode("\n", $output));
+        $chapters = @json_decode($jsonChapters, true);           
+    }
+    
+ 
     $currentChapterIndex = null;
     $mappedChapters = array_filter(array_map(function($chapter) use($responseList, &$currentChapterIndex) {
         static $i = 1;

--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -274,6 +274,28 @@ fi
 VERSION=`cat $PATHDATA/../settings/version`
 
 ##############################################
+# CHAPTEREXTENSIONS
+# Only files with the extensions listed will be scanned for chapters
+# 1. create a default if file does not exist
+if [ ! -f $PATHDATA/../settings/CHAPTEREXTENSIONS ]; then
+    echo "mp4,m4a,m4b,m4r" > $PATHDATA/../settings/CHAPTEREXTENSIONS
+    chmod 777 $PATHDATA/../settings/CHAPTEREXTENSIONS
+fi
+# 2. then|or read value from file
+CHAPTEREXTENSIONS=`cat $PATHDATA/../settings/CHAPTEREXTENSIONS`
+
+##############################################
+# CHAPTERMINDURATION
+# Only files with play length bigger than minimum will be scanned for chapters
+# 1. create a default if file does not exist
+if [ ! -f $PATHDATA/../settings/CHAPTERMINDURATION ]; then
+    echo "600" > $PATHDATA/../settings/CHAPTERMINDURATION
+    chmod 777 $PATHDATA/../settings/CHAPTERMINDURATION
+fi
+# 2. then|or read value from file
+CHAPTERMINDURATION=`cat $PATHDATA/../settings/CHAPTERMINDURATION`
+
+##############################################
 # read control card ids
 # 1. read all values from file
 CMDVOLUP=`grep 'CMDVOLUP' $PATHDATA/../settings/rfid_trigger_play.conf|tail -1|sed 's/CMDVOLUP=//g'|sed 's/"//g'|tr -d "\n"|grep -o '[0-9]*'`
@@ -306,6 +328,8 @@ CMDSEEKBACK=`grep 'CMDSEEKBACK' $PATHDATA/../settings/rfid_trigger_play.conf|tai
 # EDITION
 # LANG
 # VERSION
+# CHAPTEREXTENSIONS
+# CHAPTERMINDURATION
 # CMDVOLUP
 # CMDVOLDOWN
 # CMDNEXT
@@ -337,6 +361,8 @@ echo "READWLANIPYN=\"${READWLANIPYN}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "EDITION=\"${EDITION}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "LANG=\"${LANG}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "VERSION=\"${VERSION}\"" >> "${PATHDATA}/../settings/global.conf"
+echo "CHAPTEREXTENSIONS=\"${CHAPTEREXTENSIONS}\"" >> "${PATHDATA}/../settings/global.conf"
+echo "CHAPTERMINDURATION=\"${CHAPTERMINDURATION}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "CMDVOLUP=\"${CMDVOLUP}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "CMDVOLDOWN=\"${CMDVOLDOWN}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "CMDNEXT=\"${CMDNEXT}\"" >> "${PATHDATA}/../settings/global.conf"

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -112,8 +112,6 @@ shortcutCommands="^(setvolume|volumedown|volumeup|mute)$"
 # Run the code from this block only, if the current command is not in "shortcutCommands"
 if [[ ! "$COMMAND" =~ $shortcutCommands ]]
 then
-    ENABLE_CHAPTERS_FOR_EXTENSIONS="mp4,m4a,m4b,m4r"
-    ENABLE_CHAPTERS_MIN_DURATION="600"
 
     function dbg {
         if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then
@@ -152,7 +150,7 @@ then
     CHAPTERS_FILE="${CURRENT_SONG_DIR}/${CURRENT_SONG_BASENAME%.*}.chapters.json"
     dbg "chapters file: $CHAPTERS_FILE"
 
-    if [ "$(grep -wo "$CURRENT_SONG_FILE_EXT" <<< "$ENABLE_CHAPTERS_FOR_EXTENSIONS")" == "$CURRENT_SONG_FILE_EXT" ]; then
+    if [ "$(grep -wo "$CURRENT_SONG_FILE_EXT" <<< "$CHAPTEREXTENSIONS")" == "$CURRENT_SONG_FILE_EXT" ]; then
         CHAPTER_SUPPORT_FOR_EXTENSION="1"
     else
         CHAPTER_SUPPORT_FOR_EXTENSION="0"
@@ -160,7 +158,7 @@ then
     dbg "chapters for extension enabled: $CHAPTER_SUPPORT_FOR_EXTENSION"
 
 
-    if [ "$(printf "${CURRENT_SONG_DURATION}\n${ENABLE_CHAPTERS_MIN_DURATION}\n" | sort -g | head -1)" == "${ENABLE_CHAPTERS_MIN_DURATION}" ]; then
+    if [ "$(printf "${CURRENT_SONG_DURATION}\n${CHAPTERMINDURATION}\n" | sort -g | head -1)" == "${CHAPTERMINDURATION}" ]; then
         CHAPTER_SUPPORT_FOR_DURATION="1"
     else
         CHAPTER_SUPPORT_FOR_DURATION="0"


### PR DESCRIPTION
### Reason for improvement:
Running Phoniebox(+Spotify) on a Raspberry Pi Zero. Using the webui I noticed the player.php call takes up to 5 seconds to process on the zero which leads to a non ideal user experience.
 
### Result:
With 3 tweaks I managed to improve the performance of a player.php call by a factor of 10 for the most common scenarios.

### Proposal:
Avoid all system calls:
1. Use direct socket communication to mpd instead of netcat
2. Avoid separate volume fetching when not necessary by checking global config first
3. Avoid Chapter fetching by checking file type. This section is not perfect yet. I would propose to put the chapter extensions in a central config but need feedback what would be the best solution to do this.
