### PR TITLE
Fix Workflow Actions flake8 (future3)

### DIFF
--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -26,9 +26,9 @@ jobs:
         python-version: [3.7, 3.9]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ sphinx
 sphinx_rtd_theme
 
 # Code quality
-flake8
+flake8>=4.0.0
 pytest
 mock
 

--- a/src/jukebox/components/battery_monitor/BatteryMonitorBase.py
+++ b/src/jukebox/components/battery_monitor/BatteryMonitorBase.py
@@ -116,7 +116,7 @@ class BattmonBase():
 
     @plugs.tag
     def get_batt_status(self):
-        return(self.batt_status)
+        return (self.batt_status)
 
     def publish_status(self):
         batt_voltage_mV_raw = self.get_batt_voltage()

--- a/src/jukebox/jukebox/playlistgenerator.py
+++ b/src/jukebox/jukebox/playlistgenerator.py
@@ -202,7 +202,7 @@ class PlaylistCollector:
         self.special_handlers = {'livestream.txt': decode_livestream,
                                  'podcast.txt': decode_podcast,
                                  # Ignore all other .txt files
-                                 '.txt': lambda f, p, l: None,
+                                 '.txt': lambda _f, _p, _l: None,
                                  '.m3u': decode_m3u}
         self.default_handler = decode_musicfile
 


### PR DESCRIPTION
The post commit workflow action for python3.7 are currently failing ( actually since 01.10.2022 when _importlibs-metadata_ v5.0.0 was released ) due to an incompatiblity from _sphinx_ and _flake8_ on _importlibs-metadata_ in python 3.7 .

_sphinx_ defines since Version 4.4.0 as dependecy for _importlibs-metadata_ >= 4.4 and _flake8_ >= 3.5.0 
(https://github.com/sphinx-doc/sphinx/blob/v4.4.0/setup.py).
_flake8_ from Version 4.0.0 till 5.0.4 (latest for python 3.7) has a dependecy for _importlibs-metadata_ < 4.3.
(https://github.com/PyCQA/flake8/blob/4.0.0/setup.cfg)
_flake8_ Version 3.9.2 has no version entry for the _importlibs-metadata_ dependecy.
(https://github.com/PyCQA/flake8/blob/3.9.2/setup.cfg)

So this incompatibility in dependecies causes a version drop during installation of _flake8_ from 5.0.4 to 3.9.2 and _importlibs-metadata_ stays on a Version >= 5.0.0 as this is the first valid setup in regards of dependecies. But this Versions are incompatible and produce an error in the Workflow.


### Proposed Solution:
_flake8_ can be pinned in requirements.txt with a Version >= 4.0.0.
This will cause the _flake8_ Version to stay at 5.0.4 and _sphinx_ to drop to Version 4.3.2, due to _importlibs-metadata_ will be used in Version 4.2.0.
With this setup the tests will pass. 
This only affect the python 3.7 test as from python 3.8 and up the dependencies seem to be compatible again and newer Versions are installed (no Version drop recognized in the logs).
