### PR TITLE
Use env variables for pyzmq 

### DIFF
--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -98,9 +98,8 @@ _jukebox_core_build_and_install_pyzmq() {
       _jukebox_core_download_prebuild_libzmq_with_drafts
     fi
 
-    sudo pip3 install --pre pyzmq \
-      --install-option=--enable-drafts \
-      --install-option=--zmq=${ZMQ_PREFIX}
+    sudo ZMQ_PREFIX=${ZMQ_PREFIX} ZMQ_DRAFT_API=1 \
+      pip3 install --no-cache-dir --pre pyzmq
   else
     echo "    Skipping. pyzmq already installed"
   fi


### PR DESCRIPTION
- pyzmq: use environment variables instead of deprecated --install-options for installation