### PR TITLE
removed "is set" check (#1967)

### DIFF
--- a/scripts/rfid_trigger_play.sh
+++ b/scripts/rfid_trigger_play.sh
@@ -348,10 +348,8 @@ if [ "${DEBUG_rfid_trigger_play_sh}" == "TRUE" ]; then echo "# Type of play \$VA
 # check if
 # - $FOLDER is not empty (! -z "$FOLDER")
 # - AND (-a)
-# - $FOLDER is set (! -z ${FOLDER+x})
-# - AND (-a)
 # - and points to existing directory (-d "${AUDIOFOLDERSPATH}/${FOLDER}")
-if [ ! -z "$FOLDER" -a ! -z ${FOLDER+x} -a -d "${AUDIOFOLDERSPATH}/${FOLDER}" ]; then
+if [ ! -z "$FOLDER" -a -d "${AUDIOFOLDERSPATH}/${FOLDER}" ]; then
 
     if [ "${DEBUG_rfid_trigger_play_sh}" == "TRUE" ]; then echo "\$FOLDER set, not empty and dir exists: ${AUDIOFOLDERSPATH}/${FOLDER}" >> $PATHDATA/../logs/debug.log; fi
 


### PR DESCRIPTION
unquoted "is set" check fails if var is not set and if-statement has a subsequent check. Further the preceding "is empty" check is sufficient in this case.