### PR TITLE
command line script for linking RFID cards to folders & fixing broken links 

### DIFF
--- a/scripts/cli-player.py
+++ b/scripts/cli-player.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+import os
+import subprocess
+from organizeFiles import readFolders
+
+
+if __name__ == "__main__":
+    baseDir = "/home/pi/RPi-Jukebox-RFID"
+    shortcutsDir = os.path.join(baseDir, "shared", "shortcuts")
+    audioDir = os.path.join(baseDir, "shared", "audiofolders")
+    scriptsDir = os.path.join(baseDir, "scripts")
+
+    print("=== audio folders:")
+    audioFolders = {}
+    folders = readFolders(audioDir=audioDir)
+    lc2 = 0
+    for d2, hasFolderConf2 in sorted(folders.items()):
+        print(str(lc2) + ": " + d2)
+        audioFolders[lc2] = d2
+        lc2 = lc2 + 1
+
+    while True:
+        i = input("select folder: ")
+        if len(i.strip()) == 0:
+            break
+        if not i.isnumeric():
+            print("not a number.")
+            continue
+        inum = int(i)
+        if inum not in audioFolders:
+            print("invalid option")
+            continue
+        selectedFolder = audioFolders[inum]
+        print("  playing " + selectedFolder)
+        subprocess.check_output([scriptsDir + '/rfid_trigger_play.sh', '--dir=' + selectedFolder], shell=False)
+
+    print("bye.")
+

--- a/scripts/cli-player.py
+++ b/scripts/cli-player.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
 
     while True:
         i = input("select folder: ")
-        if len(i.strip()) == 0:
+        if i == "quit" or i == "exit":
             break
         if not i.isnumeric():
             print("not a number.")

--- a/scripts/cli-player.py
+++ b/scripts/cli-player.py
@@ -23,11 +23,13 @@ if __name__ == "__main__":
         lc2 = lc2 + 1
 
     while True:
-        i = input("select folder: ")
+        i = input("select folder / enter mpc command: ")
         if i == "quit" or i == "exit":
             break
         if not i.isnumeric():
-            print("not a number.")
+            if len(i.strip()) != 0:
+                print("mpc " + i)
+                subprocess.call(["mpc"] + i.split(" "))
             continue
         inum = int(i)
         if inum not in audioFolders:

--- a/scripts/organizeFiles.py
+++ b/scripts/organizeFiles.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+import sys
+import os
+
+
+musicConf = """CURRENTFILENAME="filename"
+ELAPSED="0"
+PLAYSTATUS="Stopped"
+RESUME="OFF"
+SHUFFLE="OFF"
+LOOP="OFF"
+SINGLE="OFF"
+"""
+
+audiobookConf = """CURRENTFILENAME="filename"
+ELAPSED="0"
+PLAYSTATUS="Stopped"
+RESUME="ON"
+SHUFFLE="OFF"
+LOOP="OFF"
+SINGLE="OFF"
+"""
+
+
+def readShortcuts(shortcutsDir):
+    result = {}
+    for f in os.listdir(shortcutsDir):
+        absf = os.path.join(shortcutsDir, f)
+        if os.path.isfile(absf):
+            val = []
+            with open(absf, "r") as fobj:
+                for line in fobj:
+                    if len(line.strip()) != 0:
+                        val.append(line.rstrip())
+            result[f] = val
+    return result
+
+
+def readFolders(audioDir, relpath=None, isFirst=True):
+    result = {}
+    relpath = "" if relpath is None else relpath
+    hasAudioFiles = False
+    for f in os.listdir(audioDir):
+        absf = os.path.join(audioDir, f)
+        if os.path.isfile(absf):
+            if not isFirst:
+                hasAudioFiles = True
+        elif os.path.isdir(absf):
+            childResult = readFolders(audioDir=absf, relpath=os.path.join(relpath, f), isFirst=False)
+            for k, v in childResult.items():
+                assert(k not in result)
+                result[k] = v
+    if hasAudioFiles:
+        result[relpath] = os.path.exists(os.path.join(audioDir, "folder.conf"))
+    return result
+
+
+def _deleteBrokenSymlink(shortcutsDir, cardid, d):
+    i = input("\ndelete broken symlink [" + cardid + " --> " + str(d) + "]? [y/N]")
+    if i == "y":
+        print("deleting symlink.")
+        os.remove(os.path.join(shortcutsDir, cardid))
+    else:
+        print("keeping broken symlink.")
+
+
+def fixBrokenShortcuts(shortcutsDir, shortcuts, audioFolders):
+    for cardid, dirs in shortcuts.items():
+        if len(dirs) == 0 and cardid != "placeholder":
+            _deleteBrokenSymlink(shortcutsDir=shortcutsDir, cardid=cardid, d=None)
+        for d in dirs:
+            if d not in audioFolders and d != cardid:
+                _deleteBrokenSymlink(shortcutsDir=shortcutsDir, cardid=cardid, d=d)
+
+def _writeFolderConf(audioDir, d, content):
+    with open(os.path.join(audioDir, d, "folder.conf"), "w") as f:
+        f.write(content)
+
+
+def _askFolderType(audioDir, d):
+    i = input("\ntype of " + d + " ? [m]usic/[a]udiobook/[I]gnore: ")
+    if i == "m":
+        _writeFolderConf(audioDir=audioDir, d=d, content=musicConf)
+    elif i == "a":
+        _writeFolderConf(audioDir=audioDir, d=d, content=audiobookConf)
+    else:
+        print("ignoring folder.")
+
+
+def linkLooseFolders(shortcutsDir, audioDir, shortcuts, audioFolders):
+    allShortcutsDirs = []
+    print("\n\n=== linking loose folders")
+    for cardid, dirs in shortcuts.items():
+        allShortcutsDirs.extend(dirs)
+    for d, hasFolderConf in audioFolders.items():
+        if d not in allShortcutsDirs:
+            cardid = input("\ncardid for [" + d + "]: ")
+            if len(cardid) == 0:
+                print("ok, ignoring this folder.")
+            else:
+                doit = True
+                if cardid in shortcuts:
+                    doit = False
+                    yn = input("WARNING: cardid already assigned to " + str(shortcuts[cardid]) + ". Override? [y/N] ")
+                    if yn == "y":
+                        doit = True
+
+                if doit:
+                    if not hasFolderConf:
+                        _askFolderType(audioDir=audioDir, d=d)
+                    with open(os.path.join(shortcutsDir, cardid), "w") as f:
+                        f.write(d)
+                else:
+                    print("skipping.")
+    print("done.")
+
+
+def fixFoldersWithoutFolderConf(audioDir, audioFolders):
+    print("\n\n=== Fixing folders with missing folder.conf ...")
+    for d, hasFolderConf in audioFolders.items():
+        if not hasFolderConf:
+            _askFolderType(audioDir=audioDir, d=d)
+    print("=== done.")
+
+
+if __name__ == "__main__":
+    baseDir = "/home/pi/RPi-Jukebox-RFID/shared"
+    shortcutsDir = os.path.join(baseDir, "shortcuts")
+    audioDir = os.path.join(baseDir, "audiofolders")
+
+    shortcuts = readShortcuts(shortcutsDir=shortcutsDir)
+    audioFolders = readFolders(audioDir=audioDir)
+
+    linkLooseFolders(shortcutsDir=shortcutsDir, audioDir=audioDir, shortcuts=shortcuts, audioFolders=audioFolders)
+    fixBrokenShortcuts(shortcutsDir=shortcutsDir, shortcuts=shortcuts, audioFolders=audioFolders)
+
+    audioFolders2 = readFolders(audioDir=audioDir)
+    fixFoldersWithoutFolderConf(audioDir=audioDir, audioFolders=audioFolders2)
+

--- a/scripts/organizeFiles.py
+++ b/scripts/organizeFiles.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     fixBrokenShortcuts(shortcutsDir=shortcutsDir, shortcuts=shortcuts, audioFolders=audioFolders)
 
     shortcuts2 = readShortcuts(shortcutsDir=shortcutsDir)
-    findDuplicateShortcuts(shortcuts)
+    findDuplicateShortcuts(shortcuts=shortcuts2)
 
     audioFolders2 = readFolders(audioDir=audioDir)
     fixFoldersWithoutFolderConf(audioDir=audioDir, audioFolders=audioFolders2)

--- a/scripts/organizeFiles.py
+++ b/scripts/organizeFiles.py
@@ -4,6 +4,7 @@
 
 import sys
 import os
+import argparse
 
 
 musicConf = """CURRENTFILENAME="filename"
@@ -175,25 +176,49 @@ if __name__ == "__main__":
     shortcutsDir = os.path.join(baseDir, "shared", "shortcuts")
     audioDir = os.path.join(baseDir, "shared", "audiofolders")
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseDir", help="directory containing the phoniebox code; defaults to " + baseDir)
+    parser.add_argument("--latestRFIDFile", help="file storing the latest RFID card id; defaults to " + latestRFIDFile)
+    parser.add_argument("--shortcutsDir", help="directory containing the RFID card id shortcuts; defaults to " + shortcutsDir)
+    parser.add_argument("--audioDir", help="directory containing the audio files; defaults to " + audioDir)
+
+    parser.add_argument("--printShortcuts", help="print list of available shortcuts", action="store_true")
+    parser.add_argument("--linkLooseFolders", help="iterate through list of folders that are currently unbound to any card id and ask user whether to link them", action="store_true")
+    parser.add_argument("--fixBrokenShortcuts", help="find and delete dangling shortcuts ", action="store_true")
+    parser.add_argument("--findDuplicateShortcuts", help="find and delete duplicate shortcuts ", action="store_true")
+    parser.add_argument("--fixFoldersWithoutFolderConf", help="ask user whether folders without a folder.conf file should be either treated as a music album or an audio book", action="store_true")
+    args = parser.parse_args()
+
+    if args.baseDir:
+        baseDir = args.baseDir
+    if args.latestRFIDFile:
+        latestRFIDFile = args.latestRFIDFile
+    if args.shortcutsDir:
+        shortcutsDir = args.shortcutsDir
+    if args.audioDir:
+        audioDir = args.audioDir
+
     shortcuts = readShortcuts(shortcutsDir=shortcutsDir)
     audioFolders = readFolders(audioDir=audioDir)
 
-    print("===== shortcuts =====")
-    shortcutslist = []
-    for cardid, thefolders in sorted(shortcuts.items()):
-        for f in thefolders:
-            shortcutslist.append([cardid, f])
-    for e in sorted(shortcutslist, key=lambda x: x[1]):
-        print("\"" + e[1] + "\";\t\"" + e[0] + "\"")
-    print("==================================")
+    if args.printShortcuts:
+        print("===== shortcuts =====")
+        shortcutslist = []
+        for cardid, thefolders in sorted(shortcuts.items()):
+            for f in thefolders:
+                shortcutslist.append([cardid, f])
+        for e in sorted(shortcutslist, key=lambda x: x[1]):
+            print("\"" + e[1] + "\";\t\"" + e[0] + "\"")
+        print("==================================")
 
-    linkLooseFolders(shortcutsDir=shortcutsDir, audioDir=audioDir, shortcuts=shortcuts, audioFolders=audioFolders, latestRFIDFile=latestRFIDFile)
-    fixBrokenShortcuts(shortcutsDir=shortcutsDir, shortcuts=shortcuts, audioFolders=audioFolders)
-
-    shortcuts2 = readShortcuts(shortcutsDir=shortcutsDir)
-    findDuplicateShortcuts(shortcuts=shortcuts2)
-
-    audioFolders2 = readFolders(audioDir=audioDir)
-    fixFoldersWithoutFolderConf(audioDir=audioDir, audioFolders=audioFolders2)
-
+    if args.linkLooseFolders:
+        linkLooseFolders(shortcutsDir=shortcutsDir, audioDir=audioDir, shortcuts=shortcuts, audioFolders=audioFolders, latestRFIDFile=latestRFIDFile)
+    if args.fixBrokenShortcuts:
+        fixBrokenShortcuts(shortcutsDir=shortcutsDir, shortcuts=shortcuts, audioFolders=audioFolders)
+    if args.findDuplicateShortcuts:
+        shortcuts2 = readShortcuts(shortcutsDir=shortcutsDir)
+        findDuplicateShortcuts(shortcuts=shortcuts2)
+    if args.fixFoldersWithoutFolderConf:
+        audioFolders2 = readFolders(audioDir=audioDir)
+        fixFoldersWithoutFolderConf(audioDir=audioDir, audioFolders=audioFolders2)
 


### PR DESCRIPTION
organizeFiles: I added a small script for conveniently organizing audio folders, linking them to RFID cards, finding audio folders that are currently not bound to any RFID card, and fixing broken links.
I wrote this script as a replacement for the phoniebox-web-ui, since I'm running out of memory when using the web-ui on a raspberry pi zero. Using this small script significantly reduces resource usage on the system, so that works pretty well in my case.
Hope this might help someone.