### PR TITLE
Shortcuts volume commands of playout control

### DIFF
--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -101,6 +101,9 @@ VOLFILE=${PATHDATA}/../settings/Audio_Volume_Level
 # see following file for details:
 . ${PATHDATA}/inc.readArgsFromCommandLine.sh
 
+if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "VAR COMMAND: ${COMMAND}" >> ${PATHDATA}/../logs/debug.log; fi
+if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "VAR VALUE: ${VALUE}" >> ${PATHDATA}/../logs/debug.log; fi
+
 # Regex that declares commands for which the following code can be shortcut
 # and we can immediately jump to the switch-case statement. Increases execution
 # speed of these commands.
@@ -109,10 +112,6 @@ shortcutCommands="^(setvolume|volumedown|volumeup|mute)$"
 # Run the code from this block only, if the current command is not in "shortcutCommands"
 if [[ ! "$COMMAND" =~ $shortcutCommands ]]
 then
-    if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "VAR COMMAND: ${COMMAND}" >> ${PATHDATA}/../logs/debug.log; fi
-    if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "VAR VALUE: ${VALUE}" >> ${PATHDATA}/../logs/debug.log; fi
-
-
     ENABLE_CHAPTERS_FOR_EXTENSIONS="mp4,m4a,m4b,m4r"
     ENABLE_CHAPTERS_MIN_DURATION="600"
 

--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -101,92 +101,101 @@ VOLFILE=${PATHDATA}/../settings/Audio_Volume_Level
 # see following file for details:
 . ${PATHDATA}/inc.readArgsFromCommandLine.sh
 
-if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "VAR COMMAND: ${COMMAND}" >> ${PATHDATA}/../logs/debug.log; fi
-if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "VAR VALUE: ${VALUE}" >> ${PATHDATA}/../logs/debug.log; fi
+# Regex that declares commands for which the following code can be shortcut
+# and we can immediately jump to the switch-case statement. Increases execution
+# speed of these commands.
+shortcutCommands="^(setvolume|volumedown|volumeup|mute)$"
+
+# Run the code from this block only, if the current command is not in "shortcutCommands"
+if [[ ! "$COMMAND" =~ $shortcutCommands ]]
+then
+    if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "VAR COMMAND: ${COMMAND}" >> ${PATHDATA}/../logs/debug.log; fi
+    if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then echo "VAR VALUE: ${VALUE}" >> ${PATHDATA}/../logs/debug.log; fi
 
 
-ENABLE_CHAPTERS_FOR_EXTENSIONS="mp4,m4a,m4b,m4r"
-ENABLE_CHAPTERS_MIN_DURATION="600"
+    ENABLE_CHAPTERS_FOR_EXTENSIONS="mp4,m4a,m4b,m4r"
+    ENABLE_CHAPTERS_MIN_DURATION="600"
 
-function dbg {
-  if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then
-    echo "$1" >> ${PATHDATA}/../logs/debug.log;
-  fi
-}
+    function dbg {
+    if [ "${DEBUG_playout_controls_sh}" == "TRUE" ]; then
+        echo "$1" >> ${PATHDATA}/../logs/debug.log;
+    fi
+    }
 
-function sec_to_ms() {
-  SECONDSPART="$(cut -d '.' -f 1 <<< "$1")"
-  MILLISECONDSPART="$(cut -d '.' -f 2 <<< "$1")"
-  MILLISECONDSPART_NORMALIZED="$(echo "$MILLISECONDSPART" | cut -c1-3 | sed 's/^0*//')"
+    function sec_to_ms() {
+    SECONDSPART="$(cut -d '.' -f 1 <<< "$1")"
+    MILLISECONDSPART="$(cut -d '.' -f 2 <<< "$1")"
+    MILLISECONDSPART_NORMALIZED="$(echo "$MILLISECONDSPART" | cut -c1-3 | sed 's/^0*//')"
 
-  if [[ "" == "$SECONDSPART" ]]; then
-    SECONDSPART="0"
-  fi
+    if [[ "" == "$SECONDSPART" ]]; then
+        SECONDSPART="0"
+    fi
 
-  if [[ "" == "$MILLISECONDSPART_NORMALIZED" ]]; then
-    MILLISECONDSPART_NORMALIZED="0"
-  fi
-  echo "$((${SECONDSPART} * 1000 + ${MILLISECONDSPART_NORMALIZED}))"
-}
+    if [[ "" == "$MILLISECONDSPART_NORMALIZED" ]]; then
+        MILLISECONDSPART_NORMALIZED="0"
+    fi
+    echo "$((${SECONDSPART} * 1000 + ${MILLISECONDSPART_NORMALIZED}))"
+    }
 
-AUDIO_FOLDERS_PATH=$(cat "${PATHDATA}/../settings/Audio_Folders_Path")
+    AUDIO_FOLDERS_PATH=$(cat "${PATHDATA}/../settings/Audio_Folders_Path")
 
-CURRENT_SONG_INFO=$(echo -e "currentsong\nclose" | nc -w 1 localhost 6600)
-CURRENT_SONG_FILE=$(echo "$CURRENT_SONG_INFO" | grep -o -P '(?<=file: ).*')
-CURRENT_SONG_FILE_ABS="${AUDIO_FOLDERS_PATH}/${CURRENT_SONG_FILE}"
-dbg "current file: $CURRENT_SONG_FILE_ABS"
+    CURRENT_SONG_INFO=$(echo -e "currentsong\nclose" | nc -w 1 localhost 6600)
+    CURRENT_SONG_FILE=$(echo "$CURRENT_SONG_INFO" | grep -o -P '(?<=file: ).*')
+    CURRENT_SONG_FILE_ABS="${AUDIO_FOLDERS_PATH}/${CURRENT_SONG_FILE}"
+    dbg "current file: $CURRENT_SONG_FILE_ABS"
 
-CURRENT_SONG_DIR="$(dirname -- "$CURRENT_SONG_FILE_ABS")"
-CURRENT_SONG_BASENAME="$(basename -- "${CURRENT_SONG_FILE_ABS}")"
-CURRENT_SONG_FILE_EXT="${CURRENT_SONG_BASENAME##*.}"
-CURRENT_SONG_ELAPSED=$(echo -e "status\nclose" | nc -w 1 localhost 6600 | grep -o -P '(?<=elapsed: ).*')
-CURRENT_SONG_DURATION=$(echo -e "status\nclose" | nc -w 1 localhost 6600 | grep -o -P '(?<=duration: ).*')
+    CURRENT_SONG_DIR="$(dirname -- "$CURRENT_SONG_FILE_ABS")"
+    CURRENT_SONG_BASENAME="$(basename -- "${CURRENT_SONG_FILE_ABS}")"
+    CURRENT_SONG_FILE_EXT="${CURRENT_SONG_BASENAME##*.}"
+    CURRENT_SONG_ELAPSED=$(echo -e "status\nclose" | nc -w 1 localhost 6600 | grep -o -P '(?<=elapsed: ).*')
+    CURRENT_SONG_DURATION=$(echo -e "status\nclose" | nc -w 1 localhost 6600 | grep -o -P '(?<=duration: ).*')
 
-CHAPTERS_FILE="${CURRENT_SONG_DIR}/${CURRENT_SONG_BASENAME%.*}.chapters.json"
-dbg "chapters file: $CHAPTERS_FILE"
+    CHAPTERS_FILE="${CURRENT_SONG_DIR}/${CURRENT_SONG_BASENAME%.*}.chapters.json"
+    dbg "chapters file: $CHAPTERS_FILE"
 
-if [ "$(grep -wo "$CURRENT_SONG_FILE_EXT" <<< "$ENABLE_CHAPTERS_FOR_EXTENSIONS")" == "$CURRENT_SONG_FILE_EXT" ]; then
-  CHAPTER_SUPPORT_FOR_EXTENSION="1"
-else
-  CHAPTER_SUPPORT_FOR_EXTENSION="0"
-fi
-dbg "chapters for extension enabled: $CHAPTER_SUPPORT_FOR_EXTENSION"
-
-
-if [ "$(printf "${CURRENT_SONG_DURATION}\n${ENABLE_CHAPTERS_MIN_DURATION}\n" | sort -g | head -1)" == "${ENABLE_CHAPTERS_MIN_DURATION}" ]; then
-  CHAPTER_SUPPORT_FOR_DURATION="1"
-else
-  CHAPTER_SUPPORT_FOR_DURATION="0"
-fi
-dbg "chapters for duration enabled: $CHAPTER_SUPPORT_FOR_DURATION"
-
-if [ "${CHAPTER_SUPPORT_FOR_EXTENSION}${CHAPTER_SUPPORT_FOR_DURATION}" == "11" ]; then
-  if ! [ -f "${CHAPTERS_FILE}" ]; then
-    CHAPTERS_COUNT="0"
-    dbg "chaptes file does not exist - export triggered"
-    ffprobe -i "${CURRENT_SONG_FILE_ABS}" -print_format json -show_chapters -loglevel error > "${CHAPTERS_FILE}" &
-  else
-    CHAPTERS_COUNT="$(grep  '"id":' "${CHAPTERS_FILE}" | wc -l )"
-    dbg "chapters file does exist, chapter count: $CHAPTERS_COUNT"
-  fi
+    if [ "$(grep -wo "$CURRENT_SONG_FILE_EXT" <<< "$ENABLE_CHAPTERS_FOR_EXTENSIONS")" == "$CURRENT_SONG_FILE_EXT" ]; then
+    CHAPTER_SUPPORT_FOR_EXTENSION="1"
+    else
+    CHAPTER_SUPPORT_FOR_EXTENSION="0"
+    fi
+    dbg "chapters for extension enabled: $CHAPTER_SUPPORT_FOR_EXTENSION"
 
 
-  CHAPTER_START_TIMES="$( ( echo -e $CURRENT_SONG_ELAPSED & grep 'start_time' "$CHAPTERS_FILE" | cut -d '"' -f 4 | sed 's/000$//') | sort -V)"
-  ELAPSED_MATCH_CHAPTER_COUNT=$(grep "$CURRENT_SONG_ELAPSED" <<< "$CHAPTER_START_TIMES" | wc -l)
+    if [ "$(printf "${CURRENT_SONG_DURATION}\n${ENABLE_CHAPTERS_MIN_DURATION}\n" | sort -g | head -1)" == "${ENABLE_CHAPTERS_MIN_DURATION}" ]; then
+    CHAPTER_SUPPORT_FOR_DURATION="1"
+    else
+    CHAPTER_SUPPORT_FOR_DURATION="0"
+    fi
+    dbg "chapters for duration enabled: $CHAPTER_SUPPORT_FOR_DURATION"
 
-  # elapsed and chapter start exactly match -> skip one line
-  if [ "$ELAPSED_MATCH_CHAPTER_COUNT" == "2" ]; then
-    PREV_CHAPTER_START=$(grep "$CURRENT_SONG_ELAPSED" -B 1 <<< "$CHAPTER_START_TIMES" | head -n1)
-    CURRENT_CHAPTER_START="$CURRENT_SONG_ELAPSED"
-  else
-    PREV_CHAPTER_START=$(grep "$CURRENT_SONG_ELAPSED" -B 2 <<< "$CHAPTER_START_TIMES" | head -n1)
-    CURRENT_CHAPTER_START=$(grep "$CURRENT_SONG_ELAPSED" -B 1 <<< "$CHAPTER_START_TIMES" | head -n1)
-  fi
+    if [ "${CHAPTER_SUPPORT_FOR_EXTENSION}${CHAPTER_SUPPORT_FOR_DURATION}" == "11" ]; then
+    if ! [ -f "${CHAPTERS_FILE}" ]; then
+        CHAPTERS_COUNT="0"
+        dbg "chaptes file does not exist - export triggered"
+        ffprobe -i "${CURRENT_SONG_FILE_ABS}" -print_format json -show_chapters -loglevel error > "${CHAPTERS_FILE}" &
+    else
+        CHAPTERS_COUNT="$(grep  '"id":' "${CHAPTERS_FILE}" | wc -l )"
+        dbg "chapters file does exist, chapter count: $CHAPTERS_COUNT"
+    fi
 
-  NEXT_CHAPTER_START=$(grep "$CURRENT_SONG_ELAPSED" -A 1 <<< "$CHAPTER_START_TIMES" | tail -n1)
-fi
 
-# SHUFFLE_STATUS=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep -o -P '(?<=random: ).*')
+    CHAPTER_START_TIMES="$( ( echo -e $CURRENT_SONG_ELAPSED & grep 'start_time' "$CHAPTERS_FILE" | cut -d '"' -f 4 | sed 's/000$//') | sort -V)"
+    ELAPSED_MATCH_CHAPTER_COUNT=$(grep "$CURRENT_SONG_ELAPSED" <<< "$CHAPTER_START_TIMES" | wc -l)
+
+    # elapsed and chapter start exactly match -> skip one line
+    if [ "$ELAPSED_MATCH_CHAPTER_COUNT" == "2" ]; then
+        PREV_CHAPTER_START=$(grep "$CURRENT_SONG_ELAPSED" -B 1 <<< "$CHAPTER_START_TIMES" | head -n1)
+        CURRENT_CHAPTER_START="$CURRENT_SONG_ELAPSED"
+    else
+        PREV_CHAPTER_START=$(grep "$CURRENT_SONG_ELAPSED" -B 2 <<< "$CHAPTER_START_TIMES" | head -n1)
+        CURRENT_CHAPTER_START=$(grep "$CURRENT_SONG_ELAPSED" -B 1 <<< "$CHAPTER_START_TIMES" | head -n1)
+    fi
+
+    NEXT_CHAPTER_START=$(grep "$CURRENT_SONG_ELAPSED" -A 1 <<< "$CHAPTER_START_TIMES" | tail -n1)
+    fi
+
+    # SHUFFLE_STATUS=$(echo -e status\\nclose | nc -w 1 localhost 6600 | grep -o -P '(?<=random: ).*')
+fi # END COMMANDS SHORTCUT
 
 case $COMMAND in
     shutdown)


### PR DESCRIPTION
This shortcuts in `playout_control.sh` reduces the execution time of `volumeup`, `volumedown` etc. on my RPi Zero by the half:

```sh
# before
pi@raspberrypi:~/RPi-Jukebox-RFID/scripts $ time ./playout_controls.sh -c=volumedown
Simple mixer control 'Master',0
  Capabilities: volume
  Playback channels: Front Left - Front Right
  Capture channels: Front Left - Front Right
  Limits: 0 - 255
  Front Left: 3 [1%]
  Front Right: 3 [1%]

real    0m0.615s
user    0m0.232s
sys     0m0.290s


#after
pi@raspberrypi:~/RPi-Jukebox-RFID/scripts $ time ./playout_controls.sh -c=volumedown
Simple mixer control 'Master',0
  Capabilities: volume
  Playback channels: Front Left - Front Right
  Capture channels: Front Left - Front Right
  Limits: 0 - 255
  Front Left: 3 [1%]
  Front Right: 3 [1%]

real    0m0.290s
user    0m0.159s
sys     0m0.101s