### PR TITLE
Update phoniebox-rfid-reader.service.stretch-default.sample

### DIFF
--- a/misc/sampleconfigs/phoniebox-rfid-reader.service.stretch-default.sample
+++ b/misc/sampleconfigs/phoniebox-rfid-reader.service.stretch-default.sample
@@ -8,6 +8,7 @@ Group=pi
 Restart=always
 WorkingDirectory=/home/pi/RPi-Jukebox-RFID
 ExecStart=/home/pi/RPi-Jukebox-RFID/scripts/daemon_rfid_reader.py
+Nice=-15
 
 [Install]
 WantedBy=multi-user.target

--- a/misc/sampleconfigs/phoniebox-rfid-reader.service.stretch-default.sample
+++ b/misc/sampleconfigs/phoniebox-rfid-reader.service.stretch-default.sample
@@ -8,7 +8,7 @@ Group=pi
 Restart=always
 WorkingDirectory=/home/pi/RPi-Jukebox-RFID
 ExecStart=/home/pi/RPi-Jukebox-RFID/scripts/daemon_rfid_reader.py
-Nice=-15
+Nice=15
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
reducing cpu-load for Stop on Removal #1097 #1122 
My cpuload on the pi zero was relativly high causing the rfid-chips to be detected with a huge delay. I think the main issue is the constant reading of the rfid reader. by just decreasing the nice-level the impact is decreased to an accaptable level
