### PR TITLE
flexible php version in variable php_ini

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -693,7 +693,7 @@ samba_config() {
 web_server_config() {
     local lighthttpd_conf="/etc/lighttpd/lighttpd.conf"
     local fastcgi_php_conf="/etc/lighttpd/conf-available/15-fastcgi-php.conf"
-    local php_ini="/etc/php/7.3/cgi/php.ini"
+    local php_ini="/etc/php/$(ls -1 /etc/php)/cgi/php.ini"
     local sudoers="/etc/sudoers"
 
     echo "Configuring web server..."


### PR DESCRIPTION
Follow-up for commit "facilitate transition to bullseye".
Bug: Since bullseye uses php7.4, php.ini will not be replaced by the sample
Solution: Read folder name in /etc/php and use it in variable php_ini, keeping compatibility with buster