### PR TITLE
Publish "card swiped" event via MQTT

### DIFF
--- a/components/smart-home-automation/MQTT-protocol/README.md
+++ b/components/smart-home-automation/MQTT-protocol/README.md
@@ -34,8 +34,16 @@ Phoniebox' MQTT client will do the following things:
 2. at shutdown send state info to
    - `phoniebox/state` (offline)
 3. periodically send *all* attributes to `phoniebox/attribute/$attributeName` (this interval can be defined through `refreshIntervalPlaying` and `refreshIntervalIdle` in the `SETTINGS` section)
-4. listen for attribute requests on `phoniebox/get/$attribute`
-5. listen for commands on `phoniebox/cmd/$command` (if a command needs a parameter it has to be provided via payload)
+4. send specific events to `phoniebox/event/$eventName` right away
+5. listen for attribute requests on `phoniebox/get/$attribute`
+6. listen for commands on `phoniebox/cmd/$command` (if a command needs a parameter it has to be provided via payload)
+
+## Topic: phoniebox/event/$event
+This is a read-only topic. The following events trigger immediate messages through this topic:
+
+- card_swiped
+
+Use these topics to get notified of time-critical events right away rather than having to wait for the periodic send of all attributes or requesting an attribute through the get topic. Currently the only event triggering a message is the "card_swiped" event with the obvious use-case of letting your smart home react upon swiped cards. These cards needn't be configured in Phoniebox as the MQTT daemon will just relay any swiped card to the MQTT server. So it's possible to have a "dim lights" card that will not trigger any Phoniebox action but is picked up by your smart home to dim the lights.
 
 ## Topic: phoniebox/get/$attribute
 MQTT clients can (additionally to the periodic updates) request an attribute of Phoniebox. Sending an empty payload to `phoniebox/get/volume` will trigger Phoniebox' MQTT client to fetch the current volume from MPD and send the result to `phoniebox/attribute/volume`. 

--- a/components/smart-home-automation/MQTT-protocol/README.md
+++ b/components/smart-home-automation/MQTT-protocol/README.md
@@ -122,7 +122,7 @@ Sending empty payload to `phoniebox/cmd/help` will be responded by a list of all
 Install missing python packages for MQTT:
 
 ~~~
-sudo pip3 install paho-mqtt inotify
+sudo python3 -m pip install --upgrade --force-reinstall -q -r requirements.txt
 ~~~
 
 All relevant files can be found in the folder:

--- a/components/smart-home-automation/MQTT-protocol/README.md
+++ b/components/smart-home-automation/MQTT-protocol/README.md
@@ -114,7 +114,7 @@ Sending empty payload to `phoniebox/cmd/help` will be responded by a list of all
 Install missing python packages for MQTT:
 
 ~~~
-sudo pip3 install paho-mqtt
+sudo pip3 install paho-mqtt inotify
 ~~~
 
 All relevant files can be found in the folder:

--- a/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
+++ b/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
@@ -56,6 +56,14 @@ def watchForNewCard():
 
             # file was closed and written => a new card was swiped
             if "IN_CLOSE_WRITE" in e_type_names:
+                # fetch card ID
+                cardid = readfile(path + "/../settings/Latest_RFID")
+
+                # publish event "card_swiped"
+                client.publish(mqttBaseTopic + "/event/card_swiped", payload=cardid)
+                print(" --> Publishing event card_swiped = " + cardid)
+
+                # process all attributes
                 processGet("all")
 
 

--- a/components/smart-home-automation/MQTT-protocol/requirements.txt
+++ b/components/smart-home-automation/MQTT-protocol/requirements.txt
@@ -1,0 +1,5 @@
+# MQTT daemon related requirements
+# you need to install these with `sudo python3 -m pip install --upgrade --force-reinstall -q -r requirements.txt`
+
+paho-mqtt
+inotify


### PR DESCRIPTION
Added a new topic that the MQTT daemon will publish messages on. This is about immediate event-based messages (in contrast to periodic) with currently the only event being the "card swiped" event. It makes use of inotify to watch for changes to the `Latest_RFID` file and immediately sending the card ID to the MQTT server.

That way also cards that are not assigned to media or an action within Phoniebox will get relayed to the MQTT server allowing to e.g. control your smart home via the Phoniebox (e.g. having a "dim the lights" card to change lights while not interfering with the current playback).

It's an implementation of the idea presented in https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/1492 but directly integrated into the MQTT daemon rather than the RFID daemon.