### PR TITLE
addedd internal mpd status polling

### DIFF
--- a/src/jukebox/player/PlayerMPD.py
+++ b/src/jukebox/player/PlayerMPD.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from mpd import MPDClient
+import mpd
+import threading
 import logging
+import time
 
 logger = logging.getLogger('jb.PlayerMPD')
 
@@ -13,7 +15,7 @@ class player_control:
         self.volume_control = volume_control
         self.music_player_status = music_player_status
 
-        self.mpd_client = MPDClient()
+        self.mpd_client = mpd.MPDClient()
         self.mpd_client.timeout = 0.5               # network timeout in seconds (floats allowed), default: None
         self.mpd_client.idletimeout = 0.5           # timeout for fetching the result of the idle command
         self.connect()
@@ -32,22 +34,72 @@ class player_control:
                 self.mpd_client.add(last_played_folder)
                 logger.info(f"Last Played Folder: {last_played_folder}")
 
+        self.old_song = None
+        self.mpd_status = {}
+        self.mpd_status_poll_interval = 0.25
+        self.mpd_mutex = threading.Lock()
+        self.status_thread = threading.Timer(self.mpd_status_poll_interval, self._mpd_status_poll).start()
+
     def connect(self):
         self.mpd_client.connect(self.mpd_host, 6600)
 
-    def mpd_retry(self, mpd_cmd, params=None):
-        try:
-            ret = mpd_cmd(params)
-        except ConnectionError:
-            logger.error("MPD Connection Error, retry")
-            self.conncet()
-            ret = mpd_cmd(params)
-        except Exception as e:
-            logger.error(f"{e}")
-        return ret
+    def mpd_retry_with_mutex(self, mpd_cmd, params=None):
+        '''
+        This method adds thread saftey for acceses to mpd via a mutex lock,
+        it shall be used for each access to mpd to ensure thread safety
+        In case of a communication error the connection will be reestablished and the pending command will be repeated 2 times
+        '''
+        retry = 2
+        with self.mpd_mutex:
+            while retry:
+                try:
+                    if params is None:
+                        ret = mpd_cmd()
+                    else:
+                        ret = mpd_cmd(params)
+                    break
+                except ConnectionError:     # TODO: this is not working properly yet, we are alwas anding up in the Exception!
+                    logger.info(f"MPD Connection Error, retry {retry}")
+                    self.connect()
+                    retry -= 1
+                except Exception as e:
+                    if retry:
+                        retry -= 1
+                        self.connect()      # TODO: Workaround, since the above ConnectionError is not properly caught
+                        logger.info(f"MPD Error, retry {retry}")
+                        logger.info(f"{e.__class__}")
+                        logger.info(f"{e}")
+                    else:
+                        logger.error(f"{e}")
+                        ret = {}
+                        break
+            return ret
+
+    def _mpd_status_poll(self):
+        '''
+        this method polls the status from mpd and stores the important inforamtion in the music_player_status,
+        it will repeat itself in the intervall specified by self.mpd_status_poll_interval
+        '''
+        self.mpd_status.update(self.mpd_retry_with_mutex(self.mpd_client.status))
+
+        # get song name just if the song has changed
+        if self.mpd_status.get('song') != self.old_song:
+            self.mpd_status.update(self.mpd_retry_with_mutex(self.mpd_client.currentsong))
+            self.old_song = self.mpd_status['song']
+
+        self.mpd_status['volume'] = self.volume_control.volume
+
+        if self.mpd_status.get('elapsed') is not None:
+            self.current_folder_status["ELAPSED"] = self.mpd_status['elapsed']
+            self.music_player_status['player_status']["CURRENTSONGPOS"] = self.mpd_status['song']
+            self.music_player_status['player_status']["CURRENTFILENAME"] = self.mpd_status['file']
+
+        # the repetation is intentionally at the end, to avoid overruns in case of delays caused by communication
+        self.status_thread = threading.Timer(self.mpd_status_poll_interval, self._mpd_status_poll).start()
+        return ()
 
     def get_player_type_and_version(self, param):
-        return ({'result': 'mpd', 'version': self.mpd_client.mpd_version})
+        return ({'result': 'mpd', 'version': self.mpd_retry_with_mutex(self.mpd_client.mpd_version)})
 
     def play(self, param):
 
@@ -58,37 +110,30 @@ class player_control:
         else:
             songid = 1
 
-        try:
-            self.mpd_client.play(songid)
-        except ConnectionError:
-            logger.error("MPD Connection Error, retry")
-            self.conncet()
-            self.mpd_client.play(songid)
-        except Exception as e:
-            logger.error(f"{e}")
+        self.mpd_retry_with_mutex(self.mpd_client.play, songid)
 
         return ({})
 
     def stop(self, param):
-        self.mpd_client.stop()
+        self.mpd_retry_with_mutex(self.mpd_client.stop)
         return ({})
 
     def pause(self, param):
-        self.mpd_client.pause(1)
+        self.mpd_retry_with_mutex(self.mpd_client.pause, 1)
         return ({})
 
     def prev(self, param):
-        self.mpd_client.previous()
+        self.mpd_retry_with_mutex(self.mpd_client.previous)
         return ({})
 
     def next(self, param):
-        self.mpd_client.next()
+        self.mpd_retry_with_mutex(self.mpd_client.next)
         return ({})
 
     def seek(self, param):
         val = param.get('time')
         if val is not None:
-            self.mpd_client.seekcur(val)
+            self.mpd_retry_with_mutex(self.mpd_client.seekcur, val)
         return ({})
 
     def replay(self, param):
@@ -99,18 +144,21 @@ class player_control:
             mode = param.get("mode")
 
             if mode == 'repeat':
-                MPDClient.repeat(1)
-                MPDClient.single(0)
+                repeat = 1
+                single = 0
             elif mode == 'single':
-                MPDClient.repeat(1)
-                MPDClient.single(1)
+                repeat = 1
+                single = 1
             else:
-                MPDClient.repeat(0)
-                MPDClient.single(0)
+                repeat = 0
+                single = 0
+
+            self.mpd_retry_with_mutex(self.mpd_client.repeat, repeat)
+            self.mpd_retry_with_mutex(self.mpd_client.single, single)
         return ({})
 
     def get_current_song(self, param):
-        return {'resp': self.mpd_client.currentsong()}
+        return {'resp': self.mpd_retry_with_mutex(self.mpd_client.currentsong)}
 
     def map_filename_to_playlist_pos(self, filename):
         logger.error("map_filename_to_playlist_pos not yet implemented")
@@ -129,6 +177,11 @@ class player_control:
 
         logger.error("move not yet implemented")
         return ({})
+
+    def test_mutex(self, param):
+        self.mpd_mutex.acquire()
+        time.sleep(1)
+        self.mpd_mutex.release()
 
     def playsingle(self, param):
         logger.error("playsingle not yet implemented")
@@ -150,11 +203,11 @@ class player_control:
 
         if folder is not None:
             # load playlist
-            self.mpd_client.clear()
+            self.mpd_retry_with_mutex(self.mpd_client.clear)
 
             # TODO: why dealing with playlists? at least partially redundant with folder.config,
             # so why not combine if needed alternative solution, just add folders recursively to quene
-            self.mpd_client.add(folder)
+            self.mpd_retry_with_mutex(self.mpd_client.add, folder)
 
             self.music_player_status['player_status']['last_played_folder'] = folder
 
@@ -162,7 +215,7 @@ class player_control:
             if self.current_folder_status is None:
                 self.current_folder_status = self.music_player_status['audio_folder_status'][folder] = {}
 
-            self.mpd_client.play()
+            self.mpd_retry_with_mutex(self.mpd_client.play)
 
         if 0:
             # Change some settings according to current folder IF the folder.conf exists
@@ -285,7 +338,7 @@ class player_control:
         # write latest folder played to settings file
         # sudo echo ${FOLDER} > ${PATHDATA}/../settings/Latest_Folder_Played
 
-        song = self.mpd_client.currentsong()
+        song = self.mpd_retry_with_mutex(self.mpd_client.currentsong)
 
         self.current_folder_status["CURRENTFILENAME"] = song.get('file')
         self.current_folder_status["ELAPSED"] = 0
@@ -298,22 +351,8 @@ class player_control:
         return ({'song': song})
 
     def playerstatus(self, param):
-        status = self.mpd_client.currentsong()
-        status.update(self.mpd_client.status())
-        status['volume'] = self.volume_control.volume
-
-        # for now use this to update the actual folder status (require web ui to run)
-        # finnaly a switch to asynio implementation makes sense, to handle the plloing independant
-        elapsed = status.get('elapsed')
-        if elapsed is not None:
-            self.current_folder_status["ELAPSED"] = elapsed
-            self.music_player_status['player_status']["CURRENTSONGPOS"] = status['song']
-            self.music_player_status['player_status']["CURRENTFILENAME"] = status['file']
-
-        # for k in status:
-        #    print ("{} : {}".format(k,status.get(k)))
-        return (status)
+        return (self.mpd_status)
 
     def playlistinfo(self, param):
-        playlistinfo = (self.mpd_client.playlistinfo())
+        playlistinfo = (self.mpd_retry_with_mutex(self.mpd_client.playlistinfo))
         return (playlistinfo)


### PR DESCRIPTION
the PlayerMPD now polls the mpd status each 250ms internally. 
The improvement here is that the internal mpd_status does not depend any more on the web ui
E.g. the JukeBox can now be exited any time without the need of extra mpd status polling, the status just 250ms old, which is probably acceptable for song continuation after restart.
This can also be the point to think about pub/sub for this information

The initial approach of using asyncio for that purpose has been discarded since asyncio depends on a main loop, 
which is not existing here. 
Instead the polling is done by a thread and thread safty has been added to the mpd calls via a mutex

TODO:
 - as @ChisSoc mentioned before we need to think about a defined method to exit all the threads in all the modules , this is also not solved here yet.
 - The internal mpd.status is just everything the mpd returns. most likely many information we don't need.
  I'd like to reduce the information to the really used and useful ones