### PR TITLE
Reader.py: split line read from deviceName.txt

### DIFF
--- a/scripts/Reader.py.experimental
+++ b/scripts/Reader.py.experimental
@@ -187,7 +187,7 @@ class Reader(object):
             sys.exit('Please run RegisterDevice.py first')
         else:
             with open(path + '/deviceName.txt', 'r') as f:
-                device_name = f.read()
+                device_name = f.read().rstrip().split(';',1)[0]
 
             if device_name == 'MFRC522':
                 self.reader = Mfrc522Reader()


### PR DESCRIPTION
Hi There,

First of all, thank you very much for that great project. I recently made a box as Christmas present and enjoyed very much working on it.

I had a little trouble getting the RFID-RC522 running. I used the Reader.py.experimental script for reading RFID tags.
The problem seems to be, that the line from the deviceName.txt is just taken as device name but the line seems to have several columns separated by ';'.
I improved the code by copying over a snippet from the Reader.py.experimental.Multi to split the line at ';'.

Could you please double check if this works on your side to.

Thank you and best regards,
Daniel