### PR TITLE
feat: keep USB Button Encoder settings during update

### DIFF
--- a/scripts/installscripts/buster-install-default-with-autohotspot.sh
+++ b/scripts/installscripts/buster-install-default-with-autohotspot.sh
@@ -372,6 +372,18 @@ https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/Using-GPIO-hardware-buttons"
                 # append variables to config file
                 echo "EXISTINGuseGpio=$EXISTINGuseGpio" >> "${HOME_DIR}/PhonieboxInstall.conf"
 
+                read -rp "Button USB Encoder: use existing device and button mapping? [Y/n] " response
+                case "$response" in
+                    [nN][oO]|[nN])
+                        EXISTINGuseButtonUSBEncoder=NO
+                        ;;
+                    *)
+                        EXISTINGuseButtonUSBEncoder=YES
+                        ;;
+                esac
+                # append variables to config file
+                echo "EXISTINGuseButtonUSBEncoder=$EXISTINGuseButtonUSBEncoder" >> "${HOME_DIR}/PhonieboxInstall.conf"
+
                 echo "Thanks. Got it."
                 echo "The existing install can be found in the BACKUP directory."
                 read -rp "Hit ENTER to proceed to the next step." INPUT
@@ -428,7 +440,7 @@ config_audio_interface() {
     esac
     # append variables to config file
     echo "AUDIOiFace=\"$AUDIOiFace\"" >> "${HOME_DIR}/PhonieboxInstall.conf"
-    echo "Your iFace is called'$AUDIOiFace'"
+    echo "Your iFace is called '$AUDIOiFace'"
     read -rp "Hit ENTER to proceed to the next step." INPUT
 }
 
@@ -1082,6 +1094,19 @@ existing_assets() {
         if [ "${EXISTINGuseGpio}" == "YES" ]; then
             # copy from backup to new install
             cp "${backup_dir}"/settings/gpio_settings.ini "${jukebox_dir}"/settings/gpio_settings.ini
+        fi
+
+        # Button USB Encoder: use existing file
+        if [ "${EXISTINGuseButtonUSBEncoder}" == "YES" ]; then
+            # copy from backup to new install
+            cp "${backup_dir}"/components/controls/buttons_usb_encoder/deviceName.txt "${jukebox_dir}"/components/controls/buttons_usb_encoder/deviceName.txt
+            cp "${backup_dir}"/components/controls/buttons_usb_encoder/buttonMap.json "${jukebox_dir}"/components/controls/buttons_usb_encoder/buttonMap.json
+            # make buttons_usb_encoder.py ready to be use from phoniebox-buttons-usb-encoder service
+            sudo chmod +x "${jukebox_dir}"/components/controls/buttons_usb_encoder/buttons_usb_encoder.py
+            # make sure service is still enabled by registering again
+            sudo cp -v "${jukebox_dir}"/components/controls/buttons_usb_encoder/phoniebox-buttons-usb-encoder.service.sample /etc/systemd/system/phoniebox-buttons-usb-encoder.service
+            sudo systemctl start phoniebox-buttons-usb-encoder.service
+            sudo systemctl enable phoniebox-buttons-usb-encoder.service
         fi
 
         # Sound effects: use existing startup / shutdown sounds

--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -372,6 +372,18 @@ https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/Using-GPIO-hardware-buttons"
                 # append variables to config file
                 echo "EXISTINGuseGpio=$EXISTINGuseGpio" >> "${HOME_DIR}/PhonieboxInstall.conf"
 
+                read -rp "Button USB Encoder: use existing device and button mapping? [Y/n] " response
+                case "$response" in
+                    [nN][oO]|[nN])
+                        EXISTINGuseButtonUSBEncoder=NO
+                        ;;
+                    *)
+                        EXISTINGuseButtonUSBEncoder=YES
+                        ;;
+                esac
+                # append variables to config file
+                echo "EXISTINGuseButtonUSBEncoder=$EXISTINGuseButtonUSBEncoder" >> "${HOME_DIR}/PhonieboxInstall.conf"
+
                 echo "Thanks. Got it."
                 echo "The existing install can be found in the BACKUP directory."
                 read -rp "Hit ENTER to proceed to the next step." INPUT
@@ -1065,6 +1077,19 @@ existing_assets() {
         if [ "${EXISTINGuseGpio}" == "YES" ]; then
             # copy from backup to new install
             cp "${backup_dir}"/settings/gpio_settings.ini "${jukebox_dir}"/settings/gpio_settings.ini
+        fi
+
+        # Button USB Encoder: use existing file
+        if [ "${EXISTINGuseButtonUSBEncoder}" == "YES" ]; then
+            # copy from backup to new install
+            cp "${backup_dir}"/components/controls/buttons_usb_encoder/deviceName.txt "${jukebox_dir}"/components/controls/buttons_usb_encoder/deviceName.txt
+            cp "${backup_dir}"/components/controls/buttons_usb_encoder/buttonMap.json "${jukebox_dir}"/components/controls/buttons_usb_encoder/buttonMap.json
+            # make buttons_usb_encoder.py ready to be use from phoniebox-buttons-usb-encoder service
+            sudo chmod +x "${jukebox_dir}"/components/controls/buttons_usb_encoder/buttons_usb_encoder.py
+            # make sure service is still enabled by registering again
+            sudo cp -v "${jukebox_dir}"/components/controls/buttons_usb_encoder/phoniebox-buttons-usb-encoder.service.sample /etc/systemd/system/phoniebox-buttons-usb-encoder.service
+            sudo systemctl start phoniebox-buttons-usb-encoder.service
+            sudo systemctl enable phoniebox-buttons-usb-encoder.service
         fi
 
         # Sound effects: use existing startup / shutdown sounds

--- a/scripts/installscripts/stretch-install-default.sh
+++ b/scripts/installscripts/stretch-install-default.sh
@@ -234,6 +234,18 @@ echo "#####################################################
             # append variables to config file
             echo "EXISTINGuseSounds=$EXISTINGuseSounds" >> "${PATHDATA}/PhonieboxInstall.conf"
 
+            read -r -p "Button USB Encoder: use existing device and button mapping? [Y/n] " response
+            case "$response" in
+                [nN][oO]|[nN])
+                    EXISTINGuseButtonUSBEncoder=NO
+                    ;;
+                *)
+                    EXISTINGuseButtonUSBEncoder=YES
+                    ;;
+            esac
+            # append variables to config file
+            echo "EXISTINGuseButtonUSBEncoder=$EXISTINGuseButtonUSBEncoder" >> "${PATHDATA}/PhonieboxInstall.conf"
+
             echo "Thanks. Got it."
             echo "The existing install can be found in the BACKUP directory."
             echo "Hit ENTER to proceed to the next step."
@@ -769,6 +781,19 @@ then
         # copy from backup to new install
         mv /home/pi/BACKUP/shared/startupsound.mp3 /home/pi/RPi-Jukebox-RFID/shared/startupsound.mp3
         mv /home/pi/BACKUP/shared/shutdownsound.mp3 /home/pi/RPi-Jukebox-RFID/shared/shutdownsound.mp3
+    fi
+
+    # Button USB Encoder: use existing file
+    if [ $EXISTINGuseButtonUSBEncoder == "YES" ]; then
+        # copy from backup to new install
+        mv /home/pi/BACKUP/components/controls/buttons_usb_encoder/deviceName.txt /home/pi/RPi-Jukebox-RFID/components/controls/buttons_usb_encoder/deviceName.txt
+        mv /home/pi/BACKUP/components/controls/buttons_usb_encoder/buttonMap.json /home/pi/RPi-Jukebox-RFID/components/controls/buttons_usb_encoder/buttonMap.json
+        # make buttons_usb_encoder.py ready to be use from phoniebox-buttons-usb-encoder service
+        sudo chmod +x /home/pi/RPi-Jukebox-RFID/components/controls/buttons_usb_encoder/buttons_usb_encoder.py
+        # make sure service is still enabled by registering again
+        sudo cp -v /home/pi/RPi-Jukebox-RFID/components/controls/buttons_usb_encoder/phoniebox-buttons-usb-encoder.service.sample /etc/systemd/system/phoniebox-buttons-usb-encoder.service
+        sudo systemctl start phoniebox-buttons-usb-encoder.service
+        sudo systemctl enable phoniebox-buttons-usb-encoder.service
     fi
 
 fi


### PR DESCRIPTION
Provide possibility to keep USB button encoder mappings during update.

tested with buster-install-default.sh