### PR TITLE
(bugfix) Fixes bug in folder tree, related to special chars

### DIFF
--- a/htdocs/func.php
+++ b/htdocs/func.php
@@ -288,7 +288,7 @@ function index_folders_print($item, $key)
         }
     }
     $playlist = $contentTree[$key]['path_rel'];
-    $id = str_replace(",", "", $contentTree[$key]['id']);
+    $id = $contentTree[$key]['id'];
 /**/
     //print "<pre>\nkey:".$key." id:".$contentTree[$key]['id']." path_rel:".$contentTree[$key]['path_rel']; print_r($contentTree); print "</pre>"; //???
     //print "<pre>\nfiles:"; print_r($files); print "</pre>"; //???

--- a/htdocs/inc.viewFolderTree.php
+++ b/htdocs/inc.viewFolderTree.php
@@ -140,13 +140,8 @@ foreach($subfolders as $key => $subfolder) {
         // chop off the $Audio_Folders_Path in the beginning
         //$temp['path_rel'] = substr($folder."/".$value, strlen($Audio_Folders_Path) + 1, strlen($folder."/".$value));
         $temp['path_rel'] = substr($subfolder, strlen($Audio_Folders_Path) + 1, strlen($subfolder));
-        // some special version with no slashes or whitespaces for IDs on the panel collapse
-        $temp['id'] = preg_replace('/\//', '---', $temp['path_rel']);
-        $temp['id'] = preg_replace('/\ /', '-_-', $temp['id']);
-        $temp['id'] = preg_replace('/\[/', '_-', $temp['id']);
-        $temp['id'] = preg_replace('/\]/', '-_', $temp['id']);
-        $temp['id'] = preg_replace('/&/', 'and', $temp['id']);
-        $temp['id'] = "ID".preg_replace('/\:/', '-+-', $temp['id']);
+        // IDs on the panel collapse
+        $temp['id'] = "ID".$idcounter++;
         // count the level depth in the tree by counting the slashes in the path
         $temp['level'] = substr_count($temp['path_rel'], '/');
         // information about the content

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -124,16 +124,12 @@ foreach ($shortcutstemp as $shortcuttemp) {
 $audiofolders = array_filter(glob($Audio_Folders_Path.'/*'), 'is_dir');
 usort($audiofolders, 'strcasecmp');
 
-// counter for ID of each folder
+// counter for ID of each folder, increased when used (within inc.viewFolderTree.php)
 $idcounter = 0;
 
 // go through all folders
 foreach($audiofolders as $audiofolder) {
-    // increase ID counter
-    $idcounter++;
-    
     include('inc.viewFolderTree.php');
-    
 }
 
 ?>


### PR DESCRIPTION
Resolving #469 by simplifying collapse IDs in folder tree.
Make use of integers for collapse IDs rather than folder names to avoid
problem with any kind of non-allowed characters as ID value.

Simplifies corresponding code as no character replacement is required
for collapse IDs anymore.