### PR TITLE
Added ready-for-card status LED GPIO control

### DIFF
--- a/components/gpio_control/GPIODevices/led.py
+++ b/components/gpio_control/GPIODevices/led.py
@@ -2,7 +2,6 @@ import logging
 import time
 from os import system
 
-import mpd
 from RPi import GPIO
 
 GPIO.setmode(GPIO.BCM)
@@ -30,37 +29,11 @@ class LED:
         return GPIO.input(self.pin)
 
 
-class MPDStatusLED(LED):
-    logger = logging.getLogger("MPDStatusLED")
+class StatusLED(LED):
+    logger = logging.getLogger("StatusLED")
 
-    def __init__(self, pin, host='localhost', port=6600, name='MPDStatusLED'):
-        super(MPDStatusLED, self).__init__(pin, initial_value=False, name=name)
-        self.mpc = mpd.MPDClient()
-        self.host = host
-        self.port = port
-        self.logger.info('Waiting for MPD Connection on {}:{}'.format(
-            self.host, self.port))
-        while not self.has_mpd_connection():
-            self.logger.debug('No MPD Connection yet established')
-            time.sleep(1)
-        self.logger.info('Connection to MPD server on host {}:{} established'.format(self.host, self.port))
-        self.on()
-
-    def has_mpd_connection(self):
-        self.mpc.disconnect()
-        try:
-            self.mpc.connect(self.host, self.port)
-            self.mpc.ping()
-            self.mpc.disconnect()
-            return True
-        except ConnectionError:
-            return False
-
-class StartupScriptsStatusLED(LED):
-    logger = logging.getLogger("StartupScriptsStatusLED")
-
-    def __init__(self, pin, name='StartupScriptsStatusLED'):
-        super(StartupScriptsStatusLED, self).__init__(pin, initial_value=False, name=name)
+    def __init__(self, pin, name='StatusLED'):
+        super(StatusLED, self).__init__(pin, initial_value=False, name=name)
         self.logger.info('Waiting for phoniebox-startup-scripts service to be active')
         systemctlCmd = 'systemctl is-active --quiet phoniebox-startup-scripts.service'
         while system(systemctlCmd) != 0:

--- a/components/gpio_control/GPIODevices/led.py
+++ b/components/gpio_control/GPIODevices/led.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from os import system
 
 import mpd
 from RPi import GPIO
@@ -54,3 +55,17 @@ class MPDStatusLED(LED):
             return True
         except ConnectionError:
             return False
+
+class StartupScriptsStatusLED(LED):
+    logger = logging.getLogger("StartupScriptsStatusLED")
+
+    def __init__(self, pin, name='StartupScriptsStatusLED'):
+        super(StartupScriptsStatusLED, self).__init__(pin, initial_value=False, name=name)
+        self.logger.info('Waiting for phoniebox-startup-scripts service to be active')
+        systemctlCmd = 'systemctl is-active --quiet phoniebox-startup-scripts.service'
+        while system(systemctlCmd) != 0:
+            self.logger.debug('phoniebox-startup-scripts service not yet active')
+            time.sleep(1)
+        self.logger.info('phoniebox-startup-scripts service active')
+        self.on()
+

--- a/components/gpio_control/example_configs/gpio_settings_status_led.ini
+++ b/components/gpio_control/example_configs/gpio_settings_status_led.ini
@@ -3,5 +3,5 @@ enabled: True
 
 [StatusLED]
 enable: True
-Type: StartupScriptsStatusLED
+Type: StatusLED
 Pin: 14

--- a/components/gpio_control/example_configs/gpio_settings_status_led.ini
+++ b/components/gpio_control/example_configs/gpio_settings_status_led.ini
@@ -1,0 +1,7 @@
+[DEFAULT]
+enabled: True
+
+[StatusLED]
+enable: True
+Type: StartupScriptsStatusLED
+Pin: 14

--- a/components/gpio_control/gpio_control.py
+++ b/components/gpio_control/gpio_control.py
@@ -8,7 +8,6 @@ import function_calls
 from signal import pause
 from RPi import GPIO
 # from GPIODevices.VolumeControl import VolumeControl
-# from GPIODevices.led import LED, MPDStatusLED
 
 class gpio_control():
 
@@ -61,16 +60,8 @@ class gpio_control():
             return LED(config.getint('Pin'),
                                 name=deviceName,
                                 initial_value=config.getboolean('initial_value', fallback=True))
-        elif device_type == 'MPDStatusLED':
-            return MPDStatusLED(config.getint('Pin'),
-                                host=config.get('host', fallback='localhost'),
-                                port=config.getint('port', fallback=6600),
-                                name=deviceName
-                                )
-        elif device_type == 'StartupScriptsStatusLED':
-            return StartupScriptsStatusLED(config.getint('Pin'),
-                                name=deviceName
-                                )
+        elif device_type in ('StatusLED', 'MPDStatusLED'):
+            return StatusLED(config.getint('Pin'), name=deviceName)
         elif device_type == 'RotaryEncoder':
             return RotaryEncoder(config.getint('pinUp'),
                     config.getint('pinDown'),

--- a/components/gpio_control/gpio_control.py
+++ b/components/gpio_control/gpio_control.py
@@ -67,6 +67,10 @@ class gpio_control():
                                 port=config.getint('port', fallback=6600),
                                 name=deviceName
                                 )
+        elif device_type == 'StartupScriptsStatusLED':
+            return StartupScriptsStatusLED(config.getint('Pin'),
+                                name=deviceName
+                                )
         elif device_type == 'RotaryEncoder':
             return RotaryEncoder(config.getint('pinUp'),
                     config.getint('pinDown'),

--- a/components/gpio_control/test/gpio_settings_test.ini
+++ b/components/gpio_control/test/gpio_settings_test.ini
@@ -5,7 +5,7 @@ enabled: True
 ; RotaryEncoder
 ; TwoButtonControl
 ; SimpleButton = Button
-; StartupScriptsStatusLED
+; StatusLED
 [VolumeControl]
 enabled: True
 Type: RotaryEncoder
@@ -85,5 +85,5 @@ pull_up: True
 
 [StatusLED]
 enable: True
-Type: StartupScriptsStatusLED
+Type: StatusLED
 Pin: 14

--- a/components/gpio_control/test/gpio_settings_test.ini
+++ b/components/gpio_control/test/gpio_settings_test.ini
@@ -5,6 +5,7 @@ enabled: True
 ; RotaryEncoder
 ; TwoButtonControl
 ; SimpleButton = Button
+; StartupScriptsStatusLED
 [VolumeControl]
 enabled: True
 Type: RotaryEncoder
@@ -63,6 +64,7 @@ Pin: 19
 pull_up: True
 hold_time: 0.3
 hold_repeat: True
+
 [NextSong]
 enabled: False
 Type:  Button
@@ -80,3 +82,8 @@ enabled: False
 Type:  Button
 Pin: 21
 pull_up: True
+
+[StatusLED]
+enable: True
+Type: StartupScriptsStatusLED
+Pin: 14


### PR DESCRIPTION
Adds a status LED GPIO control that lights up the LED if the phoniebox
is ready (finished startup scripts, checked via systemctl). Type called
`StartupScriptsStatusLED`.

Comparison to MPDStatusLED:
MPDStatusLED lights up the LED if MPD is started which is (on a RPi
zero seconds) before the phoniebox is actually ready for its first card.
Therefore, another status LED indicating whether startup completely
finished appears useful.