### PR TITLE
Update 'GPIO Recipes'  for power button

### DIFF
--- a/src/jukebox/components/gpio/gpioz/README.rst
+++ b/src/jukebox/components/gpio/gpioz/README.rst
@@ -124,7 +124,7 @@ A button to increase the volume by 5 steps every 0.75 seconds as long as it is p
 Button: Shutdown
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-A button to shutdown the Jukebox if it is presse for more than 3 seconds. Note the different ``type`` here!
+A button to shutdown the Jukebox if it is pressed for more than 3 seconds. Note the different ``type`` here!
 
 .. code-block:: yaml
 
@@ -132,12 +132,11 @@ A button to shutdown the Jukebox if it is presse for more than 3 seconds. Note t
       IncreaseVolume:
         type: LongPressButton
         kwargs:
-          pin: 13
+          pin: 3
           hold_time: 3
         actions:
           on_press:
-            alias: change_volume
-            args: +5
+            alias: shutdown
 
 Button: Dual Action
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fix used alias in example for shutdown button. Using GPIO 3, as it allows waking a raspi from halt state [1].

[1] https://elinux.org/RPI_safe_mode#cite_note-1