### PR TITLE
Fix ShutdownButton LED does not stay on after hold time has expired and shutdown is ongoing 

### DIFF
--- a/components/gpio_control/GPIODevices/shutdown_button.py
+++ b/components/gpio_control/GPIODevices/shutdown_button.py
@@ -34,27 +34,28 @@ class ShutdownButton(SimpleButton):
             logger.debug('cannot set LED to {}: no LED pin defined'.format(status))
 
     def callbackFunctionHandler(self, *args):
-        logger.debug('ShutdownButton pressed, ensuring long press for {} seconds, checking each {}s'.format(
-            self.hold_time, self.iteration_time
-        ))
-        t_passed = 0
-        led_state = True
-        while t_passed < self.hold_time:
-            self.set_led(led_state)
-            time.sleep(self.iteration_time)
-            t_passed += self.iteration_time
-            led_state = not led_state
-            if not self.is_pressed:
-                break
-        if t_passed >= self.hold_time:
-            # trippel off period to indicate command accepted
-            self.set_led(GPIO.HIGH)
-            time.sleep(.6)
-            # leave it on for the moment, it will be off when the system is down
-            self.when_pressed(*args)
-        else:
-            # switch off LED if pressing was cancelled early (during flashing)
-            self.set_led(GPIO.LOW)
+        if self.is_pressed: # Should not be necessary, but handler gets called on rising edge too
+           logger.debug('ShutdownButton pressed, ensuring long press for {} seconds, checking each {}s'.format(
+               self.hold_time, self.iteration_time
+           ))
+           t_passed = 0
+           led_state = True
+           while t_passed < self.hold_time:
+               self.set_led(led_state)
+               time.sleep(self.iteration_time)
+               t_passed += self.iteration_time
+               led_state = not led_state
+               if not self.is_pressed:
+                   break
+           if t_passed >= self.hold_time:
+               # trippel off period to indicate command accepted
+               self.set_led(GPIO.HIGH)
+               time.sleep(.6)
+               # leave it on for the moment, it will be off when the system is down
+               self.when_pressed(*args)
+           else:
+               # switch off LED if pressing was cancelled early (during flashing)
+               self.set_led(GPIO.LOW)
 
     def __repr__(self):
         return '<ShutdownButton-{}(pin={},hold_time={},iteration_time={},led_pin={},edge={},bouncetime={},antibouncehack={},pull_up_down={})>'.format(


### PR DESCRIPTION
* Fixes #1982
* See the issue reproduction procedure and please test if you're seeing this issue, too.
* callbackFunctionHandler from [ShutdownButton](https://github.com/topas-rec/RPi-Jukebox-RFID/blob/610574655dd6c0086675a3bb3fb493db75006dce/components/gpio_control/GPIODevices/shutdown_button.py#L12) gets called when pushing AND releasing the button
* First call of handler sets LED to on correctly after the timeout time has expired - the second call caused by releasing the button sets the LED to off. The reason is that in that call the button is not pressed anymore and the hold time does therefor not expire.
* The handler should be called only when the button is pressed, as configured here: https://github.com/MiczFlor/RPi-Jukebox-RFID/blob/develop/components/gpio_control/GPIODevices/simple_button.py#L86
* The fix is not ideal - we should find out why the GPIO does react to falling AND rising edges, but this works and therefor better than keeping the issue
* Tested on Phoniebox