### PR TITLE
Fix Pirate Audio Button Volume Up

### DIFF
--- a/components/audio/PirateAudioHAT/README.md
+++ b/components/audio/PirateAudioHAT/README.md
@@ -73,7 +73,7 @@ NOTE: changes to the installation should find their way into the script `setup_p
     bcm5 = play_pause,active_low,150
     bcm6 = volume_down,active_low,150
     bcm16 = next,active_low,150
-    bcm20 = volume_up,active_low,150
+    bcm24 = volume_up,active_low,150
     
     [pidi]
     enabled = true

--- a/components/audio/PirateAudioHAT/README.md
+++ b/components/audio/PirateAudioHAT/README.md
@@ -80,6 +80,8 @@ NOTE: changes to the installation should find their way into the script `setup_p
     enabled = true
     display = st7789
     ```
+    **Attention:** Early revisions of PirateAudio HAT used bcm20 for Volume up, later revisions use bcm24. see also https://github.com/pimoroni/pirate-audio/issues/63#issuecomment-916860634
+    
 
 12. Enable access for modipy user
     `sudo usermod -a -G spi,i2c,gpio,video mopidy`

--- a/components/audio/PirateAudioHAT/README.md
+++ b/components/audio/PirateAudioHAT/README.md
@@ -73,6 +73,7 @@ NOTE: changes to the installation should find their way into the script `setup_p
     bcm5 = play_pause,active_low,150
     bcm6 = volume_down,active_low,150
     bcm16 = next,active_low,150
+    bcm20 = volume_up,active_low,150
     bcm24 = volume_up,active_low,150
     
     [pidi]

--- a/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
+++ b/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
@@ -105,6 +105,7 @@ enabled = true
 bcm5 = play_pause,active_low,150
 bcm6 = volume_down,active_low,150
 bcm16 = next,active_low,150
+bcm20 = volume_up,active_low,150
 bcm24 = volume_up,active_low,150
 
 [pidi]

--- a/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
+++ b/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
@@ -105,7 +105,7 @@ enabled = true
 bcm5 = play_pause,active_low,150
 bcm6 = volume_down,active_low,150
 bcm16 = next,active_low,150
-bcm20 = volume_up,active_low,150
+bcm24 = volume_up,active_low,150
 
 [pidi]
 enabled = true


### PR DESCRIPTION
Fix #1974

important to note that early revisions of PirateAudio HAT used bcm20 for Volume up, later revisions use bcm24. See also https://github.com/pimoroni/pirate-audio/issues/63#issuecomment-916860634