### PR TITLE
Update to encrypted git protocol for RC522 dependency download

### DIFF
--- a/src/jukebox/components/rfid/hardware/rc522_spi/requirements.txt
+++ b/src/jukebox/components/rfid/hardware/rc522_spi/requirements.txt
@@ -3,11 +3,11 @@
 
 # pi-rc522 use latest version from Github
 # This is the original versions. Seems unmaintained for the moment
-# git+git://github.com/ondryaso/pi-rc522.git#egg=pi-rc522
+# git+https://github.com/ondryaso/pi-rc522.git#egg=pi-rc522
 
 # The fork of kevinvalk has some good improvements
 # https://github.com/kevinvalk/pi-rc522
 # Get the kevinvalk fork yet again from a different fork which ensures compatibility with the Phoniebox
-git+git://github.com/ChisSoc/pi-rc522.git#egg=pi-rc522
+git+https://github.com/ChisSoc/pi-rc522.git#egg=pi-rc522
 
 


### PR DESCRIPTION
Fixes:

~~~
Collecting pi-rc522
  Cloning git://github.com/ChisSoc/pi-rc522.git to /tmp/pip-install-9ufnoeqv/pi-rc522_675a00eee274444790e977f26418741c
  Running command git clone --filter=blob:none -q git://github.com/ChisSoc/pi-rc522.git /tmp/pip-install-9ufnoeqv/pi-rc522_675a00eee274444790e977f26418741c
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
WARNING: Discarding git+git://github.com/ChisSoc/pi-rc522.git#egg=pi-rc522. Command errored out with exit status 128: git clone --filter=blob:none -q git://github.com/ChisSoc/pi-rc522.git /tmp/pip-install-9ufnoeqv/pi-rc522_675a00eee274444790e977f26418741c Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement pi-rc522 (unavailable) (from versions: 1.1.0.linux-armv6l, 1.1.0, 2.2.0, 2.2.1)
ERROR: No matching distribution found for pi-rc522 (unavailable)
Error: The operation was canceled.
~~~