### PR TITLE
Spotify url conversion (http to mopidy format)

### DIFF
--- a/htdocs/inc.processCheckCardEditRegister.php
+++ b/htdocs/inc.processCheckCardEditRegister.php
@@ -172,8 +172,7 @@ if($post['delete'] == "delete") {
     }
 
     //wrong spotify url, convert to mopidy format
-    if((isset($post['streamURL']) && $post['streamType'] == "spotify") && (strpos($post['streamURL'], "https://open.spotify.com/") !== false)){
-        $messageError .= "Wrong spotify url, converted to the correct format";
+    if((isset($post['streamURL']) && $post['streamType'] == "spotify") && (strpos($post['streamURL'], "https://open.spotify.com/") !== false)){        
         $patterns = array();
         $patterns[0] = '/https\:\/\/open.spotify.com/';
         $patterns[1] = '/\/(playlist|album|track|artist)\//';
@@ -182,7 +181,9 @@ if($post['delete'] == "delete") {
         $replacements[0] = 'spotify:';
         $replacements[1] = '$1:';
         $replacements[2] = '$1';
-        $post['streamURL'] = preg_replace($patterns, $replacements, $post['streamURL']);
+        $newSpotifyURL = preg_replace($patterns, $replacements, $post['streamURL']);
+        $messageError .= $lang['cardRegisterErrorConvertSpotifyURL']." (error 007)<br />".$post['streamURL']." ➔ ".$newSpotifyURL;
+        $post['streamURL'] = $newSpotifyURL;
     }
 
 

--- a/htdocs/inc.processCheckCardEditRegister.php
+++ b/htdocs/inc.processCheckCardEditRegister.php
@@ -171,6 +171,21 @@ if($post['delete'] == "delete") {
         $post['audiofolderNew'] = $link = str_replace(array('http://','https://','/','=','-','.', 'www','?','&'), '', $post['streamURL']);
     }
 
+    //wrong spotify url, convert to mopidy format
+    if((isset($post['streamURL']) && $post['streamType'] == "spotify") && (strpos($post['streamURL'], "https://open.spotify.com/") !== false)){
+        $messageError .= "Wrong spotify url, converted to the correct format";
+        $patterns = array();
+        $patterns[0] = '/https\:\/\/open.spotify.com/';
+        $patterns[1] = '/\/(playlist|album|track|artist)\//';
+        $patterns[2] = '/(\w+)\?(.*)/';
+        $replacements = array();
+        $replacements[0] = 'spotify:';
+        $replacements[1] = '$1:';
+        $replacements[2] = '$1';
+        $post['streamURL'] = preg_replace($patterns, $replacements, $post['streamURL']);
+    }
+
+
     /*
     * any errors?
     */

--- a/htdocs/lang/lang-de-DE.php
+++ b/htdocs/lang/lang-de-DE.php
@@ -124,6 +124,7 @@ $lang['cardRegisterErrorStreamOrAudio'] = "<p>Das ist nicht genug! Füge eine UR
 $lang['cardRegisterErrorExistingAndNew'] = "<p>Das ist zu viel! Wähle entweder einen bestehenden Ordner aus oder erstelle einen neuen.</p>";
 $lang['cardRegisterErrorExistingFolder'] = "<p>Ein Ordner mit dem gleichen Namen existiert bereits! Wähle einen anderen. </p>";
 $lang['cardRegisterErrorSuggestFolder'] = "Ein Ordnername für den Stream muss erstellt werden. Unten im Formular steht ein Vorschlag.";
+$lang['cardRegisterErrorConvertSpotifyURL'] = "Falsche Spotify URL, konvertiert in korrektes Format";
 $lang['cardRegisterStream2Card'] = "Stream ist mit der Karten-ID verknüpft.";
 $lang['cardRegisterFolder2Card'] = "Audio-Ordner ist nun mit der Karten-ID verknüpft.";
 $lang['cardRegisterDownloadingYT'] = "<p>YouTube Audio wird heruntergeladen. Dies kann einige Minuten dauern. Du kannst die Logdatei \"youtube-dl.log\" im Ordner \"shared\" ansehen.</p>";

--- a/htdocs/lang/lang-en-UK.php
+++ b/htdocs/lang/lang-en-UK.php
@@ -125,6 +125,7 @@ $lang['cardRegisterErrorStreamOrAudio'] = "<p>Seems you haven't selected anythin
 $lang['cardRegisterErrorExistingAndNew'] = "<p>This is too much! Either choose an existing folder or create a new one.</p>";
 $lang['cardRegisterErrorExistingFolder'] = "<p>A folder named with the same name already exists! Chose a different one.</p>";
 $lang['cardRegisterErrorSuggestFolder'] = "A folder name for the stream needs to be created. Below in the form I made a suggestion.";
+$lang['cardRegisterErrorConvertSpotifyURL'] = "Wrong spotify url, converted to the correct format";
 $lang['cardRegisterStream2Card'] = "Stream is linked to Card ID.";
 $lang['cardRegisterFolder2Card'] = "Audio folder is now linked to Card.";
 $lang['cardRegisterDownloadingYT'] = "<p>YouTube audio is downloading. This may take a couple of minutes. You may check the logfile \"youtube-dl.log\" in the shared folder.</p>";

--- a/htdocs/lang/lang-nl-NL.php
+++ b/htdocs/lang/lang-nl-NL.php
@@ -109,6 +109,7 @@ $lang['cardRegisterErrorStreamOrAudio'] = "<p>Dit is niet genoeg! Voeg een URL t
 $lang['cardRegisterErrorExistingAndNew'] = "<p>Dit is te veel! Kies een bestaande map of maak een nieuwe map aan.</p>";
 $lang['cardRegisterErrorExistingFolder'] = "<p>Er bestaat al een map met dezelfde naam! Kies een andere.</p>";
 $lang['cardRegisterErrorSuggestFolder'] = "Er moet een mapnaam voor de stream worden gemaakt. Hieronder in het formulier heb ik een suggestie gedaan.";
+$lang['cardRegisterErrorConvertSpotifyURL'] = "Verkeerde spotify url, geconverteerd naar het juiste formaat";
 $lang['cardRegisterStream2Card'] = "Stream is gekoppeld aan kaart-ID.";
 $lang['cardRegisterFolder2Card'] = "De audiomap is nu gekoppeld aan kaart-ID";
 $lang['cardRegisterDownloadingYT'] = "<p>YouTube-audio wordt gedownload. Dit kan een paar minuten duren. U kunt het logbestand 'youtube-dl.log' in de gedeelde map controleren.</p>";


### PR DESCRIPTION
Reason for improvement:
Running Phoniebox(+Spotify). I was adding multiple albums/playlists from spotify to Phoniebox when realizing I couldn't just copy&paste the urls. 

Result:
All Urls from https://open.spotify.com get converted to the mopidy format and are redisplayed in the correct format.

Proposal:
Use a regex replacement inside inc.processCheckCardEditRegister.php to validate/replace the url.
