### PR TITLE
Fixed documentation and example for shutdown button

### DIFF
--- a/resources/default-settings/gpio.example.yaml
+++ b/resources/default-settings/gpio.example.yaml
@@ -65,3 +65,11 @@ input_devices:
         args: 3
       on_long_press_ab:
         alias: toggle_output
+  Shutdown:
+    type: LongPressButton
+    kwargs:
+      pin: 3
+      hold_time: 3
+    actions:
+      on_press:
+        alias: shutdown

--- a/src/jukebox/components/gpio/gpioz/README.rst
+++ b/src/jukebox/components/gpio/gpioz/README.rst
@@ -130,12 +130,11 @@ A button to shutdown the Jukebox if it is presse for more than 3 seconds. Note t
       IncreaseVolume:
         type: LongPressButton
         kwargs:
-          pin: 13
+          pin: 3
           hold_time: 3
         actions:
           on_press:
-            alias: change_volume
-            args: +5
+            alias: shutdown
 
 Button: Dual Action
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Hello,
I tried to replace a legacy phoniebox with future3 and struggled with the shutdown button, because the documentation seemed only half correct. I fixed that and added an example to the gpio config.
