### PR TITLE
Future3/cfghandler

### DIFF
--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -y libasound2-dev
+        sudo apt-get install -y libasound2-dev
         python -m pip install --upgrade pip
         pip install wheel
         pip install spidev

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ruamel.yaml
 flake8
 
 # Jukebox
+# sudo apt install libasound2-dev required on some machines
 pyalsaaudio
 mock
 py532lib

--- a/settings/jukebox.yaml
+++ b/settings/jukebox.yaml
@@ -1,0 +1,13 @@
+system:
+    box_name : Jukebox
+    startup_sound: ../../resources/startupsound.wav
+player:
+    music_player_status: ../../shared/music_player_status.json
+modules:
+    volume: jukebox.alsaif
+    player: jukebox.mpd
+mpd:
+    host: localhost
+alsaif:
+    mixer: Master
+    start_sound_device: default

--- a/settings/jukebox.yaml
+++ b/settings/jukebox.yaml
@@ -1,13 +1,20 @@
 system:
     box_name : Jukebox
     startup_sound: ../../resources/startupsound.wav
+    audiofolder_path: ../../shared
+    playlistfolder_path: ../../playlists
 player:
-    music_player_status: ../../shared/music_player_status.json
+    status_file: ../../shared/music_player_status.json
 modules:
     volume: jukebox.alsaif
     player: jukebox.mpd
+    others: [rfid]
 mpd:
     host: localhost
 alsaif:
     mixer: Master
     start_sound_device: default
+rpc:
+    port_cmd: 5555
+rfid:
+    cardid_database: ../../settings/phoniebox_cardid_database.json

--- a/settings/phoniebox_cardid_database.json
+++ b/settings/phoniebox_cardid_database.json
@@ -1,67 +1,89 @@
 {
-  "VolumeUp": {
+  "VolumeUp (kwargs)": {
     "object": "volume",
     "method": "set_volume",
-    "params": {
+    "kwargs": {
       "volume": 12
     }
   },
-  "VolumeMute": {
+  "VolumeUp (args)": {
+    "object": "volume",
+    "method": "set_volume",
+    "args": [12]
+  },
+  "VolumeUp (error in args)": {
+    "object": "volume",
+    "method": "set_volume",
+    "args": ["12b"]
+  },
+  "VolumeMute (empty kwargs)": {
     "object": "volume",
     "method": "mute",
-    "params": {}
+    "kwargs": {}
+  },
+  "VolumeUnMute (no args)": {
+    "object": "volume",
+    "method": "mute"
+  },
+  "No Method": {
+    "object": "volume",
+    "method": "does_not_exist"
+  },
+  "No Module": {
+    "object": "some_fantasy",
+    "method": "does_not_exist"
   },
     "104,49914": {
     "object": "player",
     "method": "playlistaddplay",
-    "params": {
+    "kwargs": {
       "folder": "acdc"
     }
   },
   "103,12632": {
     "object": "player",
     "method": "playlistaddplay",
-    "params": {
+    "kwargs": {
       "folder": "roxette"
     }
   },
   "104,29698": {
     "object": "player",
     "method": "playlistaddplay",
-    "params": {
+    "kwargs": {
       "folder": "digger barnes/every story true"
     }
   },
   "108,07437": {
     "object": "player",
     "method": "playlistaddplay",
-    "params": {
+    "kwargs": {
       "folder": "digger barnes"
     }
   },
   "107,60360": {
     "object": "",
     "method": "",
-    "params": {}
+    "kwargs": {}
   },
   "106,64513": {
     "object": "",
     "method": "",
-    "params": {}
+    "kwargs": {}
   },
   "104,14891": {
     "object": "",
     "method": "",
-    "params": {}
+    "kwargs": {}
   },
   "103,24033": {
     "object": "",
     "method": "",
-    "params": {}
+    "kwargs": {}
   },
   "104,32860": {
     "object": "",
     "method": "",
-    "params": {}
+    "kwargs": {}
   }
 }

--- a/settings/phoniebox_cardid_database.json
+++ b/settings/phoniebox_cardid_database.json
@@ -1,5 +1,17 @@
 {
-  "104,49914": {
+  "VolumeUp": {
+    "object": "volume",
+    "method": "set_volume",
+    "params": {
+      "volume": 12
+    }
+  },
+  "VolumeMute": {
+    "object": "volume",
+    "method": "mute",
+    "params": {}
+  },
+    "104,49914": {
     "object": "player",
     "method": "playlistaddplay",
     "params": {

--- a/settings/phoniebox_cardid_database.json
+++ b/settings/phoniebox_cardid_database.json
@@ -1,88 +1,88 @@
 {
   "VolumeUp (kwargs)": {
-    "object": "volume",
+    "plugin": "volume",
     "method": "set_volume",
     "kwargs": {
       "volume": 12
     }
   },
   "VolumeUp (args)": {
-    "object": "volume",
+    "plugin": "volume",
     "method": "set_volume",
     "args": [12]
   },
   "VolumeUp (error in args)": {
-    "object": "volume",
+    "plugin": "volume",
     "method": "set_volume",
     "args": ["12b"]
   },
   "VolumeMute (empty kwargs)": {
-    "object": "volume",
+    "plugin": "volume",
     "method": "mute",
     "kwargs": {}
   },
   "VolumeUnMute (no args)": {
-    "object": "volume",
+    "plugin": "volume",
     "method": "mute"
   },
   "No Method": {
-    "object": "volume",
+    "plugin": "volume",
     "method": "does_not_exist"
   },
   "No Module": {
-    "object": "some_fantasy",
+    "plugin": "some_fantasy",
     "method": "does_not_exist"
   },
     "104,49914": {
-    "object": "player",
+    "plugin": "player",
     "method": "playlistaddplay",
     "kwargs": {
       "folder": "acdc"
     }
   },
   "103,12632": {
-    "object": "player",
+    "plugin": "player",
     "method": "playlistaddplay",
     "kwargs": {
       "folder": "roxette"
     }
   },
   "104,29698": {
-    "object": "player",
+    "plugin": "player",
     "method": "playlistaddplay",
     "kwargs": {
       "folder": "digger barnes/every story true"
     }
   },
   "108,07437": {
-    "object": "player",
+    "plugin": "player",
     "method": "playlistaddplay",
     "kwargs": {
       "folder": "digger barnes"
     }
   },
   "107,60360": {
-    "object": "",
+    "plugin": "",
     "method": "",
     "kwargs": {}
   },
   "106,64513": {
-    "object": "",
+    "plugin": "",
     "method": "",
     "kwargs": {}
   },
   "104,14891": {
-    "object": "",
+    "plugin": "",
     "method": "",
     "kwargs": {}
   },
   "103,24033": {
-    "object": "",
+    "plugin": "",
     "method": "",
     "kwargs": {}
   },
   "104,32860": {
-    "object": "",
+    "plugin": "",
     "method": "",
     "kwargs": {}
   }

--- a/src/jukebox/components/rfid_reader/PhonieboxRfidReader.py
+++ b/src/jukebox/components/rfid_reader/PhonieboxRfidReader.py
@@ -50,7 +50,7 @@ class UsbReader(object):
 
 
 class RFID_Reader(object):
-    def __init__(self, device_name, param=None, zmq_context=None):
+    def __init__(self, device_name, zmq_address, param=None, zmq_context=None):
 
         if device_name == 'MFRC522':
             from .RfidReader_RC522 import Mfrc522Reader
@@ -71,8 +71,8 @@ class RFID_Reader(object):
             except IndexError:
                 sys.exit('Could not find the device %s.\n Make sure it is connected' % device_name)
 
-        self.PhonieboxRpc = RpcClient()
-        self.PhonieboxRpc.connect(zmq_context=zmq_context)
+        self.PhonieboxRpc = RpcClient(context=zmq_context)
+        self.PhonieboxRpc.connect(zmq_address)
         self._keep_running = True
         self.cardnotification = None
         self.valid_cardnotification = None

--- a/src/jukebox/jukebox/NvManager.py
+++ b/src/jukebox/jukebox/NvManager.py
@@ -11,24 +11,25 @@ class nv_manager():
         new_nv_dict = nv_dict(default_filename)
         self.all_nv_objects.append(new_nv_dict)
         return new_nv_dict
-    
+
     def save_all(self):
         for nv_obj in self.all_nv_objects:
             #print ("Saving {} ".format(nv_obj))
             nv_obj.save_to_json()
 
-    
-            
+
+
 
 # Todo: add hashing support
 
 # this is inherting from dict
-# you should not do this! 
+# you should not do this!
 # In this case it is ok since we are just adding methods, and are not overwriting any parent methods
 class nv_dict(dict):
     def __init__(self,default_filename=None):
         super().__init__()
-        
+
+        self.initial_hash = None
         self.default_filename=default_filename
 
         if self.default_filename is not None:
@@ -41,19 +42,19 @@ class nv_dict(dict):
                 self.default_filename_is_writeable = True
                 self.save_to_json()
         self.initial_hash = self.hash()
-            
+
     def __setitem__(self, item, value):
         self.dirty = True   #not working, see comment above, intention is to just write dicts which content has changed
         super(nv_dict,self).__setitem__(item, value)
-    
+
     def init_from_json(self,path=None,merge=False):
         if merge is False:
             self.clear()
         self.update(json.load( open( path ) ))
 
     def hash(self):
-        return hashlib.md5(json.dumps(self).encode('UTF8')).digest() 
-    
+        return hashlib.md5(json.dumps(self).encode('UTF8')).digest()
+
     def save_to_json(self,filename=None):
         actual_hash = self.hash()
         if self.initial_hash != actual_hash:
@@ -73,10 +74,10 @@ class nv_dict(dict):
                     json.dump( self, outfile, indent=2)
         else:
             print ("dont need to save")
-                    
-  
+
+
 if __name__ == "__main__":
-    
+
     nvd = nv_dict()
 
     nvd['a'] = 1
@@ -102,7 +103,7 @@ if __name__ == "__main__":
     nvd3 = nv_dict(default_filename="test3.json")
 
 
-    
+
     nvm = nv_manager()
 
     nvd4 =nvm.load("test4.json")
@@ -113,7 +114,6 @@ if __name__ == "__main__":
     nvd5 =nvm.load("test5.json")
     nvd5['B'] = 'B'
 
-    print (nvm.all_nv_objects) 
+    print (nvm.all_nv_objects)
 
     nvm.save_all()
-    

--- a/src/jukebox/jukebox/alsaif.py
+++ b/src/jukebox/jukebox/alsaif.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+import alsaaudio
+import logging
+from functools import partial
+import wave
+import jukebox.cfghandler
+import os
+
+logger = logging.getLogger('jb.alsaif')
+cfg = jukebox.cfghandler.get_handler('jukebox')
+
+
+class AlsaCtrl:
+    def __init__(self):
+        mixer_name = cfg.setndefault('alsaif', 'mixer', value='Master')
+        self.mixer = alsaaudio.Mixer(mixer_name, 0)
+
+    def get_volume(self):
+        return self.mixer.getvolume()[0]
+
+    def set_volume(self, volume):
+        if 0 <= volume <= 100:
+            self.mixer.setvolume(volume)
+        else:
+            logger.warning(f"set_volume: volume out-of-range: f{volume}")
+        return self.get_volume()
+
+    def mute(self, mute_on=True):
+        self.mixer.setmute(1 if mute_on else 0)
+
+
+def _play_wave_core(filename):
+    with wave.open(filename, 'rb') as f:
+        width = f.getsampwidth()
+        fmt_lookup = {1: alsaaudio.PCM_FORMAT_U8,
+                      2: alsaaudio.PCM_FORMAT_S16_LE,
+                      3: alsaaudio.PCM_FORMAT_S24_3LE,
+                      4: alsaaudio.PCM_FORMAT_S32_LE}
+        if width not in fmt_lookup:
+            raise ValueError('Unsupported format')
+        device_name = cfg.setndefault('alsaif', 'start_sound_device', value='default')
+        periodsize = f.getframerate() // 8
+        device = alsaaudio.PCM(channels=f.getnchannels(),
+                               rate=f.getframerate(),
+                               format=fmt_lookup[width],
+                               periodsize=periodsize,
+                               device=device_name)
+
+        data = f.readframes(periodsize)
+        while data:
+            device.write(data)
+            data = f.readframes(periodsize)
+
+
+def play_wave(filename):
+    if os.path.exists(filename) and os.path.isfile(filename):
+        logger.debug("Playing wave file")
+        try:
+            _play_wave_core(filename)
+        except Exception as e:
+            logger.error(f"{type(e)}: {e}")
+    else:
+        logger.error(f"File does not exist: '{filename}'")
+
+
+# ---------------------------------------------------------------------------
+# Module interface API for jukebox
+# ---------------------------------------------------------------------------
+
+class Collector:
+    pass
+
+
+callables = Collector()
+alsactrl = None
+
+
+def init():
+    global alsactrl
+    try:
+        alsactrl = AlsaCtrl()
+    except Exception as e:
+        logger.error("Failed to init AlsaCtrl. Trying without...")
+        logger.error(f"Reason: {e}")
+    else:
+        callables.set_volume = alsactrl.set_volume
+        callables.get_volume = alsactrl.get_volume
+        callables.mute = partial(alsactrl.mute, True)
+        callables.unmute = partial(alsactrl.mute, False)
+    callables.play_wave = play_wave
+    return callables

--- a/src/jukebox/jukebox/alsaif.py
+++ b/src/jukebox/jukebox/alsaif.py
@@ -19,6 +19,7 @@ class AlsaCtrl:
         return self.mixer.getvolume()[0]
 
     def set_volume(self, volume):
+        logger.debug(f"Set Volume = {volume}")
         if 0 <= volume <= 100:
             self.mixer.setvolume(volume)
         else:
@@ -26,6 +27,7 @@ class AlsaCtrl:
         return self.get_volume()
 
     def mute(self, mute_on=True):
+        logger.debug(f"Set Mute = {mute_on}")
         self.mixer.setmute(1 if mute_on else 0)
 
 

--- a/src/jukebox/jukebox/cfghandler.py
+++ b/src/jukebox/jukebox/cfghandler.py
@@ -1,0 +1,267 @@
+import sys
+import threading
+import logging
+from ruamel.yaml import YAML
+import hashlib
+
+logger = logging.getLogger('jb.cfghandler')
+
+# Collects all created config handlers
+# Using a simple dict as this is sufficient if nobody accesses that directly unless he knows exactly what he is doing
+# and it saves a lot of code
+handlers = {}
+
+# ---------------------------------------------------------------------------
+# Global thread-related stuff
+# ---------------------------------------------------------------------------
+# _lock_module is used to serialize access to shared data structures in this module
+# (currently only during creation of a new config_handler)
+# Each config handler has its own lock for protecting access to the underlying shared data
+# this cannot be acquired automatically, as the shared data is typically a mutable. It is in the users
+# responsibility to do that. See documentation below for more info
+
+_lock_module = threading.RLock()
+
+
+def _acquire_lock():
+    """
+    Acquire the module-level lock for serializing access to shared data.
+
+    This should be released with _releaseLock().
+    """
+    if _lock_module:
+        _lock_module.acquire()
+
+
+def _release_lock():
+    """
+    Release the module-level lock acquired by calling _acquireLock().
+    """
+    if _lock_module:
+        _lock_module.release()
+
+
+# ---------------------------------------------------------------------------
+# The main entry point
+# ---------------------------------------------------------------------------
+
+def get_handler(name):
+    """
+    Get a configuration data handler with the specified name, creating it
+    if it doesn't yet exit. If created, it is always created empty.
+
+    This is the main entry point for obtaining an configuration handler
+
+    :param name: Name of the config handler for reference
+    """
+    _acquire_lock()
+    try:
+        if name in handlers:
+            cfg_handler = handlers[name]
+        else:
+            cfg_handler = handlers[name] = ConfigHandler(name)
+    finally:
+        _release_lock()
+    return cfg_handler
+
+
+class ConfigHandler:
+    """
+    The actual configuration handler.
+
+    Don't instantiate directly. Always use get_handler()!
+
+    The concept is that config handler is created once in the main thread with
+    >>> cfg = get_handler('global')
+    and loaded
+    >>> load_yaml(cfg, 'filename.yaml')
+    and in all other modules (in potentially different threads) the same handler is obtained and used by
+    >>> cfg = get_handler('global')
+
+    This eliminates the need to pass an effectively global configuration handler by paramters across the entire design
+
+    All threads can read and write to the configuration data.
+    Proper thread-safeness must be ensured by the the thread modifying the data by acquiring the lock
+    Easiest and best way is to use the context handler:
+    with cfg:
+       cfg['key'] = 66
+       cfg.setdefault['hello'] = 'world'
+
+    Alternatively, you can lock and release manually by using acquire() and release()
+    But be very sure to release the lock even in cases of errors an exceptions!
+    Else we have a deadlock!
+
+    Reading can be done without acquiring a lock. But be aware that when reading multiple values without locking, another
+    thread may intervene and modify some values in between
+
+    """
+    def __init__(self, name):
+        self.name = name
+        # Initialize this as empty standard dict. Type may be overwritten by config_dict
+        self._data = {}
+        # self._hash = hashlib.md5(self._data.__str__().encode('utf8')).digest()
+        # Pre-computed MD5 hash of an empty dictionary
+        self._hash = b'\x99\x91K\x93+\xd3zP\xb9\x83\xc5\xe7\xc9\n\xe9;'
+        # Using a RLock to prevent deadlocks
+        # This allows to have an always-on safety lock around the config_dict function and still work with outer locked context
+        # Writing is a rare event, so performance is not an issue
+        self._lock = threading.RLock()
+
+    def acquire(self):
+        return self._lock.acquire()
+
+    def release(self):
+        return self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.release()
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        # We rely on calling function to properly lock before writing
+        # Locking here will only help in the rarest of cases (because of mutable objects) and suggests false safety
+        self._data[key] = value
+
+    def get(self, key, *, default=None):
+        """
+        Enforce keyword on default to avoid accidental misuse when actually getn is wanted
+        """
+        return self._data.get(key, default)
+
+    def setdefault(self, key, *, value):
+        """
+        Enforce keyword on default to avoid accidental misuse when actually setndefault is wanted
+        """
+        return self._data.setdefault(key, value)
+
+    def getn(self, *keys, default=None):
+        """
+        Get the value at arbitrary hierarchy depth. Return default if last key not present
+
+        Note that default only refers to the lowest hierarchy level. All upper levels MUST exist
+        else a KeyError is raised
+        """
+        with self._lock:
+            if len(keys) == 1:
+                return self._data.get(keys[0], default)
+            else:
+                tmp = self._data[keys[0]]
+                for nk in keys[1:-1]:
+                    tmp = tmp[nk]
+                return tmp.get(keys[-1], default)
+
+    def setndefault(self, *keys, value):
+        """
+        Set the key = value pair at arbitrary hierarchy depth unless the key already exists
+
+        Note: default only refers to the lowest hierarchy level. All upper levels MUST exist
+        else a KeyError is raised.
+        """
+        if len(keys) == 1:
+            return self._data.setdefault(keys[0], value)
+        else:
+            tmp = self._data[keys[0]]
+            for nk in keys[1:-1]:
+                tmp = tmp[nk]
+            return tmp.setdefault(keys[-1], value)
+
+    def __str__(self):
+        return f'ConfigHandler({self.name}):: ' + self._data.__str__()
+
+    def __contains__(self, item):
+        return self._data.__contains__(item)
+
+    def __iter__(self):
+        return self._data.__iter__()
+
+    def __len__(self):
+        return self._data.__len__()
+
+    def items(self):
+        return self._data.items()
+
+    def keys(self):
+        return self._data.keys()
+
+    def values(self):
+        return self._data.values()
+
+    def config_dict(self, data):
+        """
+        Initialize configuration data from dict-like data structure
+        :param data: configuration data
+        :return: None
+        """
+        logger.debug(f"({self.name}) Replacing current config data")
+        with self._lock:
+            self._data = data
+            self._hash = hashlib.md5(self._data.__str__().encode('utf8')).digest()
+
+    def is_modified(self):
+        """
+        Note: This relies on the __str__ representation of the underlying data structure
+        In case of ruamel, this ignores comments and only looks at the data
+        :return:
+        """
+        with self._lock:
+            is_modified = self._hash != hashlib.md5(self._data.__str__().encode('utf8')).digest()
+        return is_modified
+
+    def clear_modified(self):
+        """
+        Sets the current state as new baseline, clearing the is_modified state
+        :return:
+        """
+        with self._lock:
+            self._hash = hashlib.md5(self._data.__str__().encode('utf8')).digest()
+
+
+# ---------------------------------------------------------------------------
+# Pre-defined file I/O for yaml
+# ---------------------------------------------------------------------------
+
+
+def load_yaml(cfg, filename) -> None:
+    """
+    Load a yaml file into a ConfigHandler
+    :param cfg: ConfigHandler instance
+    :param filename: filename to yaml file
+    :return: None
+    """
+    yaml = YAML(typ='rt')
+    logger.info(f"({cfg.name}) Loading yaml file '{filename}'")
+    with open(filename) as stream:
+        cfg.config_dict(yaml.load(stream))
+
+
+def write_yaml(cfg, filename, only_if_changed=False, *args, **kwargs) -> None:
+    """
+    Writes ConfigHandler data to yaml file / sys.stdout
+    :param cfg: ConfigHandler instance
+    :param filename: filename to output file. If sys.stdout, output is written to console
+    :param only_if_changed: Write file only, if ConfigHandler.is_modified()
+    :param args: passed on to yaml.dump(...)
+    :param kwargs: passed on to yaml.dump(...)
+    :return: None
+    """
+    # Lock cfg first thing, to prevent any changes between write call and actual write-out
+    with cfg:
+        if cfg.is_modified() or not only_if_changed:
+            logger.info(f"({cfg.name}) Writing yaml file '{filename}'")
+            yaml = YAML(typ='rt')
+            # The access to "private" _data here is ok, because the lock is acquired
+            if filename is sys.stdout:
+                yaml.dump(cfg._data, sys.stdout, *args, **kwargs)
+            else:
+                with open(filename, 'wt') as stream:
+                    yaml.dump(cfg._data, stream, *args, **kwargs)
+        else:
+            logger.info(f"({cfg.name}) "
+                        f"Not writing to file as data has unchanged status set (use only_if_changed=True to override)")
+

--- a/src/jukebox/jukebox/cfghandler.py
+++ b/src/jukebox/jukebox/cfghandler.py
@@ -142,26 +142,29 @@ class ConfigHandler:
 
     def getn(self, *keys, default=None):
         """
-        Get the value at arbitrary hierarchy depth. Return default if last key not present
+        Get the value at arbitrary hierarchy depth. Return default if key not present
 
-        Note that default only refers to the lowest hierarchy level. All upper levels MUST exist
-        else a KeyError is raised
+        Note: that default value is returned no matter at which hierarchy level the path aborts
         """
         with self._lock:
             if len(keys) == 1:
                 return self._data.get(keys[0], default)
             else:
-                tmp = self._data[keys[0]]
-                for nk in keys[1:-1]:
-                    tmp = tmp[nk]
-                return tmp.get(keys[-1], default)
+                try:
+                    tmp = self._data[keys[0]]
+                    for nk in keys[1:-1]:
+                        tmp = tmp[nk]
+                except KeyError as e:
+                    return default
+                else:
+                    return tmp.get(keys[-1], default)
 
-    def setndefault(self, *keys, value):
+    def setndefault(self, *keys, value, create=False):
         """
         Set the key = value pair at arbitrary hierarchy depth unless the key already exists
 
         Note: default only refers to the lowest hierarchy level. All upper levels MUST exist
-        else a KeyError is raised.
+        else a KeyError is raised. That is because we cannot know which types the levels should consist of
         """
         if len(keys) == 1:
             return self._data.setdefault(keys[0], value)
@@ -263,5 +266,5 @@ def write_yaml(cfg, filename, only_if_changed=False, *args, **kwargs) -> None:
                     yaml.dump(cfg._data, stream, *args, **kwargs)
         else:
             logger.info(f"({cfg.name}) "
-                        f"Not writing to file as data has unchanged status set (use only_if_changed=True to override)")
+                        f"Not writing to file as data has unchanged status set (use only_if_changed=False to override)")
 

--- a/src/jukebox/jukebox/rpc/Server.py
+++ b/src/jukebox/jukebox/rpc/Server.py
@@ -32,7 +32,7 @@ class RpcServer:
         if (call_obj is not None):
             call_function = getattr(call_obj, cmd, None)
             if (call_function is not None):  # better to check with is callable() ??
-                response = call_function(param)
+                response = call_function(**param)
             else:
                 response = {'resp': "no valid commad"}
         else:

--- a/src/jukebox/jukebox/rpc/client.py
+++ b/src/jukebox/jukebox/rpc/client.py
@@ -1,29 +1,32 @@
 import zmq
 import json
 import logging
+import jukebox.cfghandler
 
 logger = logging.getLogger('jb.rpc_client')
+cfg = jukebox.cfghandler.get_handler('jukebox')
 
 
 class RpcClient:
-    def __init__(self):
-        self.context = None
+    def __init__(self, context=None):
+        # Get the global context (will be created if non-existing)
+        self.context = context or zmq.Context.instance()
 
-    def connect(self, addr=None, zmq_context=None):
-        if zmq_context is not None:
-            self.context = zmq_context
-            local_addr = "inproc://JukeBoxRpcServer"
-        else:
-            self.context = zmq.Context()
-            local_addr = "tcp://127.0.0.1:5555"
-
-        if addr is not None:
-            local_addr = addr
+    def connect(self, address):
+        # if zmq_context is not None:
+        #     self.context = zmq_context
+        #     local_addr = "inproc://JukeBoxRpcServer"
+        # else:
+        #     self.context = zmq.Context()
+        #     local_addr = "tcp://127.0.0.1:5555"
+        #
+        # if addr is not None:
+        #     local_addr = addr
 
         self.queue = self.context.socket(zmq.REQ)
         self.queue.setsockopt(zmq.RCVTIMEO, 200)
         self.queue.setsockopt(zmq.LINGER, 200)
-        self.queue.connect(local_addr)
+        self.queue.connect(address)
 
     def enqueue(self, request):
         # TODO: check reqest

--- a/src/jukebox/player/PlayerMPD.py
+++ b/src/jukebox/player/PlayerMPD.py
@@ -25,7 +25,7 @@ class player_control:
             self.music_player_status.save_to_json()
             self.current_folder_status = {}
         else:
-            last_played_folder = self.music_player_status['player_status']['last_played_folder']
+            last_played_folder = self.music_player_status['player_status'].get('last_played_folder')
             if last_played_folder is not None:
                 self.current_folder_status = self.music_player_status['audio_folder_status'][last_played_folder]
                 self.mpd_client.clear()

--- a/src/jukebox/run_jukebox.py
+++ b/src/jukebox/run_jukebox.py
@@ -14,6 +14,7 @@ import misc.loggingext
 def main():
     # Get absolute path of this script
     script_path = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+    working_path = os.path.abspath(os.getcwd())
     default_cfg_jukebox = os.path.abspath(os.path.join(script_path, '../../settings/jukebox.conf'))
     default_cfg_logger = os.path.abspath(os.path.join(script_path, '../../settings/logger.yaml'))
 
@@ -39,6 +40,10 @@ def main():
         logger = misc.loggingext.configure_from_file(args.logger)
 
     logger.info("Starting Jukebox Daemon")
+    if working_path != script_path:
+        logger.warning("It is working_path != script_path. If you have relative filenames in your config, they may not be found!")
+        logger.warning(f"working_path: '{working_path}'")
+        logger.warning(f"script_path : '{script_path}'")
     myjukebox = jukebox.daemon.JukeBox(args.conf.name)
     myjukebox.run()
 


### PR DESCRIPTION
I have added the yaml-based config handling.

This works slightly different to the handler before. It uses the same 'background'-style mechanism that the logging module uses. See cfghandler.py for documentation.

This PR also changes the way additional modules are loaded. This is the first step to a plugin interface for additional modules. Very rudimentary at the moment. Currently plugin handling is only available for the also volume control. And the plugin source code handling is spread over daemon.py and server.py. Things to change in the future.

Important changes:
- Uses yaml config file for main config (others not changed)
- Volume.py is replaced by alsaif.py (just in case somebody later wants to write a pulseaudio plugin for volume control) The superseded Volume.py is not yet deleted for reference.
### The format for the RPC has changed: Instead of 
`{'object':'','method':'','params':{},id:''}`
it is now
`{'plugin':'','method':'',args:'', kwargs:'',id:''}`
where args and kwargs can be used as in python and both are entirely optional.


