### PR TITLE
(docs) GPIO-Documentation in /docs is deprecated

### DIFF
--- a/docs/GPIO-BUTTONS.md
+++ b/docs/GPIO-BUTTONS.md
@@ -1,4 +1,5 @@
-
+Deprecated, please see [wiki](/wiki) for the latest version
+---------------------------------------------
 # Control Jukebox with buttons / GPIO
 
 (Other docs: [Installation](https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/INSTALL-stretch) |


### PR DESCRIPTION
Article in the wiki has been updated, this one is deprecated -> maybe remove entirely?