### PR TITLE
fix: handle list of keycodes in buttons usb encoder

### DIFF
--- a/components/controls/buttons_usb_encoder/README.md
+++ b/components/controls/buttons_usb_encoder/README.md
@@ -14,6 +14,6 @@ Tested Devices:
 
 1. Plug in your USB Encoder. You don't need to install any drivers. After plugging in, the USB encoder acts like an
    input device.
-2. Run the script `setup-buttons-usb-encoder.sh` to set up your USB Encoder (choose the device and map the buttons).
+2. Navigate to your RPi-Jukebox home directory and run the script `setup-buttons-usb-encoder.sh` to set up your USB Encoder (choose the device and map the buttons).
 
 ![USB Encoder schematics](buttons-usb-encoder.jpg)

--- a/components/controls/buttons_usb_encoder/buttons_usb_encoder.py
+++ b/components/controls/buttons_usb_encoder/buttons_usb_encoder.py
@@ -19,7 +19,7 @@ try:
             if keyevent.keystate == KeyEvent.key_down:
                 button_string = keyevent.keycode
                 if type(button_string) is list:
-                    button_string = '-'.join(button_string)
+                    button_string = '-'.join(sorted(button_string))
                 try:
                     function_name = button_map[button_string]
                     try:

--- a/components/controls/buttons_usb_encoder/buttons_usb_encoder.py
+++ b/components/controls/buttons_usb_encoder/buttons_usb_encoder.py
@@ -17,14 +17,17 @@ try:
         if event.type == ecodes.EV_KEY:
             keyevent = categorize(event)
             if keyevent.keystate == KeyEvent.key_down:
+                button_string = keyevent.keycode
+                if type(button_string) is list:
+                    button_string = '-'.join(button_string)
                 try:
-                    function_name = button_map[keyevent.keycode]
+                    function_name = button_map[button_string]
                     try:
                         getattr(components.gpio_control.function_calls, function_name)()
                     except:
                         logger.warning(
-                            "Function " + function_name + " not found in function_calls.py (mapped from button: " + keyevent.keycode + ")")
+                            "Function " + function_name + " not found in function_calls.py (mapped from button: " + button_string + ")")
                 except KeyError:
-                    logger.warning("Button " + keyevent.keycode + " not mapped to any function.")
+                    logger.warning("Button " + button_string + " not mapped to any function.")
 except:
     logger.error("An error with Buttons USB Encoder occurred.")

--- a/components/controls/buttons_usb_encoder/map_buttons_usb_encoder.py
+++ b/components/controls/buttons_usb_encoder/map_buttons_usb_encoder.py
@@ -32,7 +32,7 @@ try:
                     if keyevent.keystate == KeyEvent.key_down:
                         button_string = keyevent.keycode
                         if type(button_string) is list:
-                            button_string = '-'.join(button_string)
+                            button_string = '-'.join(sorted(button_string))
                         button_map[button_string] = function_name
                         print("Button " + button_string + " is now mapped to " + function_name_short)
                         break

--- a/components/controls/buttons_usb_encoder/map_buttons_usb_encoder.py
+++ b/components/controls/buttons_usb_encoder/map_buttons_usb_encoder.py
@@ -30,8 +30,11 @@ try:
                 if event.type == ecodes.EV_KEY:
                     keyevent = categorize(event)
                     if keyevent.keystate == KeyEvent.key_down:
-                        button_map[keyevent.keycode] = function_name
-                        print("Button " + keyevent.keycode + " is now mapped to " + function_name_short)
+                        button_string = keyevent.keycode
+                        if type(button_string) is list:
+                            button_string = '-'.join(button_string)
+                        button_map[button_string] = function_name
+                        print("Button " + button_string + " is now mapped to " + function_name_short)
                         break
         except KeyboardInterrupt:
             continue

--- a/components/controls/buttons_usb_encoder/setup-buttons-usb-encoder.sh
+++ b/components/controls/buttons_usb_encoder/setup-buttons-usb-encoder.sh
@@ -14,6 +14,12 @@ question() {
     esac
 }
 
+if [ "$PWD" != "$JUKEBOX_HOME_DIR" ]
+then
+    printf "Please execute script from %s directory\n" $JUKEBOX_HOME_DIR
+    exit 0
+fi
+
 printf "Please make sure that the Buttons USB Encoder and the buttons are connected before continuing...\n"
 question "Continue"
 


### PR DESCRIPTION
There is a possibility, that the buttons USB encoder sends a list of pressed keys. The previous implementation ended up in an error. This fix now handles lists of keycodes.
Additionally there is a hint that the setup script has to be executed from RPi home directory.