### PR TITLE
[Bugfix] pip install fails sometimes when not updated initally

### DIFF
--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -29,6 +29,8 @@ _jukebox_core_install_os_dependencies() {
     --allow-downgrades \
     --allow-remove-essential \
     --allow-change-held-packages
+
+  pip3 install --upgrade pip
 }
 
 _jukebox_core_build_libzmq_with_drafts() {


### PR DESCRIPTION
During install, I received this error when installing `pyzmq`

```
Collecting pyzmq
  Downloading https://files.pythonhosted.org/packages/6c/95/d37e7db364d7f569e71068882b1848800f221c58026670e93a4c6d50efe7/pyzmq-22.3.0.tar.gz (1.2MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  Complete output from command /usr/bin/python3 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-5da89x76 --no-warn-script-location --no-binary :all: --only-binary :none: -i https://pypi.org/simple --extra-index-url https://www.piwheels.org/simple --pre -- setuptools wheel packaging "cffi; implementation_name == 'pypy'":
  Ignoring cffi: markers 'implementation_name == "pypy"' don't match your environment
  Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple, https://www.piwheels.org/simple
  Collecting setuptools
    Downloading https://files.pythonhosted.org/packages/02/b5/456e90af3712ca1b25c60ed74d0facb8b65cbaaa42cdceedf3b210580eef/setuptools-58.4.0.tar.gz (2.3MB)
    Installing build dependencies: started
    Installing build dependencies: finished with status 'error'
    Complete output from command /usr/bin/python3 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-k9mh0ds2 --no-warn-script-location --no-binary :all: --only-binary :none: -i https://pypi.org/simple --extra-index-url https://www.piwheels.org/simple --extra-index-url https://www.piwheels.org/simple --pre --:
    ERROR: You must give at least one requirement to install (see "pip help install")

    ----------------------------------------
  Command "/usr/bin/python3 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-k9mh0ds2 --no-warn-script-location --no-binary :all: --only-binary :none: -i https://pypi.org/simple --extra-index-url https://www.piwheels.org/simple --extra-index-url https://www.piwheels.org/simple --pre --" failed with error code 1 in None

  ----------------------------------------
/usr/lib/python3/dist-packages/pip/_internal/commands/install.py:222: UserWarning: Disabling all use of wheels due to the use of --build-options / --global-options / --install-options.
  cmdoptions.check_install_build_global(options)
Command "/usr/bin/python3 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-5da89x76 --no-warn-script-location --no-binary :all: --only-binary :none: -i https://pypi.org/simple --extra-index-url https://www.piwheels.org/simple --pre -- setuptools wheel packaging "cffi; implementation_name == 'pypy'"" failed with error code 1 in None
```

After a bit of research, I found that it is required to update `pip` for whatever reason, which was not required before.
This is the fix

```
pip3 install --upgrade pip
```