### PR TITLE
fix: move path append command in buttons usb encoder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/components/controls/buttons_usb_encoder/ @jeripeierSBB
+/scripts/installscripts/buster-install-default.sh @jeripeierSBB
+/scripts/installscripts/buster-install-default-with-autohotspot.sh @jeripeierSBB

--- a/components/controls/buttons_usb_encoder/buttons_usb_encoder.py
+++ b/components/controls/buttons_usb_encoder/buttons_usb_encoder.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 import sys
+
+sys.path.append(".") # This command should be before imports of components
+
 import logging
 from evdev import categorize, ecodes, KeyEvent
 from io_buttons_usb_encoder import button_map, current_device
 from components.gpio_control.function_calls import phoniebox_function_calls
 
-sys.path.append(".")
 
 logger = logging.getLogger(__name__)
 

--- a/components/controls/buttons_usb_encoder/map_buttons_usb_encoder.py
+++ b/components/controls/buttons_usb_encoder/map_buttons_usb_encoder.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
 import sys
+
+sys.path.append(".") # This command should be before imports of components
+
 from evdev import categorize, ecodes, KeyEvent
 from io_buttons_usb_encoder import current_device, write_button_map
 import components.gpio_control.function_calls
-
-sys.path.append(".")
-
 
 try:
     functions = list(


### PR DESCRIPTION
Script can only be executed if sys.path.append(".") is executed before imports.
This bug (https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/1249#issuecomment-803221057) I think was accidentally introduced with change #1332.

Also introduced git CODEOWNERS file, which automatically adds reviewers if a PR affects a specific scope. For now I just configured myself. File can be updated for everyone needs :-)
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
