### PR TITLE
fix(install): mopidy for spotify install

### DIFF
--- a/scripts/installscripts/buster-install-default-with-autohotspot.sh
+++ b/scripts/installscripts/buster-install-default-with-autohotspot.sh
@@ -828,7 +828,7 @@ install_main() {
         # keep major verson 3 of mopidy
         echo -e "Package: mopidy\nPin: version 3.*\nPin-Priority: 1001" | sudo tee /etc/apt/preferences.d/mopidy
 
-        wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
+        sudo wget -q -O /usr/local/share/keyrings/mopidy-archive-keyring.gpg https://apt.mopidy.com/mopidy.gpg
         sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/buster.list
         ${apt_get} update
         ${apt_get} upgrade

--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -834,7 +834,7 @@ install_main() {
         # keep major verson 3 of mopidy
         echo -e "Package: mopidy\nPin: version 3.*\nPin-Priority: 1001" | sudo tee /etc/apt/preferences.d/mopidy
 
-        wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
+        sudo wget -q -O /usr/local/share/keyrings/mopidy-archive-keyring.gpg https://apt.mopidy.com/mopidy.gpg
         sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/buster.list
         ${apt_get} update
         ${apt_get} upgrade


### PR DESCRIPTION
Follow up of https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/1789/files fixing the issue also for the spotify install