### PR TITLE
Remove Gmusic

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The [2.4](https://github.com/MiczFlor/RPi-Jukebox-RFID/milestone/7?closed=1) rel
 * [Playout **Resume**](https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/MANUAL#manage-playout-behaviour) switch for audio books, allowing you to jump straight back to where you were (unless you fell asleep...).
 * Playout **Shuffle** switch to mix up your playlists.
 * Download from **YouTube** directly to your Phoniebox.
-* Support for **[Spotify](https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/Spotify-FAQ)** and **[Google Play Music](https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/Enable-Google-Play-Music-GMusic)** integration.
+* Support for **[Spotify](https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/Spotify-FAQ)** integration.
 * **Podcasts!** More for myself than anybody else, I guess, I added the [podcast feature for Phoniebox](https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/MANUAL#podcasts) (2018-05-09)
 * [Buttons](https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/Using-GPIO-hardware-buttons) and [knobs / dials](https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/Audio-RotaryKnobVolume) to control your **Phoniebox via GPIO**.
 

--- a/requirements-gmusic.txt
+++ b/requirements-gmusic.txt
@@ -1,3 +1,0 @@
-# Google Music related requirements (in addition to requirements-spotify.txt)
-# You need to install these with `sudo pip install --upgrade --force-reinstall -r requirements-gmusic.txt`
-Mopidy-Gmusic


### PR DESCRIPTION
GMusic is no longer available (see https://play.google.com/music).

also mopidy-gmusic is deprecated, so removing also here.