### PR TITLE
future3 - Editorconfig: Fix indent_size for js and yaml files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{js,yaml}]
+indent_size = 2


### PR DESCRIPTION
Like mentioned in https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2009#discussion_r1160975441 the indent size of js files should be 2. This also applies for yaml files.
So this should be applied by the editorconfig.