### PR TITLE
Make test gpio control work again

### DIFF
--- a/components/gpio_control/test/gpio_settings_test.ini
+++ b/components/gpio_control/test/gpio_settings_test.ini
@@ -13,8 +13,8 @@ PinUp: 16
 PinDown: 19
 timeBase: 0.1
 ; timeBase only for rotary encoder
-functionCallDown: functionCallVolD
-functionCallUp: functionCallVolU
+functionCall1: functionCallVolU
+functionCall2: functionCallVolD
 functionCallTwoButtons: functionCallVol0
 ; functionCallTwoButtons only for TwoButtonControl
 ; functionCallButton: functionCallPlayerPause ; only for RotaryEncoderClickable

--- a/components/gpio_control/test/test_gpio_control.py
+++ b/components/gpio_control/test/test_gpio_control.py
@@ -2,7 +2,8 @@ import configparser
 import logging
 
 from mock import patch, MagicMock
-from gpio_control import gpio_control
+with patch('os.system', return_value=0):
+    from gpio_control import gpio_control
 import function_calls
 
 # def test_functionCallTwoButtonsOnlyBtn2Pressed(btn1Mock, btn2Mock, functionCall1Mock, functionCall2Mock,

--- a/components/gpio_control/test/test_gpio_control.py
+++ b/components/gpio_control/test/test_gpio_control.py
@@ -29,7 +29,7 @@ logging.basicConfig(level='DEBUG')
 
 def testMain():
     config = configparser.ConfigParser()
-    config.read('./gpio_settings_test.ini')
+    config.read('./test/gpio_settings_test.ini')
 
     phoniebox_function_calls = function_calls.phoniebox_function_calls()
     gpio_controler = gpio_control(phoniebox_function_calls)


### PR DESCRIPTION
Test was running, but with the wrong configuration file.
With the correct configuration file it was failing because the content of the file was not up to date (RotaryEncoder was using wrong function call names)
After adding the correct function calls in the config the test didn't finish because os.system was never returning non zero in `led.py`. This is because os.system should find a phoniebox system service that may not be present on the machine that tests.