### PR TITLE
fix(install): add missing python package

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -804,7 +804,7 @@ install_main() {
     sudo cp /etc/resolv.conf.orig /etc/resolv.conf
 
     # prepare python3
-    ${apt_get} ${allow_downgrades} install python3 python3-dev python3-pip python3-mutagen python3-gpiozero python3-spidev
+    ${apt_get} ${allow_downgrades} install python3 python3-dev python3-pip python3-mutagen python3-gpiozero python3-spidev python3-evdev
 
     # use python3 as default
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1


### PR DESCRIPTION
Should address one of the issues mentioned in the following tickets:

- https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/1618
- https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/1788 