### PR TITLE
Adding a boot volume settings to be set in startup script after reboot

### DIFF
--- a/htdocs/inc.header.php
+++ b/htdocs/inc.header.php
@@ -165,6 +165,7 @@ $version = $globalConf['VERSION'];
 $edition = $globalConf['EDITION'];
 $maxvolumevalue = $globalConf['AUDIOVOLMAXLIMIT'];
 $startupvolumevalue = $globalConf['AUDIOVOLSTARTUP'];
+$bootvolumevalue = $globalConf['AUDIOVOLBOOT'];
 $volstepvalue = $globalConf['AUDIOVOLCHANGESTEP'];
 $idletimevalue = $globalConf['IDLETIMESHUTDOWN'];
 $conf['settings_lang'] = $globalConf['LANG'];
@@ -193,6 +194,7 @@ $nonEmptyCommands = array(
     'volume',
     'maxvolume',
     'startupvolume',
+    'bootvolume',
     'volstep',
     'shutdown',
     'reboot',
@@ -294,6 +296,7 @@ $commandToAction = array(
     'volume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setvolume -v=%s",            // change volume
     'maxvolume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setmaxvolume -v=%s",      // change max volume
     'startupvolume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setstartupvolume -v=%s",      // change startup volume
+    'bootvolume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setbootvolume -v=%s",      // change startup volume
     'volstep' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setvolstep -v=%s",          // change volume step
     'mute' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=mute",                         // volume mute (toggle)
     'volumeup' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=volumeup",                 // volume up

--- a/htdocs/inc.header.php
+++ b/htdocs/inc.header.php
@@ -296,7 +296,7 @@ $commandToAction = array(
     'volume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setvolume -v=%s",            // change volume
     'maxvolume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setmaxvolume -v=%s",      // change max volume
     'startupvolume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setstartupvolume -v=%s",      // change startup volume
-    'bootvolume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setbootvolume -v=%s",      // change startup volume
+    'bootvolume' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setbootvolume -v=%s",      // change boot volume
     'volstep' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=setvolstep -v=%s",          // change volume step
     'mute' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=mute",                         // volume mute (toggle)
     'volumeup' => "/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=volumeup",                 // volume up

--- a/htdocs/inc.setBootVolume.php
+++ b/htdocs/inc.setBootVolume.php
@@ -1,0 +1,59 @@
+<!--
+Boot Volume => the volume that will be set when the Phoniebox is booted
+-->
+        <!-- input-group -->
+        <?php
+        $maxvalueselect = round(($maxvolumevalue/5))*5;
+        $bootvolvaluedisplay = round($bootvolumevalue);
+        ?>
+        <div class="col-md-4 col-sm-6">
+            <div class="row" style="margin-bottom:1em;">
+              <div class="col-xs-6">
+              <h4><?php print $lang['settingsBootVol']; ?></h4>
+                <form name='bootvolume' method='post' action='<?php print $_SERVER['PHP_SELF']; ?>'>
+                  <div class="input-group my-group">
+                    <select id="bootvolume" name="bootvolume" class="selectpicker form-control">
+                      <option value='0'<?php
+                          if($bootvolumevalue == 0) {
+                              print " selected";
+                          }
+                      ?>><?php print $lang['globalOff']; ?></option>
+                    <?php
+                    $i = $maxvalueselect;
+                    while ($i >= 5) {
+                        print "
+                        <option value='".$i."'";
+                        if($bootvolvaluedisplay == $i) {
+                            print " selected";
+                        }
+                        print ">".$i."%</option>";
+                        $i = $i - 5;
+                    };
+                    print "\n";
+                    ?>
+                    </select>
+                    <span class="input-group-btn">
+                        <input type='submit' class="btn btn-default" name='submit' value='<?php print $lang['globalSet']; ?>'/>
+                    </span>
+                  </div>
+                </form>
+              </div>
+
+              <div class="col-xs-6">
+                  <div class="c100 p<?php print $bootvolvaluedisplay; ?>">
+                    <span><?php
+                        if ($bootvolumevalue == 0) {
+                            print $lang['globalOff'];
+                        } else {
+                            print $bootvolumevalue."%";
+                        }
+                    ?></span>
+                    <div class="slice">
+                        <div class="bar"></div>
+                        <div class="fill"></div>
+                    </div>
+                  </div>
+              </div>
+            </div><!-- ./row -->
+        </div>
+        <!-- /input-group -->

--- a/htdocs/inc.setStartupVolume.php
+++ b/htdocs/inc.setStartupVolume.php
@@ -3,8 +3,6 @@ Startup Volume Select Form
 -->
         <!-- input-group -->
         <?php
-        //$maxvolumevalue = exec("/usr/bin/sudo ".$conf['scripts_abs']."/playout_controls.sh -c=getmaxvolume");
-        //$maxvolumevalue = 43.6;//debug
         $maxvalueselect = round(($maxvolumevalue/5))*5;
         $startupvaluedisplay = round($startupvolumevalue);
         ?>

--- a/htdocs/lang/lang-de-DE.php
+++ b/htdocs/lang/lang-de-DE.php
@@ -207,6 +207,7 @@ $lang['trackEditDeleteYes'] = "Ja, diesen Track LÖSCHEN";
 $lang['settingsVolChangePercent'] = "Lautst. Änderung";
 $lang['settingsMaxVol'] = "Max. Lautstärke";
 $lang['settingsStartupVol'] = "Start-Lautstärke";
+$lang['settingsBootVol'] = "Lautst. nach Boot";
 $lang['settingsWifiRestart'] = "Die Änderungen an der WiFi-Verbindung erfordern einen Neustart, um wirksam zu werden";
 $lang['settingsWifiSsidPlaceholder'] = "z.B. PhonieHomie";
 $lang['settingsWifiSsidHelp'] = "Der Name, unter dem dein WiFi als 'verfügbares Netzwerk' angezeigt wird";

--- a/htdocs/lang/lang-en-UK.php
+++ b/htdocs/lang/lang-en-UK.php
@@ -208,6 +208,7 @@ $lang['trackEditDeleteYes'] = "Yes, DELETE this track";
 $lang['settingsVolChangePercent'] = "Vol. Change %";
 $lang['settingsMaxVol'] = "Maximum Volume";
 $lang['settingsStartupVol'] = "Startup Volume";
+$lang['settingsBootVol'] = "Volume after reboot";
 $lang['settingsWifiRestart'] = "The changes applied to your WiFi connection require a restart to take effect.";
 $lang['settingsWifiSsidPlaceholder'] = "e.g.: PhonieHomie";
 $lang['settingsWifiSsidHelp'] = "The name under which your WiFi shows up as 'available network'";

--- a/htdocs/settings.php
+++ b/htdocs/settings.php
@@ -119,6 +119,7 @@ include("inc.setVolume.php");
 include("inc.setMaxVolume.php");
 include("inc.setVolumeStep.php");
 include("inc.setStartupVolume.php");
+include("inc.setBootVolume.php");
 ?>
       </div><!-- / .row -->
     </div><!-- /.panel-body -->

--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -150,11 +150,21 @@ AUDIOVOLMINLIMIT=`cat $PATHDATA/../settings/Min_Volume_Limit`
 # Startup_Volume
 # 1. create a default if file does not exist
 if [ ! -f $PATHDATA/../settings/Startup_Volume ]; then
-    echo "30" > $PATHDATA/../settings/Startup_Volume
+    echo "0" > $PATHDATA/../settings/Startup_Volume
     chmod 777 $PATHDATA/../settings/Startup_Volume
 fi
 # 2. then|or read value from file
 AUDIOVOLSTARTUP=`cat $PATHDATA/../settings/Startup_Volume`
+
+##############################################
+# Volume_Boot - after reboot
+# 1. create a default if file does not exist
+if [ ! -f $PATHDATA/../settings/Volume_Boot ]; then
+    echo "30" > $PATHDATA/../settings/Volume_Boot
+    chmod 777 $PATHDATA/../settings/Volume_Boot
+fi
+# 2. then|or read value from file
+AUDIOVOLBOOT=`cat $PATHDATA/../settings/Volume_Boot`
 
 ##############################################
 # Change_Volume_Idle
@@ -282,6 +292,7 @@ CMDSEEKBACK=`grep 'CMDSEEKBACK' $PATHDATA/../settings/rfid_trigger_play.conf|tai
 # AUDIOVOLMAXLIMIT
 # AUDIOVOLMINLIMIT
 # AUDIOVOLSTARTUP
+# AUDIOVOLBOOT
 # VOLCHANGEIDLE
 # IDLETIMESHUTDOWN
 # POWEROFFCMD
@@ -314,6 +325,7 @@ echo "AUDIOVOLCHANGESTEP=\"${AUDIOVOLCHANGESTEP}\"" >> "${PATHDATA}/../settings/
 echo "AUDIOVOLMAXLIMIT=\"${AUDIOVOLMAXLIMIT}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOVOLMINLIMIT=\"${AUDIOVOLMINLIMIT}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOVOLSTARTUP=\"${AUDIOVOLSTARTUP}\"" >> "${PATHDATA}/../settings/global.conf"
+echo "AUDIOVOLBOOT=\"${AUDIOVOLBOOT}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "VOLCHANGEIDLE=\"${VOLCHANGEIDLE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "IDLETIMESHUTDOWN=\"${IDLETIMESHUTDOWN}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "POWEROFFCMD=\"${POWEROFFCMD}\"" >> "${PATHDATA}/../settings/global.conf"

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -30,6 +30,9 @@ NOW=`date +%Y-%m-%d.%H:%M:%S`
 # setstartupvolume
 # getstartupvolume
 # setvolumetostartup
+# setbootvolume
+# getbootvolume
+# setvolumetobootvolume
 # volumeup
 # volumedown
 # getchapters
@@ -558,6 +561,39 @@ case $COMMAND in
             else
                 # manage volume with mpd
                 echo -e setvol ${AUDIOVOLSTARTUP}\\nclose | nc -w 1 localhost 6600
+            fi
+
+        fi
+        ;;
+    setbootvolume)
+        if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "   ${COMMAND}" >> ${PATHDATA}/../logs/debug.log; fi
+        # if value is greater than wanted maxvolume, set value to maxvolume
+        if [ ${VALUE} -gt $AUDIOVOLMAXLIMIT ];
+        then
+            VALUE=$AUDIOVOLMAXLIMIT;
+        fi
+        # write new value to file
+        echo "$VALUE" > ${PATHDATA}/../settings/Volume_Boot
+        # create global config file because individual setting got changed
+        . ${PATHDATA}/inc.writeGlobalConfig.sh
+        ;;
+    getbootvolume)
+        if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "   ${COMMAND}" >> ${PATHDATA}/../logs/debug.log; fi
+        echo ${AUDIOVOLBOOT}
+        ;;
+    setvolumetobootvolume)
+        if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "   ${COMMAND}" >> ${PATHDATA}/../logs/debug.log; fi
+        # check if startup-volume is disabled
+        if [ "${AUDIOVOLBOOT}" == 0 ]; then
+            exit 1
+        else
+            # set volume level in percent
+            if [ "${VOLUMEMANAGER}" == "amixer" ]; then
+                # volume handling alternative with amixer not mpd (2020-06-12 related to ticket #973)
+                amixer sset \'$AUDIOIFACENAME\' ${AUDIOVOLBOOT}%
+            else
+                # manage volume with mpd
+                echo -e setvol ${AUDIOVOLBOOT}\\nclose | nc -w 1 localhost 6600
             fi
 
         fi

--- a/scripts/startup-scripts.sh
+++ b/scripts/startup-scripts.sh
@@ -34,7 +34,16 @@ STATUS=0
 while [ "$STATUS" != "ACTIVE" ]; do STATUS=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep 'OK MPD'| sed 's/^.*$/ACTIVE/'); done
 
 ####################################
-# check if and set volume on startup
+# Set volume levels on boot
+# Both can be set in the Web UI under settings
+# Confusion explained:
+# 1. Set the volume to the global boot level.
+#    Sometimes the Pi sets volume to 0.
+#    The first command makes sure there is *some* level, not 0.
+# 2. Then set the volume to the startup volume.
+#    If the kids crank up the volume at night,
+#    after a reboot, the box will be back to this level.
+/home/pi/RPi-Jukebox-RFID/scripts/playout_controls.sh -c=setvolumetobootvolume
 /home/pi/RPi-Jukebox-RFID/scripts/playout_controls.sh -c=setvolumetostartup
 
 ####################

--- a/scripts/startup-scripts.sh
+++ b/scripts/startup-scripts.sh
@@ -48,7 +48,7 @@ while [ "$STATUS" != "ACTIVE" ]; do STATUS=$(echo -e status\\nclose | nc -w 1 lo
 
 ####################
 # play startup sound
-mpgvolume=$((32768*${AUDIOVOLSTARTUP}/100))
+mpgvolume=$((32768*${AUDIOVOLBOOT}/100))
 echo "${mpgvolume} is the mpg123 startup volume"
 /usr/bin/mpg123 -f -${mpgvolume} /home/pi/RPi-Jukebox-RFID/shared/startupsound.mp3
 


### PR DESCRIPTION
Referencing @BerniPi comment in https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/1169 , this adds a new value to the global.conf -> the global level of the audio mixer after any boot of the Raspberry Pi.
The value can be set in the Web UI
NEEDS TESTING!!!
@BerniPi - I invited you as a collaborator, please accept the invitation (don't know if and where it will reach you. Mail?)