### PR TITLE
feature: add repeat mode attribute to mqtt

### DIFF
--- a/components/smart-home-automation/MQTT-protocol/README.md
+++ b/components/smart-home-automation/MQTT-protocol/README.md
@@ -52,6 +52,7 @@ MQTT clients can (additionally to the periodic updates) request an attribute of 
 - volume
 - mute
 - repeat
+- repeat_mode [off / single / playlist]
 - random
 - state
 - file

--- a/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
+++ b/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
@@ -631,11 +631,6 @@ tWatchForNewCard = Thread(target=watchForNewCard)
 tWatchForNewCard.setDaemon(True)
 tWatchForNewCard.start()
 
-# register thread for watchForNewCard
-tWatchForNewCard = Thread(target=watchForNewCard)
-tWatchForNewCard.setDaemon(True)
-tWatchForNewCard.start()
-
 # start endless loop
 client.loop_start()
 while True:

--- a/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
+++ b/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
@@ -453,6 +453,24 @@ def regex(needle, hay, exception="-"):
         return exception
 
 
+REPEAT_MODE_OFF = "off"
+REPEAT_MODE_SINGLE = "single"
+REPEAT_MODE_PLAYLIST = "playlist"
+
+
+def get_repeat_mode(repeat, status):
+    """ Returns the repeat mode that is selected in mpd """
+
+    if repeat == "false":
+        return REPEAT_MODE_OFF
+
+    single = regex("\nsingle: (.*)\n", status)
+    if single == "0":
+        return REPEAT_MODE_PLAYLIST
+
+    return REPEAT_MODE_SINGLE
+
+
 def fetchData():
     # use global refreshInterval as this function is run as a thread through the paho-mqtt loop
     global refreshInterval
@@ -470,16 +488,8 @@ def fetchData():
     result["state"] = regex("\nstate: (.*)\n", status).lower()
     result["volume"] = regex("\nvolume: (.*)\n", status)
     result["repeat"] = normalizeTrueFalse(regex("\nrepeat: (.*)\n", status))
+    result["repeat_mode"] = get_repeat_mode(result["repeat"], status)
     result["random"] = normalizeTrueFalse(regex("\nrandom: (.*)\n", status))
-
-    if result["repeat"] == "true":
-        single = normalizeTrueFalse(regex("\nsingle: (.*)\n", status))
-        if single == "true":
-            result["repeat_mode"] = "single"
-        else:
-            result["repeat_mode"] = "playlist"
-    else:
-        result["repeat_mode"] = "off"
 
     # interpret mute state based on volume
     if result["volume"] == "0":

--- a/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
+++ b/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
@@ -86,6 +86,7 @@ arAvailableAttributes = [
     "volume",
     "mute",
     "repeat",
+    "repeat_mode",
     "random",
     "state",
     "file",
@@ -495,6 +496,15 @@ def fetchData():
     result["volume"] = regex("\nvolume: (.*)\n", status)
     result["repeat"] = normalizeTrueFalse(regex("\nrepeat: (.*)\n", status))
     result["random"] = normalizeTrueFalse(regex("\nrandom: (.*)\n", status))
+
+    if result["repeat"] == "true":
+        single = normalizeTrueFalse(regex("\nsingle: (.*)\n", status))
+        if single == "true":
+            result["repeat_mode"] = "single"
+        else:
+            result["repeat_mode"] = "playlist"
+    else:
+        result["repeat_mode"] = "off"
 
     # interpret mute state based on volume
     if result["volume"] == "0":

--- a/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
+++ b/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
@@ -138,31 +138,6 @@ def watchForNewCard():
                 processGet("all")
 
 
-def watchForNewCard():
-    i = inotify.adapters.Inotify()
-    i.add_watch(path + "/../settings/Latest_RFID")
-
-    # wait for inotify events
-    for event in i.event_gen(yield_nones=False):
-        if event is not None:
-            # fetch event attributes
-            (e_header, e_type_names, e_path, e_filename) = event
-
-            # file was closed and written => a new card was swiped
-            if "IN_CLOSE_WRITE" in e_type_names:
-                # fetch card ID
-                cardid = readfile(path + "/../settings/Latest_RFID")
-
-                # publish event "card_swiped"
-                client.publish(
-                    config.get("mqttBaseTopic") + "/event/card_swiped", payload=cardid
-                )
-                print(" --> Publishing event card_swiped = " + cardid)
-
-                # process all attributes
-                processGet("all")
-
-
 def on_connect(client, userdata, flags, rc):
     if rc == 0:
         print("Connection established.")


### PR DESCRIPTION
This PR adds the `repeat_mode` attribute to mqtt. This will have one of the three values used in [playout_controls.sh#L865](https://github.com/MiczFlor/RPi-Jukebox-RFID/blob/develop/scripts/playout_controls.sh#L865) `off`/`single`/`playlist`.

Also part of this PR is also some cleaning up of duplicated code. If you want I can separate the PRs as well.

<img width="608" alt="image" src="https://user-images.githubusercontent.com/6809130/162438376-1159f341-9644-4df6-9c0b-4b664c20160a.png">
