### PR TITLE
Ignore settings/PhonieboxInstall.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ settings/version
 htdocs/config.php
 scripts/deviceName.txt
 scripts/gpio-buttons.py
+settings/PhonieboxInstall.conf
 
 shared/*
 playlists/*


### PR DESCRIPTION
`settings/PhonieboxInstall.conf` holds secrets like wifi passwords and others, which should not get checked into VCS.