### PR TITLE
Ignore codespaces dirs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -23,3 +23,5 @@ extend-exclude =
     docs/sphinx/conf.py,
     # Ignore dirs and files that have not been ported yet
     */jukebox/NvManager.py
+    # ignore GitHub Codespaces
+    .venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 *.py[cod]
 
 .git
+.venv
 *~
 *.*~
 *.pyc


### PR DESCRIPTION
Ignore the venv directory, which is created if using GitHub Codespaces