### PR TITLE
get rid of -p option in read

### DIFF
--- a/installation/routines/customize_options.sh
+++ b/installation/routines/customize_options.sh
@@ -6,7 +6,7 @@ _option_static_ip() {
   echo "Would you like to set a static IP (will be ${CURRENT_IP_ADDRESS})?
 It'll save a lot of start up time. This can be changed later.
 [Y/n] " 1>&3
-  read -rp "ENABLE_STATIC_IP" response
+  read -r response
   case "$response" in
     [nN][oO]|[nN])
       ENABLE_STATIC_IP=false
@@ -20,7 +20,7 @@ It'll save a lot of start up time. This can be changed later.
 _option_ipv6() {
   # DISABLE_IPv6
   echo "Do you want to disable IPv6? [Y/n] " 1>&3
-  read -rp "DISABLE_IPv6" response
+  read -r response
   case "$response" in
     [nN][oO]|[nN])
       DISABLE_IPv6=false
@@ -36,7 +36,7 @@ _option_bluetooth() {
   echo "Do you want to disable Bluethooth?
 We recommend to turn off Bluetooth to save energy and booting time.
 [Y/n] " 1>&3
-  read -rp "DISABLE_BLUETOOTH" response
+  read -r response
   case "$response" in
     [nN][oO]|[nN])
       DISABLE_BLUETOOTH=false
@@ -53,7 +53,7 @@ _option_samba() {
 There are other ways to copy music to your RPi but Samba is the simplest
 method. If you are unsure, say yes!
 [Y/n] " 1>&3
-  read -rp "ENABLE_SAMBA" response
+  read -r response
   case "$response" in
     [nN][oO]|[nN])
       ENABLE_SAMBA=false
@@ -71,7 +71,7 @@ _option_webapp() {
 If you don't want to use a graphical interface to manage your Phoniebox,
 you don't need to install the web application.
 [Y/n] " 1>&3
-  read -rp "ENABLE_WEBAPP" response
+  read -r response
   case "$response" in
     [nN][oO]|[nN])
       ENABLE_WEBAPP=false
@@ -97,7 +97,7 @@ _option_webapp_prod_build() {
   The latter will install NodeJS and will proling the
   installation time but you will get the latest features.
   [Y/n] " 1>&3
-    read -rp "ENABLE_WEBAPP_PROD_BUILD" response
+    read -r response
     case "$response" in
       [nN])
         ENABLE_WEBAPP_PROD_BUILD=false
@@ -117,7 +117,7 @@ If you have a screen attached to your RPi, this will launch the
 web application right after boot. It will only install the necessary
 xserver dependencies and not the entire RPi desktop environment.
 [y/N] " 1>&3
-  read -rp "ENABLE_KIOSK_MODE" response
+  read -r response
   case "$response" in
     [yY])
       ENABLE_KIOSK_MODE=true
@@ -133,7 +133,7 @@ _options_update_raspi_os() {
   echo "Would you like to update the operating system?
 This shall be done eventually, but increases the installation time a lot.
 [y/N] " 1>&3
-  read -rp "UPDATE_RASPI_OS" response
+  read -r response
   case "$response" in
     [yY])
       UPDATE_RASPI_OS=true

--- a/installation/routines/setup_mpd.sh
+++ b/installation/routines/setup_mpd.sh
@@ -47,7 +47,7 @@ setup_mpd() {
   if [[ -f ${MPD_CONF_PATH} || -f ${SYSTEMD_PATH}/mpd.service ]]; then
     echo "  It seems there is a MPD already installed."
     echo "  Would you like to overwrite your configuration? [Y/n] " | tee /dev/fd/3
-      read -rp "MPD_OVERRIDE_CONFIG" response
+      read -r response
       case "$response" in
         [nN][oO]|[nN])
           MPD_EXECUTE_INSTALL=false


### PR DESCRIPTION
I experienced some strange behaviour during installation due to the `-p` option

For clarification the text from `read --help`

```
      -p prompt	output the string PROMPT without a trailing newline before
    		attempting to read
      -r	do not allow backslashes to escape any characters
```