### PR TITLE
Additional commands to play random cards/folders or tracks

### DIFF
--- a/scripts/playout_controls.sh
+++ b/scripts/playout_controls.sh
@@ -955,6 +955,39 @@ case $COMMAND in
             rfkill unblock wifi
         fi
         ;;
+    randomcard)
+        #activate a random card
+        NUM_CARDS=$(find $AUDIO_FOLDERS_PATH/../shortcuts/ -maxdepth 1 -name '[0-9]*' | wc -l)
+        dbg "NUM_CARDS: $NUM_CARDS"
+        if (($NUM_CARDS>0))
+        then
+            RANDOMCARDID=$(ls -d $AUDIO_FOLDERS_PATH/../shortcuts/[0-9]* | shuf -n 1 | xargs basename)
+            dbg "playing random card $RANDOMCARDID"
+            ${PATHDATA}/rfid_trigger_play.sh --cardid=$RANDOMCARDID
+        fi
+        ;;
+    randomfolder)
+        #play a random folder
+        NUM_FOLDERS=$(find $AUDIO_FOLDERS_PATH -mindepth 1 -maxdepth 1 -type d -printf '1' | wc -c)
+        dbg "NUM_FOLDERS: $NUM_FOLDERS"
+        if (($NUM_FOLDERS>0))
+        then
+            RANDOMFOLDER=$(ls -d $AUDIO_FOLDERS_PATH/*/ | shuf -n 1 | xargs -d '\n' basename)
+            dbg "playing random folder \"$RANDOMFOLDER\""
+            ${PATHDATA}/rfid_trigger_play.sh --dir="$RANDOMFOLDER"
+        fi
+        ;;
+    randomtrack)
+        #jump to a random track from the current playlist (without activating shuffle, i.e. maintaining track order)
+        NUM_TRACKS=$(echo -e "status\nclose" | nc -w 1 localhost 6600 | grep -o -P '(?<=playlistlength: ).*')
+        dbg "NUM_TRACKS: $NUM_TRACKS"
+        if(($NUM_TRACKS > 0))
+        then
+            RANDOMTRACK=$(((RANDOM%${NUM_TRACKS})+1))
+            dbg "playing random track $RANDOMTRACK"
+            mpc play ${RANDOMTRACK}
+        fi
+        ;;
     recordstart)
         #mkdir $AUDIOFOLDERSPATH/Recordings
         #kill the potential current playback

--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -184,6 +184,18 @@ if [ "$CARDID" ]; then
             sudo $PATHDATA/playout_controls.sh -c=playerprev
             #/usr/bin/sudo /home/pi/RPi-Jukebox-RFID/scripts/playout_controls.sh -c=playerprev
             ;;
+        $CMDRANDCARD)
+            # activate a random card
+            $PATHDATA/playout_controls.sh -c=randomcard
+            ;;
+        $CMDRANDFOLD)
+            # play a random folder
+            $PATHDATA/playout_controls.sh -c=randomfolder
+            ;;
+        $CMDRANDTRACK)
+            # jump to a random track in playlist (no shuffle mode required)
+            $PATHDATA/playout_controls.sh -c=randomtrack
+            ;;
         $CMDREWIND)
             # play the first track in playlist
             sudo $PATHDATA/playout_controls.sh -c=playerrewind

--- a/settings/rfid_trigger_play.conf.sample
+++ b/settings/rfid_trigger_play.conf.sample
@@ -37,6 +37,12 @@ CMDMUTE="%CMDMUTE%"
 CMDNEXT="%CMDNEXT%"
 ### Skip previous track
 CMDPREV="%CMDPREV%"
+### Activate random card
+CMDRANDCARD="%CMDRANDCARD%"
+### Play random folder
+CMDRANDFOLD="%CMDRANDFOLD%"
+### Jump to random track
+CMDRANDTRACK="%CMDRANDTRACK%"
 ### Restart the playlist
 CMDREWIND="%CMDREWIND%"
 ### Seek ahead 15 sec.


### PR DESCRIPTION
These additional commands ease the creation of special "surprise" RFID cards, buttons etc.

Following commands have been added to playout_controls.sh:

**randomcard** and **randomfolder**: Both allow to start playing an arbitrary folder/playlist. Since some phonieboxes might have either abandoned card IDs (cards formerly registered but the folder is gone) or abandoned folders (files copied but no card is assigned) the user can decide which command / selection strategy he prefers.

**randomtrack:** Jumps to a random track within the current playlist. This happens without touching the shuffle settings, i.e. the playlist order remains untouched. Playback will normally continue with the following tracks. This command is especially useful if your playlists contain complete (1-track) episodes and you would like to start any of them.

The assignment to RFID card IDs to these commands has also been prepared in rfid_trigger_play.conf.sample 