### PR TITLE
#1309, #1451 Fixes missing title and cover for spotify playlists by adding user-agent

### DIFF
--- a/htdocs/inc.viewFolderTree.php
+++ b/htdocs/inc.viewFolderTree.php
@@ -116,18 +116,19 @@ foreach($subfolders as $key => $subfolder) {
 			// this is a new and easier way for loading spotify informations!
 			$uri = file_get_contents($subfolder."/spotify.txt");
 			$url = "https://open.spotify.com/oembed/?url=".trim($uri)."&format=json";
+			$headers = stream_context_create(array('http'=>array('method'=>'GET', 'header'=>'user-agent:Phoniebox')));
 			
 			if (!file_exists($coverfile)) {
-				$str = file_get_contents($url);
+				$str = file_get_contents($url, false, $headers);
 				$json  = json_decode($str, true);
 
 				$cover = $json['thumbnail_url'];
-				$coverdl = file_get_contents($cover);
+				$coverdl = file_get_contents($cover, false, $headers);
 				file_put_contents($coverfile, $coverdl);
 			}
 			
 			if (!file_exists($titlefile)) {
-				$str = file_get_contents($url);
+				$str = file_get_contents($url, false, $headers);
 				$json  = json_decode($str, true);
 
 				$title = $json['title'];


### PR DESCRIPTION
Spotify returns a bad request when no user-agent is given.

Simple way to reproduce: 

```
<?php
// demo code to reproduce:
$headers = stream_context_create(array('http'=>array('method'=>'GET', 'header'=>'user-agent:Phoniebox')));
$url = "https://open.spotify.com/oembed?url=spotify:playlist:4wFsylSpjoor3HXkle80sa&format=json";

echo "This will work:\n";
echo file_get_contents($url, false, $headers);

echo "\n\nThis will fail (400 Bad Request):\n";
echo file_get_contents($url);
?>
```

Therefore I added a simple user-agent to all spotify requests. It is similar and inspired by the solution of @acidburn78 but without adding a new dependency.