### PR TITLE
install alsa-utils (needed for buster lite)

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,6 +22,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update
+        sudo apt-get install -y libasound2-dev
         python -m pip install --upgrade pip
         pip install wheel
         pip install spidev

--- a/installation/install-jukebox.sh
+++ b/installation/install-jukebox.sh
@@ -110,7 +110,7 @@ install_jukebox_dependencies() {
     samba samba-common-bin \
     python3 python3-dev python3-pip python3-setuptools python3-mutagen python3-gpiozero \
     ffmpeg \
-    alsa-utils \
+    alsa-utils libasound2-dev \
     --no-install-recommends \
     --allow-downgrades \
     --allow-remove-essential \

--- a/installation/install-jukebox.sh
+++ b/installation/install-jukebox.sh
@@ -110,7 +110,7 @@ install_jukebox_dependencies() {
     samba samba-common-bin \
     python3 python3-dev python3-pip python3-setuptools python3-mutagen python3-gpiozero \
     ffmpeg \
-    alsa-tools \
+    alsa-utils \
     --no-install-recommends \
     --allow-downgrades \
     --allow-remove-essential \


### PR DESCRIPTION
#1255 misses the alsa-utils package that is needed make it work on buster-lite
see #1467