### PR TITLE
altered functions to use GPIO's for playing sound

### DIFF
--- a/components/gpio_control/function_calls.py
+++ b/components/gpio_control/function_calls.py
@@ -1,8 +1,9 @@
 import logging
 import sys
-from subprocess import Popen as function_call
+from subprocess import Popen as function_call, call
 import os
 import pathlib
+
 
 
 class phoniebox_function_calls:
@@ -11,7 +12,9 @@ class phoniebox_function_calls:
 
         playout_control_relative_path = "../../scripts/playout_controls.sh"
         function_calls_absolute_path = str(pathlib.Path(__file__).parent.absolute())
+        rfid_trigger_relative_path = "../../scripts/rfid_trigger_play.sh"
         self.playout_control = os.path.abspath(os.path.join(function_calls_absolute_path, playout_control_relative_path))
+        self.rfid_control = os.path.abspath(os.path.join(function_calls_absolute_path, rfid_trigger_relative_path))
 
     def functionCallShutdown(self, *args):
         function_call("{command} -c=shutdown".format(command=self.playout_control), shell=True)
@@ -86,8 +89,40 @@ class phoniebox_function_calls:
 
     def functionCallBluetoothToggle(self, *args):
         function_call("{command} -c=bluetoothtoggle -v=toggle".format(command=self.playout_control), shell=True)
+    
+    def functionCall_1(self, *args):
+        function_call("{command} --cardid={value}".format(command=self.rfid_control, value = 1 ), shell=True)
+        
+    def functionCall_2(self, *args):
+        function_call("{command} --cardid={value}".format(command=self.rfid_control, value = 2 ), shell=True)
+
+    def functionCall_3(self, *args):
+        function_call("{command} --cardid={value}".format(command=self.rfid_control, value = 3 ), shell=True)
+
+    def functionCall_4(self, *args):
+        function_call("{command} --cardid={value}".format(command=self.rfid_control, value = 4 ), shell=True)
+
+    def functionCall_5(self, *args):
+        function_call("{command} --cardid={value}".format(command=self.rfid_control, value = 5 ), shell=True)
+
+    def functionCall_6(self, *args):
+        function_call("{command} --cardid={value}".format(command=self.rfid_control, value = 6 ), shell=True)
+        
+    def functionCall_7(self, *args):
+        function_call("{command} --cardid={value}".format(command=self.rfid_control, value = 7 ), shell=True)
+
+    def functionCall_8(self, *args):
+        function_call("{command} --cardid={value}".format(command=self.rfid_control, value = 8 ), shell=True)
+
+    def functionCall_9(self, *args):
+        function_call("{command} --cardid={value}".format(command=self.rfid_control, value = 9 ), shell=True)
 
     def getFunctionCall(self, functionName):
         self.logger.error('Get FunctionCall: {} {}'.format(functionName, functionName in locals()))
         getattr(sys.modules[__name__], str)
         return locals().get(functionName, None)
+
+if __name__ == "__main__":
+   call = phoniebox_function_calls()
+   call.functionCall_1()
+

--- a/components/gpio_control/howto_use_GPIO-to_play_sounds.md
+++ b/components/gpio_control/howto_use_GPIO-to_play_sounds.md
@@ -1,0 +1,69 @@
+To use GPIO-Pins to play music, use the "functionCall_1" to "functionCall_9" directives . Afterward the connected buttons will appear as new rfid-Cards (1 to 9).
+So you can use them to mach folders or sounds to them.
+
+Example:
+
+[PressOne]
+enabled: True
+Type: Button
+Pin: 27
+pull_up_down: pull_down
+functionCall: functionCall_1
+
+
+[PressTwo]
+enabled: True
+Type: Button
+Pin: 22
+pull_up_down: pull_down
+functionCall: functionCall_2
+
+[PressThree]
+enabled: True
+Type: Button
+Pin: 23
+pull_up_down: pull_down
+functionCall: functionCall_3
+
+[PressFour]
+enabled: True
+Type: Button
+Pin: 24
+pull_up_down: pull_down
+functionCall: functionCall_4
+
+[PressFive]
+enabled: True
+Type: Button
+Pin: 13
+pull_up_down: pull_down
+functionCall: functionCall_5
+
+[PressSix]
+enabled: True
+Type: Button
+Pin: 06
+pull_up_down: pull_down
+functionCall: functionCall_6
+
+[PressSeven]
+enabled: True
+Type: Button
+Pin: 25
+pull_up_down: pull_down
+functionCall: functionCall_7
+
+[PressEight]
+enabled: True
+Type: Button
+Pin: 5
+pull_up_down: pull_down
+functionCall: functionCall_8
+
+[PlayPause]
+enabled: True
+Type: Button
+Pin: 19
+pull_up_down: pull_down
+functionCall: functionCallPlayerPause
+


### PR DESCRIPTION
by typing functionCall_1 to functionCall_9 in config there is a possibility to use buttons on GPIO to play sounds directly instead of swyping a card. I altered the "function_calls.py" by nine more functions to be used in "gpio_settings.ini" to emulate a card with the ID 1 to 9.
After pressing a configured button, the ID appears an can be assigned to a Soundfile or a folder.

I made this extension, because I wanted to build a phoniebox, which offers certain buttons for playing the music.

(for more info's see the howto-file next to function_calls.py)