### PR TITLE
Add new python dependecies (setuptools, wheel)

### DIFF
--- a/scripts/installscripts/buster-install-default-with-autohotspot.sh
+++ b/scripts/installscripts/buster-install-default-with-autohotspot.sh
@@ -804,7 +804,7 @@ install_main() {
     sudo cp /etc/resolv.conf.orig /etc/resolv.conf
 
     # prepare python3
-    ${apt_get} ${allow_downgrades} install python3 python3-dev python3-pip python3-mutagen python3-gpiozero python3-spidev
+    ${apt_get} ${allow_downgrades} install python3 python3-dev python3-pip python3-setuptools python3-wheel python3-mutagen python3-gpiozero python3-spidev
 
     # use python3.7 as default
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1

--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -805,7 +805,7 @@ install_main() {
     sudo cp /etc/resolv.conf.orig /etc/resolv.conf
 
     # prepare python3
-    ${apt_get} ${allow_downgrades} install python3 python3-dev python3-pip python3-mutagen python3-gpiozero python3-spidev
+    ${apt_get} ${allow_downgrades} install python3 python3-dev python3-pip python3-setuptools python3-wheel python3-mutagen python3-gpiozero python3-spidev
 
     # use python3 as default
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1

--- a/scripts/installscripts/tests/test_installation.sh
+++ b/scripts/installscripts/tests/test_installation.sh
@@ -155,7 +155,7 @@ verify_apt_packages(){
     local phpver="$(ls -1 /etc/php)"
     local packages="libspotify-dev samba
 samba-common-bin gcc lighttpd php${phpver}-common php${phpver}-cgi php${phpver} at mpd mpc mpg123 git ffmpeg
-resolvconf spi-tools python3 python3-dev python3-pip python3-mutagen python3-gpiozero
+resolvconf spi-tools python3 python3-dev python3-pip python3-setuptools python3-wheel python3-mutagen python3-gpiozero
 python3-spidev netcat alsa-utils"
     # TODO apt-transport-https checking only on RPi is currently a workaround
     local packages_raspberrypi="apt-transport-https raspberrypi-kernel-headers"

--- a/scripts/installscripts/tests/test_installation_altuser.sh
+++ b/scripts/installscripts/tests/test_installation_altuser.sh
@@ -154,7 +154,7 @@ verify_wifi_settings() {
 verify_apt_packages(){
     local packages="libspotify-dev samba
 samba-common-bin gcc lighttpd php7.3-common php7.3-cgi php7.3 at mpd mpc mpg123 git ffmpeg
-resolvconf spi-tools python3 python3-dev python3-pip python3-mutagen python3-gpiozero
+resolvconf spi-tools python3 python3-dev python3-pip python3-setuptools python3-wheel python3-mutagen python3-gpiozero
 python3-spidev netcat alsa-utils"
     # TODO apt-transport-https checking only on RPi is currently a workaround
     local packages_raspberrypi="apt-transport-https raspberrypi-kernel-headers"


### PR DESCRIPTION
The installation process of requirements.txt will fail if "git+ ... #egg" dependecies are defined and setuptools and/or wheels is not installed (directly or transitiv) -> "python setup.py egg_info" failed with error code 1

This is mostly relevant for minimal 'non RaspiOS' distros like DietPi.
I smoketested on RaspiOS and DietPi on RPi 4B and the installation succeeded in both cases and e.g. RFID Reader RC522 is directly working.


But im not very familiar with python, so are there any know problems in adding theses dependencies?
And i know other distros are no officially supported, but i reckon a step in this direction wouldn't be too bad.