### PR TITLE
Update README.md

### DIFF
--- a/components/rfid-reader/RC522/README.md
+++ b/components/rfid-reader/RC522/README.md
@@ -13,3 +13,5 @@
 
 4. Restart the phoniebox-rfid-reader service:
    - `sudo systemctl restart phoniebox-rfid-reader.service`
+
+Be aware that unlike a few other installations with this card reader the phoniebox requires the IRQ pin to be connected (on the raspberry pi and zero normaly to GPIO 24 or PIN 18).


### PR DESCRIPTION
(docs) I struggled with this for the 4th time on new phoniebox installations and most pinout graphs for these card leave the cable for IRQ out and although you can read a card on python, the phoniebox does not read anything. With the cable in place on that pin it works like a charm from the beginning.