### PR TITLE
fix(install): updates the URL and adds missing key

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -786,7 +786,8 @@ install_main() {
 
     # Install required packages
     ${apt_get} ${allow_downgrades} install apt-transport-https
-    wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
+    sudo mkdir -p /usr/local/share/keyrings
+    sudo wget -q -O /usr/local/share/keyrings/mopidy-archive-keyring.gpg https://apt.mopidy.com/mopidy.gpg
     sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/buster.list
 
     ${apt_get} update


### PR DESCRIPTION
The installation of mopidy would fail for me. Adding the key like suggested in the documentation fixed it for me: https://docs.mopidy.com/en/latest/installation/debian/