### PR TITLE
Added switchable audio iFaces

### DIFF
--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -120,6 +120,16 @@ fi
 AUDIOIFACENAME=`cat $PATHDATA/../settings/Audio_iFace_Name`
 
 ##############################################
+# Audio_iFace_Active
+# 1. create a default if file does not exist
+if [ ! -f $PATHDATA/../settings/Audio_iFace_Active ]; then
+    echo "0" > $PATHDATA/../settings/Audio_iFace_Active
+    chmod 777 $PATHDATA/../settings/Audio_iFace_Active
+fi
+# 2. then|or read value from file
+AUDIOIFACEACTIVE=`cat $PATHDATA/../settings/Audio_iFace_Active`
+
+##############################################
 # Volume_Manager (mpd or amixer)
 # 1. create a default if file does not exist
 if [ ! -f $PATHDATA/../settings/Volume_Manager ]; then
@@ -313,6 +323,7 @@ CMDSEEKBACK=`grep 'CMDSEEKBACK' $PATHDATA/../settings/rfid_trigger_play.conf|tai
 # SECONDSWIPEPAUSE
 # SECONDSWIPEPAUSECONTROLS
 # AUDIOIFACENAME
+# AUDIOIFACEACTIVE
 # VOLUMEMANAGER
 # AUDIOVOLCHANGESTEP
 # AUDIOVOLMAXLIMIT
@@ -348,6 +359,7 @@ echo "SECONDSWIPE=\"${SECONDSWIPE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SECONDSWIPEPAUSE=\"${SECONDSWIPEPAUSE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SECONDSWIPEPAUSECONTROLS=\"${SECONDSWIPEPAUSECONTROLS}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOIFACENAME=\"${AUDIOIFACENAME}\"" >> "${PATHDATA}/../settings/global.conf"
+echo "AUDIOIFACEACTIVE=\"${AUDIOIFACEACTIVE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "VOLUMEMANAGER=\"${VOLUMEMANAGER}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOVOLCHANGESTEP=\"${AUDIOVOLCHANGESTEP}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOVOLMAXLIMIT=\"${AUDIOVOLMAXLIMIT}\"" >> "${PATHDATA}/../settings/global.conf"

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -69,6 +69,7 @@ NOW=`date +%Y-%m-%d.%H:%M:%S`
 # recordplaylatest
 # readwifiipoverspeaker
 # bluetoothtoggle
+# switchaudioiface
 
 # The absolute path to the folder which contains all the scripts.
 # Unless you are working with symlinks, leave the following line untouched.
@@ -95,6 +96,9 @@ fi
 # this file does not need to exist
 # it will be created or deleted by this script
 VOLFILE=${PATHDATA}/../settings/Audio_Volume_Level
+
+# path to file storing the current audio iFace name
+IFACEFILE=${PATHDATA}/../settings/Audio_iFace_Name
 
 #############################################################
 
@@ -1026,6 +1030,36 @@ case $COMMAND in
     bluetoothtoggle)
         if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "   ${COMMAND}" >> ${PATHDATA}/../logs/debug.log; fi
         $PATHDATA/../components/bluetooth-sink-switch/bt-sink-switch.py $VALUE
+        ;;
+    switchaudioiface)
+        # will switch between primary/secondary audio iFace (e.g. speaker/headphones), if exist
+        dbg "   ${COMMAND}"
+        if [ "${VOLUMEMANAGER}" == "amixer" ]; then
+            NEXTAUDIOIFACE=$(((${AUDIOIFACEACTIVE}+1) % 2))
+            if [ -f ${IFACEFILE}_${NEXTAUDIOIFACE} ]; then
+                NEXTAUDIOIFACENAME=`<${IFACEFILE}_${NEXTAUDIOIFACE}`
+                if [ -f ${VOLFILE}_${NEXTAUDIOIFACE} ]; then
+                    NEXTAUDIOIFACEVOL=`<${VOLFILE}_${NEXTAUDIOIFACE}`
+                else
+                    NEXTAUDIOIFACEVOL=${AUDIOVOLMAXLIMIT}
+                fi
+                # store current volume
+                amixer sget \'${AUDIOIFACENAME}\' | grep -Po -m 1 '(?<=\[)[^]]*(?=%])' > ${VOLFILE}_${AUDIOIFACEACTIVE}
+                # unmute next audio iFace
+                amixer sset \'${NEXTAUDIOIFACENAME}\' ${NEXTAUDIOIFACEVOL}%
+                # mute current audio iFace
+                amixer sset \'${AUDIOIFACENAME}\' 0%
+                # store new active audio iFace
+                cp ${IFACEFILE}_${NEXTAUDIOIFACE} ${IFACEFILE}
+                echo "${NEXTAUDIOIFACE}" > ${PATHDATA}/../settings/Audio_iFace_Active
+                # create global config file because individual setting got changed (time consuming)
+                . ${PATHDATA}/inc.writeGlobalConfig.sh
+            else
+                dbg "Cannot switch audio iFace. ${IFACEFILE}_${NEXTAUDIOIFACE} does not exist."
+            fi
+        else
+            dbg "Command requires \"amixer\" as volume manager."
+        fi
         ;;
     *)
         echo Unknown COMMAND $COMMAND VALUE $VALUE

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -160,6 +160,10 @@ if [ "$CARDID" ]; then
             # decrease volume by x% set in Audio_Volume_Change_Step
             $PATHDATA/playout_controls.sh -c=volumedown
             ;;
+        $CMDSWITCHAUDIOIFACE)
+            # switch between primary/secondary audio iFaces
+            $PATHDATA/playout_controls.sh -c=switchaudioiface
+	    ;;
         $CMDSTOP)
             # kill all running audio players
             $PATHDATA/playout_controls.sh -c=playerstop

--- a/settings/rfid_trigger_play.conf.sample
+++ b/settings/rfid_trigger_play.conf.sample
@@ -29,6 +29,8 @@
 CMDVOLUP="%CMDVOLUP%"
 ### Volume down by one step
 CMDVOLDOWN="%CMDVOLDOWN%"
+### Switch between primary/secondary audio iFace
+CMDSWITCHAUDIOIFACE="%CMDSWITCHAUDIOIFACE%"
 ### Stop player
 CMDSTOP="%CMDSTOP%"
 ### Mute player


### PR DESCRIPTION
Adds a feature to switch between two audio iFaces (e.g.
speaker/headphone). Audio iFaces to swap are stored in files
`settings/Audio_iFace_Name_[01]` and need to be set manually, if feature
should be activated. The correlating volumes are stored in files
`Audio_Volume_Level_[01]`. Currently active iFace "ID" (0 or 1) is
stored in file `settings/Audio_iFace_Active` (default 0).

Scenario: You have equipped your Pi with a sound card that provides a
separate output (and volume control) for speaker and headphone, like the
WM8960 Hi-Fi HAT. This feature enables you to switch between the two
outputs. It can be triggered by RFID card or (not implemented) via GPIO
(button or switched jack). Compare discussion in #636, #786.

Restriction: Only works with `amixer` as volume manager and MPD output 
set to a general iFace (e.g. "Playback").

Many room for extension of features:
- setting audio iFaces via WebUI
- display current audio iFace in WebUI + trigger for switch
- trigger switch via GPIO (not needed in my case :-))
- generalisation for more than two audio iFaces (simple to implement, if
needed)
- multi volume control in WebUI and via RFID (not sure if handy)