### PR TITLE
Add Monitoring with Battery and Jukebox Version

### DIFF
--- a/src/jukebox/components/battery_monitor/BatteryMonitorBase.py
+++ b/src/jukebox/components/battery_monitor/BatteryMonitorBase.py
@@ -77,7 +77,7 @@ class BattmonBase():
         self._logger = logger
         self.batt_status = {}
         self.batt_status['soc'] = 0
-        self.batt_status['chargeing'] = 0
+        self.batt_status['charging'] = 0
         self.batt_status['voltage'] = 0
         self.interval = 5
         num = cfg.setndefault('battmon', 'scale_to_phy_num', value=35)
@@ -127,9 +127,9 @@ class BattmonBase():
         soc = int(interpolate(self.soc_cc, batt_voltage_mV))
 
         if (batt_voltage_mV - batt_voltage_mV_slow) < 0:
-            chargeing = 0
+            charging = 0
         else:
-            chargeing = 1
+            charging = 1
 
         if (batt_voltage_mV < self.shutdown_voltage):
             self._logger.warning(f"Shutdown due to low Battery: {soc}%, Batt Voltage: {batt_voltage_mV}mV")
@@ -142,10 +142,10 @@ class BattmonBase():
             if (self.all_clear_action is not None):
                 utils.decode_and_call_rpc_command(self.all_clear_action, self._logger)
 
-        self._logger.info(f"SOC: {soc}%, Batt Voltage: {batt_voltage_mV}mV, charging:{chargeing}")
+        self._logger.info(f"SOC: {soc}%, Batt Voltage: {batt_voltage_mV}mV, charging:{charging}")
 
         self.batt_status['soc'] = soc
-        self.batt_status['chargeing'] = chargeing
+        self.batt_status['charging'] = charging
         self.batt_status['voltage'] = batt_voltage_mV
 
         jukebox.publishing.get_publisher().send('batt_status', self.batt_status)

--- a/src/webapp/src/components/Settings/helpers/battery-icon.js
+++ b/src/webapp/src/components/Settings/helpers/battery-icon.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import Battery20Icon from '@mui/icons-material/Battery20';
+import Battery30Icon from '@mui/icons-material/Battery30';
+import Battery50Icon from '@mui/icons-material/Battery50';
+import Battery60Icon from '@mui/icons-material/Battery60';
+import Battery80Icon from '@mui/icons-material/Battery80';
+import Battery90Icon from '@mui/icons-material/Battery90';
+import BatteryFullIcon from '@mui/icons-material/BatteryFull';
+import BatteryCharging20Icon from '@mui/icons-material/BatteryCharging20';
+import BatteryCharging30Icon from '@mui/icons-material/BatteryCharging30';
+import BatteryCharging50Icon from '@mui/icons-material/BatteryCharging50';
+import BatteryCharging60Icon from '@mui/icons-material/BatteryCharging60';
+import BatteryCharging80Icon from '@mui/icons-material/BatteryCharging80';
+import BatteryCharging90Icon from '@mui/icons-material/BatteryCharging90';
+import BatteryChargingFullIcon from '@mui/icons-material/BatteryChargingFull';
+import BatteryUnknownIcon from '@mui/icons-material/BatteryUnknown';
+
+const BatteryIcon = ({ soc, charging }) => {
+  if (charging) {
+    if (soc <= 20) return <BatteryCharging20Icon />;
+    else if (soc > 20 && soc <= 30) return <BatteryCharging30Icon />;
+    else if (soc > 30 && soc <= 50) return <BatteryCharging50Icon />;
+    else if (soc > 50 && soc <= 60) return <BatteryCharging60Icon />;
+    else if (soc > 60 && soc <= 80) return <BatteryCharging80Icon />;
+    else if (soc > 80 && soc <= 90) return <BatteryCharging90Icon />;
+    else if (soc > 90) return <BatteryChargingFullIcon />;
+  }
+  else {
+    if (soc <= 20) return <Battery20Icon />;
+    else if (soc > 20 && soc <= 30) return <Battery30Icon />;
+    else if (soc > 30 && soc <= 50) return <Battery50Icon />;
+    else if (soc > 50 && soc <= 60) return <Battery60Icon />;
+    else if (soc > 60 && soc <= 80) return <Battery80Icon />;
+    else if (soc > 80 && soc <= 90) return <Battery90Icon />;
+    else if (soc > 90) return <BatteryFullIcon />;
+  }
+
+  return <BatteryUnknownIcon />;
+};
+
+export default BatteryIcon;

--- a/src/webapp/src/components/Settings/index.js
+++ b/src/webapp/src/components/Settings/index.js
@@ -7,6 +7,7 @@ import SettingsSecondSwipe from './secondswipe';
 import SystemControls from './systemcontrols';
 import SettingsVolume from './volume';
 import SettingsAutoHotspot from './autohotspot';
+import SettingsStatus from './status';
 
 import { useTheme } from '@mui/material/styles';
 
@@ -24,6 +25,9 @@ const Settings = () => {
         padding: '10px',
       }}
     >
+      <Grid item>
+        <SettingsStatus />
+      </Grid>
       <Grid item>
         <SystemControls />
       </Grid>

--- a/src/webapp/src/components/Settings/status.js
+++ b/src/webapp/src/components/Settings/status.js
@@ -1,0 +1,77 @@
+import React, { useContext, useEffect, useState } from 'react';
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemAvatar,
+  Avatar,
+} from '@mui/material';
+
+import FavoriteIcon from '@mui/icons-material/Favorite';
+
+import BatteryIcon from './helpers/battery-icon';
+import PubSubContext from '../../context/pubsub/context';
+import { pluginIsLoaded } from '../../utils/utils';
+
+const SettingsStatus = () => {
+  const { state: {
+    'core.plugins.loaded': plugins,
+    'core.version': coreVersion,
+    'batt_status': { soc, charging } = {}
+  } } = useContext(PubSubContext);
+
+  const [batteryPluginAvaialble, setBatteryPluginAvailability] = useState(false);
+
+  useEffect(() => {
+    if (pluginIsLoaded(plugins, 'battmon')) {
+      setBatteryPluginAvailability(true);
+    }
+  }, [plugins]);
+
+  return (
+    <Card>
+      <CardHeader title="System Status" />
+      <Divider />
+      <CardContent>
+        <Grid container>
+          <Grid item xs={12}>
+            <List>
+              <ListItem disableGutters>
+                <ListItemAvatar>
+                  <Avatar>
+                    <FavoriteIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  primary={coreVersion ? `${coreVersion}` : 'Loading ...'}
+                  secondary="Jukebox Core Version"
+                />
+              </ListItem>
+              {batteryPluginAvaialble &&
+                <ListItem disableGutters>
+                  <ListItemAvatar>
+                    <Avatar>
+                      <BatteryIcon soc={soc} charging={charging} />
+                    </Avatar>
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={soc ? `${soc}%` : 'Loading ...'}
+                    secondary={soc ? `Battery is ${!charging ? 'not ' : ''}charging` : 'Battery'}
+                  />
+                </ListItem>
+              }
+            </List>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SettingsStatus;

--- a/src/webapp/src/components/Settings/systemcontrols.js
+++ b/src/webapp/src/components/Settings/systemcontrols.js
@@ -12,6 +12,7 @@ import RebootDialog from './dialogs/reboot';
 import ShutDownDialog from './dialogs/shutdown';
 
 const SystemControls = () => {
+
   return (
     <Card>
       <CardHeader title="System Controls" />

--- a/src/webapp/src/config.js
+++ b/src/webapp/src/config.js
@@ -6,7 +6,9 @@ const REQRES_ENDPOINT = `ws://${HOST}:5556`;
 const PUBSUB_ENDPOINT = `ws://${HOST}:5557`;
 
 const SUBSCRIPTIONS = [
+  'batt_status',
   'core.plugins.loaded',
+  'core.version',
   'core.started_at',
   'playerstatus',
   'rfid.card_id',


### PR DESCRIPTION
* New section in Settings called "System Status"
* Currently includes
  * Jukebox version
  * Battery Charging status when plugin is loaded

<img width="357" alt="Screenshot 2021-12-10 at 00 11 30" src="https://user-images.githubusercontent.com/1260686/145491001-2fcff40b-b381-43f4-ab6a-e0be47c5db0e.png">
