### PR TITLE
Add exit_on_error handler for install routines

### DIFF
--- a/installation/includes/05_finish.sh
+++ b/installation/includes/05_finish.sh
@@ -32,3 +32,24 @@ Do you want to reboot now? [Y/n]" 1>&3
       ;;
   esac
 }
+
+# Generic emergency error handler that exits the script immediately
+# Print additional custom message if passed as first argument
+# Examples:
+#   cd some-dir || exit_on_error
+#   cd some-dir || exit_on_error "During installation of some"
+exit_on_error () {
+
+  echo -e "\n****************************************" | tee /dev/fd/3
+  echo -e "ERROR OCCURRED!
+A non-recoverable error occurred.
+Check install log for details:" | tee /dev/fd/3
+  echo "$INSTALLATION_LOGFILE" | tee /dev/fd/3
+  echo -e "****************************************" | tee /dev/fd/3
+  if [[ -n $1 ]]; then
+    echo "$1" | tee /dev/fd/3
+    echo -e "****************************************" | tee /dev/fd/3
+  fi
+  echo "Abort!"
+  exit 1
+}

--- a/installation/install-jukebox.sh
+++ b/installation/install-jukebox.sh
@@ -41,10 +41,9 @@ download_jukebox_source() {
   unset GIT_REPO_DOWNLOAD
 }
 
-
 ### RUN INSTALLATION
 INSTALLATION_LOGFILE="${HOME_PATH}/INSTALL-${INSTALL_ID}.log"
-exec 3>&1 1>>${INSTALLATION_LOGFILE} 2>&1
+exec 3>&1 1>>"${INSTALLATION_LOGFILE}" 2>&1 || { echo "Cannot create log file. Panic."; exit 1; }
 echo "Log start: ${INSTALL_ID}"
 
 clear 1>&3
@@ -52,15 +51,15 @@ echo "Downloading Phoniebox software from Github ..." 1>&3
 echo "Download Source: ${GIT_URL}/${GIT_BRANCH}" | tee /dev/fd/3
 
 download_jukebox_source
-cd ${INSTALLATION_PATH}
+cd "${INSTALLATION_PATH}" || { echo "ERROR in changing to install dir. Panic."; exit 1; }
 
 # Load / Source dependencies
-for i in $INSTALLATION_PATH/installation/includes/*;
-  do source $i
+for i in "${INSTALLATION_PATH}"/installation/includes/*; do
+  source "$i"
 done
 
-for j in $INSTALLATION_PATH/installation/routines/*;
-  do source $j
+for j in "${INSTALLATION_PATH}"/installation/routines/*; do
+  source "$j"
 done
 
 welcome

--- a/installation/routines/customize_options.sh
+++ b/installation/routines/customize_options.sh
@@ -251,7 +251,7 @@ customize_options() {
   _option_samba
   _option_webapp
   _option_build_local_docs
-  if [ "$ENABLE_WEBAPP" = true ] ; then
+  if [[ $ENABLE_WEBAPP == true ]] ; then
     _option_kiosk_mode
     _option_webapp_devel_build
   fi

--- a/installation/routines/setup_git.sh
+++ b/installation/routines/setup_git.sh
@@ -140,7 +140,7 @@ _git_convert_tardir_git_repo() {
 init_git_repo_from_tardir() {
   echo "Install Git & init repository" | tee /dev/fd/3
 
-  cd ${INSTALLATION_PATH}
+  cd "${INSTALLATION_PATH}" || exit_on_error
   _git_install_os_dependencies
   _git_convert_tardir_git_repo
 

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -45,27 +45,27 @@ _jukebox_core_build_libzmq_with_drafts() {
   LIBSODIUM_VERSION="1.0.18"
   ZMQ_VERSION="4.3.4"
 
-  cd ${HOME_PATH} && mkdir ${ZMQ_TMP_DIR} && cd ${ZMQ_TMP_DIR}; \
-      wget --quiet https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}-RELEASE/libsodium-${LIBSODIUM_VERSION}.tar.gz; \
-      tar -zxvf libsodium-${LIBSODIUM_VERSION}.tar.gz; \
-      cd libsodium-${LIBSODIUM_VERSION}/; \
-      ./configure; \
-      make && make install
+  { cd "${HOME_PATH}" && mkdir "${ZMQ_TMP_DIR}" && cd "${ZMQ_TMP_DIR}"; } || exit_on_error
+  wget --quiet https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}-RELEASE/libsodium-${LIBSODIUM_VERSION}.tar.gz
+  tar -zxvf libsodium-${LIBSODIUM_VERSION}.tar.gz
+  cd libsodium-${LIBSODIUM_VERSION} || exit_on_error
+  ./configure
+  make && make install
 
-  cd ${HOME}/${ZMQ_TMP_DIR}; \
-      wget https://github.com/zeromq/libzmq/releases/download/v${ZMQ_VERSION}/zeromq-${ZMQ_VERSION}.tar.gz -O libzmq.tar.gz; \
-      tar -xzf libzmq.tar.gz; \
-      zeromq-${ZMQ_VERSION}/configure --prefix=${ZMQ_PREFIX} --enable-drafts; \
-      make && make install;
+  cd "${HOME}/${ZMQ_TMP_DIR}" || exit_on_error
+  wget https://github.com/zeromq/libzmq/releases/download/v${ZMQ_VERSION}/zeromq-${ZMQ_VERSION}.tar.gz -O libzmq.tar.gz
+  tar -xzf libzmq.tar.gz
+  zeromq-${ZMQ_VERSION}/configure --prefix=${ZMQ_PREFIX} --enable-drafts
+  make && make install
 }
 
 _jukebox_core_download_prebuild_libzmq_with_drafts() {
   local ZMQ_TAR_FILENAME="libzmq.tar.gz"
 
-  _download_file_from_google_drive ${LIBZMQ_GD_DOWNLOAD_ID} ${ZMQ_TAR_FILENAME}
+  _download_file_from_google_drive "${LIBZMQ_GD_DOWNLOAD_ID}" "${ZMQ_TAR_FILENAME}"
   tar -xzf ${ZMQ_TAR_FILENAME}
   rm -f ${ZMQ_TAR_FILENAME}
-  sudo rsync -a * ${ZMQ_PREFIX}/
+  sudo rsync -a ./* ${ZMQ_PREFIX}/
 }
 
 _jukebox_core_build_and_install_pyzmq() {
@@ -82,11 +82,11 @@ _jukebox_core_build_and_install_pyzmq() {
     # Download pre-compiled libzmq from Google Drive because RPi has trouble compiling it
     echo "    Download pre-compiled libzmq from Google Drive because RPi has trouble compiling it"
 
-    cd ${HOME_PATH} && mkdir ${ZMQ_TMP_DIR} && cd ${ZMQ_TMP_DIR}
+    { cd "${HOME_PATH}" && mkdir "${ZMQ_TMP_DIR}" && cd "${ZMQ_TMP_DIR}"; } || exit_on_error
 
     # ARMv7 as default
     LIBZMQ_GD_DOWNLOAD_ID=${GD_ID_COMPILED_LIBZMQ_ARMV7}
-    if [ `uname -m` = "armv6l" ]; then
+    if [[ $(uname -m) == "armv6l" ]]; then
       # ARMv6 as fallback
       LIBZMQ_GD_DOWNLOAD_ID=${GD_ID_COMPILED_LIBZMQ_ARMV6}
       _show_slow_hardware_message
@@ -110,30 +110,30 @@ _jukebox_core_download_prebuilt_pyzmq() {
   echo "  Download prebuilt pyzmq with WebSockets Support"
   local PYZMQ_TAR_FILENAME="pyzmq-build-armv6.tar.gz"
 
-  cd ${HOME_PATH}
+  cd "${HOME_PATH}" || exit_on_error
 
   # ARMv7 as default
   PYZMQ_GD_DOWNLOAD_ID=${GD_ID_COMPILED_PYZMQ_ARMV7}
-  if [ `uname -m` = "armv6l" ]; then
+  if [[ $(uname -m) == "armv6l" ]]; then
     # ARMv6 as fallback
     PYZMQ_GD_DOWNLOAD_ID=${GD_ID_COMPILED_PYZMQ_ARMV6}
   fi
 
-  _download_file_from_google_drive ${PYZMQ_GD_DOWNLOAD_ID} ${PYZMQ_TAR_FILENAME}
-  tar -xvf ${PYZMQ_TAR_FILENAME} -C /
-  rm -f ${PYZMQ_TAR_FILENAME}
+  _download_file_from_google_drive "${PYZMQ_GD_DOWNLOAD_ID}" "${PYZMQ_TAR_FILENAME}"
+  tar -xvf "${PYZMQ_TAR_FILENAME}" -C /
+  rm -f "${PYZMQ_TAR_FILENAME}"
 }
 
 _jukebox_core_install_python_requirements() {
   echo "  Install requirements"
-  cd ${INSTALLATION_PATH}
-  sudo pip3 install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
+  cd "${INSTALLATION_PATH}"  || exit_on_error
+  sudo pip3 install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt"
 }
 
 _jukebox_core_install_settings() {
   echo "  Register Jukebox settings"
-  cp -f ${INSTALLATION_PATH}/resources/default-settings/jukebox.default.yaml ${SETTINGS_PATH}/jukebox.yaml
-  cp -f ${INSTALLATION_PATH}/resources/default-settings/logger.default.yaml ${SETTINGS_PATH}/logger.yaml
+  cp -f "${INSTALLATION_PATH}/resources/default-settings/jukebox.default.yaml" "${SETTINGS_PATH}/jukebox.yaml"
+  cp -f "${INSTALLATION_PATH}/resources/default-settings/logger.default.yaml" "${SETTINGS_PATH}/logger.yaml"
 }
 
 _jukebox_core_register_as_service() {

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -25,7 +25,7 @@ _jukebox_webapp_install_node() {
 
     # Zero and older versions of Pi with ARMv6 only
     # support experimental NodeJS
-    if [ `uname -m` = "armv6l" ]; then
+    if [[ $(uname -m) == "armv6l" ]]; then
       NODE_SOURCE=${NODE_SOURCE_EXPERIMENTAL}
     fi
 
@@ -39,7 +39,7 @@ _jukebox_webapp_install_node() {
 # Instead implement a Github Action that prebuilds on commititung a git tag
 _jukebox_webapp_build() {
   echo "  Building web application"
-  cd ${INSTALLATION_PATH}/src/webapp
+  cd "${INSTALLATION_PATH}/src/webapp" || exit_on_error
   npm ci --prefer-offline --no-audit --production
   rm -rf build
   # The build wrapper script checks available memory on system and sets Node options accordingly
@@ -49,11 +49,11 @@ _jukebox_webapp_build() {
 _jukebox_webapp_download() {
   echo "  Downloading web application" | tee /dev/fd/3
   local TAR_FILENAME="webapp-build.tar.gz"
-  cd ${INSTALLATION_PATH}/src/webapp
+  cd "${INSTALLATION_PATH}/src/webapp" || exit_on_error
   _download_file_from_google_drive ${GD_ID_COMPILED_WEBAPP} ${TAR_FILENAME}
   tar -xzf ${TAR_FILENAME}
   rm -f ${TAR_FILENAME}
-  cd ${INSTALLATION_PATH}
+  cd "${INSTALLATION_PATH}" || exit_on_error
 }
 
 _jukebox_webapp_register_as_system_service_with_nginx() {
@@ -65,7 +65,7 @@ _jukebox_webapp_register_as_system_service_with_nginx() {
   sudo service nginx start
 
   sudo mv -f /etc/nginx/sites-available/default /etc/nginx/sites-available/default.orig
-  sudo cp -f ${INSTALLATION_PATH}/resources/default-settings/nginx.default /etc/nginx/sites-available/default
+  sudo cp -f "${INSTALLATION_PATH}/resources/default-settings/nginx.default" /etc/nginx/sites-available/default
 
   sudo service nginx restart
 }
@@ -79,16 +79,16 @@ _jukebox_build_local_docs() {
 setup_jukebox_webapp() {
   echo "Install web application" | tee /dev/fd/3
 
-  if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" = true || "$ENABLE_WEBAPP_PROD_DOWNLOAD" = release-only ]] ; then
+  if [[ $ENABLE_WEBAPP_PROD_DOWNLOAD == true || $ENABLE_WEBAPP_PROD_DOWNLOAD == release-only ]] ; then
     _jukebox_webapp_download
   fi
-  if [ "$ENABLE_INSTALL_NODE" = true ] ; then
+  if [[ $ENABLE_INSTALL_NODE == true ]] ; then
     _jukebox_webapp_install_node
     # Local Web App build during installation does not work at the moment
     # Needs to be done after reboot! There will be a message at the end of the installation process
     # _jukebox_webapp_build
   fi
-  if [ "$ENABLE_LOCAL_DOCS" = true ]; then
+  if [[ $ENABLE_LOCAL_DOCS == true ]]; then
     _jukebox_build_local_docs
   fi
   _jukebox_webapp_register_as_system_service_with_nginx

--- a/installation/routines/setup_rfid_reader.sh
+++ b/installation/routines/setup_rfid_reader.sh
@@ -3,7 +3,7 @@
 setup_rfid_reader() {
   echo "Install RFID Reader" | tee /dev/fd/3
 
-  python3 ${INSTALLATION_PATH}/src/jukebox/run_register_rfid_reader.py | tee /dev/fd/3
+  python3 "${INSTALLATION_PATH}/src/jukebox/run_register_rfid_reader.py" | tee /dev/fd/3
 
   echo "DONE: setup_rfid_reader"
 }


### PR DESCRIPTION
In case a `cd` or similar fails, the installation aborts rather than continue installation routines in wrong directory. 
This prevents the effect of #1685. 
(In #1685 the could be an improved fix as well: removing temporary directories before. However, this PR prevents ill effects in case no custom error handling is implemented)

Also fixes a few ShellCheck warnings.