### PR TITLE
Add Ci for usb reader, see also #1501

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -19,3 +19,4 @@ jobs:
         docker run --rm -i rpi-jukebox-rfid-buster:latest /code/scripts/installscripts/tests/run_installation_tests.sh
         docker run --rm -i rpi-jukebox-rfid-buster:latest /code/scripts/installscripts/tests/run_installation_tests2.sh
         docker run --rm -i rpi-jukebox-rfid-buster:latest /code/scripts/installscripts/tests/run_installation_tests3.sh
+        docker run --rm -i rpi-jukebox-rfid-buster:latest /code/scripts/installscripts/tests/run_installation_tests4.sh

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ __pycache__/
 *.*~
 *.pyc
 *.idea
+.venv
 
 
 # Created by https://www.gitignore.io/api/composer

--- a/ci/Dockerfile.buster.test_install.amd64
+++ b/ci/Dockerfile.buster.test_install.amd64
@@ -9,7 +9,8 @@ RUN groupadd --gid 1000 pi ;\
   chmod +x /code/scripts/installscripts/buster-install-default.sh ;\
   chmod +x /code/scripts/installscripts/tests/run_installation_tests.sh ;\
   chmod +x /code/scripts/installscripts/tests/run_installation_tests2.sh ;\
-  chmod +x /code/scripts/installscripts/tests/run_installation_tests3.sh
+  chmod +x /code/scripts/installscripts/tests/run_installation_tests3.sh ;\
+  chmod +x /code/scripts/installscripts/tests/run_installation_tests4.sh
 
 RUN export DEBIAN_FRONTEND=noninteractive ;\
   apt-get update ;\

--- a/ci/Dockerfile.buster.test_install.amd64
+++ b/ci/Dockerfile.buster.test_install.amd64
@@ -29,6 +29,7 @@ RUN export DEBIAN_FRONTEND=noninteractive ;\
   apt-get -y install wget build-essential git iw locales wpasupplicant;\
   apt-get clean ;\
   touch /boot/cmdlinetxt ;\
-  rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+  rm -rf /var/cache/apt/* /var/lib/apt/lists/* ;\
+  cp /code/misc/sampleconfigs/deviceName.txt.stretch-default.sample /code/deviceName.txt
 
 USER pi

--- a/scripts/installscripts/tests/run_installation_tests4.sh
+++ b/scripts/installscripts/tests/run_installation_tests4.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Install Phoniebox and test it
+# Used e.g. for tests on Docker
+
+# Objective: Test installation with script using a RC522 reader
+
+# Print current path
+echo $PWD
+
+# Preparations
+# Skip interactive Samba WINS config dialog
+echo "samba-common samba-common/dhcp boolean false" | sudo debconf-set-selections
+# No interactive frontend
+export DEBIAN_FRONTEND=noninteractive
+
+# Run installation (in interactive mode)
+# y confirm interactive
+# n dont configure wifi
+# y PCM as iface
+# n no spotify
+# y configure mpd
+# y audio default location
+# y use gpio
+# y RFID registration
+# 1 use USB reader
+# yes, reader is connected
+# n No reboot
+
+# TODO check, how this behaves on branches other than develop
+GIT_BRANCH=develop bash ./scripts/installscripts/buster-install-default.sh <<< $'y\nn\n\ny\n\nn\n\ny\n\ny\n\ny\n\ny\ny\n1\ny\nn\n'
+
+# Test installation
+./scripts/installscripts/tests/test_installation.sh

--- a/scripts/installscripts/tests/run_installation_tests4.sh
+++ b/scripts/installscripts/tests/run_installation_tests4.sh
@@ -24,11 +24,12 @@ export DEBIAN_FRONTEND=noninteractive
 # y use gpio
 # y RFID registration
 # 1 use USB reader
+# 0 use first device in list
 # yes, reader is connected
 # n No reboot
 
 # TODO check, how this behaves on branches other than develop
-GIT_BRANCH=develop bash ./scripts/installscripts/buster-install-default.sh <<< $'y\nn\n\ny\n\nn\n\ny\n\ny\n\ny\n\ny\ny\n1\ny\nn\n'
+GIT_BRANCH=develop bash ./scripts/installscripts/buster-install-default.sh <<< $'y\nn\n\ny\n\nn\n\ny\n\ny\n\ny\n\ny\ny\n1\n0\ny\nn\n'
 
 # Test installation
 ./scripts/installscripts/tests/test_installation.sh


### PR DESCRIPTION
- [ ] Fix test, see
   - [ ] provide devicename.txt
   - [ ] Fix manual inputs in run installation script

```
If you are using an RFID reader, connect it to your RPi.
(In case your RFID reader required soldering, consult the manual.)
Please select the RFID reader you want to use
1) USB-Reader (e.g. Neuftech)  4) Manual configuration
2) RC522		       5) Multiple RFID reader
3) PN532
#? Choose the reader from list
Device Number: Traceback (most recent call last):
  File "RegisterDevice.py", line 14, in <module>
    dev_id = int(input('Device Number: '))
ValueError: invalid literal for int() with base 10: 'y'
chown: cannot access '/home/pi/RPi-Jukebox-RFID/scripts/deviceName.txt': No such file or directory
chmod: cannot access '/home/pi/RPi-Jukebox-RFID/scripts/deviceName.txt': No such file or directory
```