### PR TITLE
Update python version matrix

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.11]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Added python 3.10 to version matrix
Added quotation for correct interpretation. Without it 3.10 is parsed as int and trailing zeros are cut -> 3.1

see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/1933