### PR TITLE
Added -a --address parameter to support also ws:// addresses

### DIFF
--- a/src/cli_client/pbc.c
+++ b/src/cli_client/pbc.c
@@ -50,18 +50,30 @@ typedef struct
     char method [MAX_STRLEN];
     char params [MAX_PARAMS][MAX_STRLEN];
     int num_params;
+    char address [MAX_STRLEN];
 } t_request;
 
 
-int send_zmq_request_and_wait_response(char * request, int request_len, char * response, int max_response_len)
+int send_zmq_request_and_wait_response(char * request, int request_len, char * response, int max_response_len, char * address)
 {
     int zmq_ret,ret = -1;
     void *context = zmq_ctx_new ();
     void *requester = zmq_socket (context, ZMQ_REQ);
     int linger = 200;
+    
+    if (g_verbose)
+    {
+      int major, minor, patch;
+      zmq_version (&major, &minor, &patch);
+      printf ("Current ØMQ version is %d.%d.%d\n", major, minor, patch);
+    }
+    
     zmq_setsockopt(requester,ZMQ_LINGER,&linger,sizeof(linger));
     zmq_setsockopt(requester,ZMQ_RCVTIMEO,&linger,sizeof(linger));
-    zmq_connect (requester, "tcp://localhost:5555");
+    zmq_connect (requester, address);
+
+    if (g_verbose) printf("connected to: %s",address);
+    
 
     zmq_ret = zmq_send (requester, request, request_len, 0);
 
@@ -119,7 +131,7 @@ void * connect_and_send_request(t_request * tr)
     
     if (g_verbose) printf("Sending Request (%ld Bytes):\n%s\n",json_len,json_request);
 
-    send_zmq_request_and_wait_response(json_request,json_len,json_response,MAX_REQEST_STRLEN);
+    send_zmq_request_and_wait_response(json_request,json_len,json_response,MAX_REQEST_STRLEN,tr->address);
 
     return 0;
 }
@@ -148,6 +160,7 @@ void usage(void)
     fprintf(stderr,"    -h this screen\n");
     fprintf(stderr,"    -o, --object object\n");
     fprintf(stderr,"    -m, --method method\n");
+    fprintf(stderr,"    -a, --address   default=tcp://localhost:5555\n");
     fprintf(stderr,"    -v verbose\n");
 
     fprintf(stderr,"last change %s\n\n",__DATE__);
@@ -161,6 +174,7 @@ void usage(void)
 int HandleOptions(int argc,char *argv[], t_request * tr)
 {
   int c;
+  sprintf(tr->address,"tcp://localhost:5555");
   
   const struct option long_options[] =
   {
@@ -172,10 +186,11 @@ int HandleOptions(int argc,char *argv[], t_request * tr)
     {"help",        no_argument,       0, 'h'},
     {"object",      required_argument, 0, 'o'},
     {"method",      required_argument, 0, 'm'},
+    {"address",     required_argument, 0, 'a'},
     {0, 0, 0, 0}
   };
 
-  const char short_options[] = {"o:m:p:?hv"};
+  const char short_options[] = {"o:m:p:a:?hv"};
 
   while (1)
   {
@@ -206,6 +221,10 @@ int HandleOptions(int argc,char *argv[], t_request * tr)
         g_verbose = '1';
         break;
 
+      case 'a':
+        strncpy (tr->address,optarg,MAX_STRLEN);
+        break;
+      
       default:
         usage();
         abort ();


### PR DESCRIPTION
Added the - / --address parameter to pbc.
The intention here was to enable other transport layer, e.g. to allow also ws://127.0.0.1:5556
(despite the fact that static addresses are in general not the best idea)

Note, to allow the ws:// (Web Socket) Transport Layer, at least zeromq version 4.3.4 is required.
As of today this needs to be build from source with draft option enabled: e.g. here https://pyzmq.readthedocs.io/en/latest/draft.html