### PR TITLE
Fix samplecfg for GPIO component

### DIFF
--- a/misc/sampleconfigs/gpio_settings.ini.sample
+++ b/misc/sampleconfigs/gpio_settings.ini.sample
@@ -3,7 +3,7 @@ enabled: True
 antibouncehack: False
 
 [VolumeControl]
-enabled: True
+enabled: False
 Type: TwoButtonControl ;or RotaryEncoder
 Pin1: 5
 Pin2: 6
@@ -16,7 +16,7 @@ functionCall2: functionCallVolD
 functionCallTwoButtons: functionCallVol0 ;only for TwoButtonControl
 
 [PrevNextControl]
-enabled: True
+enabled: False
 Type: TwoButtonControl
 Pin1: 22
 Pin2: 23
@@ -28,7 +28,7 @@ hold_time: 0.3
 hold_mode: None
 
 [PlayPause]
-enabled: True
+enabled: False
 Type: Button
 Pin: 27
 pull_up_down: pull_up
@@ -93,14 +93,14 @@ pull_up_down: pull_up
 functionCall: functionCallPlayerPrev
 
 [FastForward]
-enabled: false
+enabled: False
 Type:  Button
 Pin: 7
 pull_up_down: pull_up
 functionCall: functionCallPlayerSeekFwd
 
 [Rewind]
-enabled: false
+enabled: False
 Type:  Button
 Pin: 8
 pull_up_down: pull_up
@@ -114,7 +114,7 @@ pull_up_down: pull_up
 functionCall: functionCallPlayerPauseForce
 
 [RFIDDevice]
-enabled: True
+enabled: False
 Type: Button
 Pin: 21
 pull_up_down: pull_up

--- a/misc/sampleconfigs/gpio_settings.ini.sample
+++ b/misc/sampleconfigs/gpio_settings.ini.sample
@@ -1,16 +1,18 @@
 [DEFAULT]
 enabled: True
+antibouncehack: False
+
 [VolumeControl]
 enabled: True
 Type: TwoButtonControl ;or RotaryEncoder
-PinUp: 5
-PinDown: 6
-pull_up: True
+Pin1: 5
+Pin2: 6
+pull_up_down: pull_up
 hold_time: 0.3
-hold_repeat: True
+hold_mode: Repeat
 timeBase: 0.1 ;only for RotaryEncoder
-functionCallDown: functionCallVolD
-functionCallUp: functionCallVolU
+functionCall1: functionCallVolU
+functionCall2: functionCallVolD
 functionCallTwoButtons: functionCallVol0 ;only for TwoButtonControl
 
 [PrevNextControl]
@@ -21,72 +23,99 @@ Pin2: 23
 functionCall1: functionCallPlayerPrev
 functionCall2: functionCallPlayerNext
 functionCallTwoButtons: None
-pull_up: True
+pull_up_down: pull_up
 hold_time: 0.3
-hold_repeat: False
+hold_mode: None
 
 [PlayPause]
 enabled: True
 Type: Button
 Pin: 27
-pull_up: True
-hold_time: 0.3
+pull_up_down: pull_up
 functionCall: functionCallPlayerPause
 
 [Shutdown]
 enabled: False
 Type:  Button
 Pin: 3
-pull_up: True
+pull_up_down: pull_up
+hold_mode: Postpone
 hold_time: 2
 functionCall: functionCallShutdown
+
+[PauseShutdown]
+enabled: False
+Type:  Button
+Pin: 3
+pull_up_down: pull_up
+hold_time: 2.0
+hold_mode: SecondFunc
+functionCall: functionCallPlayerPause
+functionCall2: functionCallShutdown
 
 [Volume0]
 enabled: False
 Type:  Button
 Pin: 17
-pull_up: True
-hold_time: 0.3
+pull_up_down: pull_up
 functionCall: functionCallVol0
 
 [VolumeUp]
 enabled: False
 Type:  Button
 Pin: 16
-pull_up: True
+pull_up_down: pull_up
 hold_time: 0.3
-hold_repeat: True
+hold_mode: Repeat
 functionCall: functionCallVolU
 
 [VolumeDown]
 enabled: False
 Type:  Button
 Pin: 19
-pull_up: True
+pull_up_down: pull_up
 hold_time: 0.3
-hold_repeat: True
+hold_mode: Repeat
 functionCall: functionCallVolD
 
 [NextSong]
 enabled: False
 Type:  Button
 Pin: 26
-pull_up: True
-hold_time: 0.3
+pull_up_down: pull_up
 functionCall: functionCallPlayerNext
 
 [PrevSong]
 enabled: False
 Type:  Button
 Pin: 20
-pull_up: True
-hold_time: 0.3
+pull_up_down: pull_up
 functionCall: functionCallPlayerPrev
+
+[FastForward]
+enabled: false
+Type:  Button
+Pin: 7
+pull_up_down: pull_up
+functionCall: functionCallPlayerSeekFwd
+
+[Rewind]
+enabled: false
+Type:  Button
+Pin: 8
+pull_up_down: pull_up
+functionCall: functionCallPlayerSeekBack
 
 [Halt]
 enabled: False
 Type:  Button
-Pin: 21
-pull_up: True
-hold_time: 0.3
+Pin: 25
+pull_up_down: pull_up
 functionCall: functionCallPlayerPauseForce
+
+[RFIDDevice]
+enabled: True
+Type: Button
+Pin: 21
+pull_up_down: pull_up
+functionCall: functionCallPlayerStop


### PR DESCRIPTION
**Short version:**

- This replaces the  'misc/sampleconfigs/gpio_settings.ini.sample' (untouched since 11 months) with the current 'components/gpio_control/example_configs/gpio_settings.ini', which contains the latest syntax

- A few example buttons were enabled by default. I changed these to disabled too. Reason: I think it's no good idea to configure concrete GPIO ports (without knowing the user's hardware setup!), just because a user activated the GPIO control component at installation.

**Longer version:**
Background for bullet #1 was that, after Release 2.3, a user reported an issue with a shutdown button reacting too quickly on a fresh install ( https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/1509  ). This was quickly resolved after identifying a missing line in the GPIO sample config.
When we updated and extended the GPIO component few months ago, we also added an syntax-auto-update for old-style configs. 
Maybe this was the reason we did not also update the sample config in the misc folder. At least for the postponed shutdown button (which didn't work before 2.3 either) these auto-fixes did not suffice completely. So it's safer to bring the sample config to the latest syntax.

