### PR TITLE
fix reported duration attribute via mqtt

### DIFF
--- a/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
+++ b/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
@@ -476,6 +476,19 @@ def regex(needle, hay, exception="-"):
     else:
         return exception
 
+def getDuration(status):
+    """ Find the duration of the track in the output from mpd status"""
+
+    # try to get the duration value
+    duration = regex("\nduration: (.*)\n", status)
+
+    if duration == "-":
+        # if the duration attribute is missing try to get the time
+        # this attribute value is split into two parts by ":"
+        # first is the elapsed time and the second part is the duration
+        duration = regex("\ntime: .*:(.*)\n", status, "0")
+    
+    return int(float(duration))
 
 def fetchData():
     # use global refreshInterval as this function is run as a thread through the paho-mqtt loop
@@ -523,7 +536,7 @@ def fetchData():
             int(hours), int(minutes), int(seconds)
         )
 
-        duration = int(float(regex("\time: .*:(.*)\n", status, "0")))
+        duration = getDuration(status)
         hours, remainder = divmod(duration, 3600)
         minutes, seconds = divmod(remainder, 60)
         result["duration"] = "{:02}:{:02}:{:02}".format(

--- a/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
+++ b/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
@@ -523,7 +523,7 @@ def fetchData():
             int(hours), int(minutes), int(seconds)
         )
 
-        duration = int(float(regex("\nduration: (.*)\n", status, "0")))
+        duration = int(float(regex("\time: .*:(.*)\n", status, "0")))
         hours, remainder = divmod(duration, 3600)
         minutes, seconds = divmod(remainder, 60)
         result["duration"] = "{:02}:{:02}:{:02}".format(


### PR DESCRIPTION
This change adjusts the regex to read the correct duration and fixes the issue that currently duration is always 0 reported via mqtt. (Mentioned here: https://github.com/MiczFlor/RPi-Jukebox-RFID/discussions/1353#discussioncomment-2327099) 
In the status response the duration is not existing anymore and now it is getting reported as `time: 22:200`
This means the first part is the elapsed time and the second part is the actual duration of the track.

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/6809130/158489045-ee481d13-fe1b-4aa0-984c-8f8b615826e7.png">

Example how the attribute gets send now via mqtt
![image](https://user-images.githubusercontent.com/6809130/158490538-4ad54b60-fa12-482b-a84d-59985a0d9696.png)

