### PR TITLE
fix unavailable repo for pi-rc522

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
 import sys
 import os
 sys.path.append(os.path.abspath('src/jukebox'))
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,3 @@
 import sys
 import os
 sys.path.append(os.path.abspath('src/jukebox'))
-

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -4,4 +4,4 @@ readthedocs-sphinx-search
 # Install packages for documentation build from package repository
 # that are installed on the PI via APT
 RPi.GPIO
-gpiozero
+gpiozero<2.0.0;python_version<'3.8'

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -5,3 +5,4 @@ readthedocs-sphinx-search
 # that are installed on the PI via APT
 RPi.GPIO
 gpiozero<2.0.0;python_version<'3.8'
+gpiozero;python_version>='3.8'

--- a/src/jukebox/components/rfid/hardware/rc522_spi/requirements.txt
+++ b/src/jukebox/components/rfid/hardware/rc522_spi/requirements.txt
@@ -1,13 +1,6 @@
 # RC522 related requirements
 # You need to install these with `sudo python3 -m pip install --upgrade --force-reinstall -q -r requirements.txt`
 
-# pi-rc522 use latest version from Github
-# This is the original versions. Seems unmaintained for the moment
-# git+https://github.com/ondryaso/pi-rc522.git#egg=pi-rc522
-
-# The fork of kevinvalk has some good improvements
-# https://github.com/kevinvalk/pi-rc522
-# Get the kevinvalk fork yet again from a different fork which ensures compatibility with the Phoniebox
-git+https://github.com/ChisSoc/pi-rc522.git#egg=pi-rc522
+pi-rc522==2.3.0
 
 


### PR DESCRIPTION
The pi-rc522 fork from ChisSoc is not available anymore (https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2066). 
The fork from kevinvalk (base of ChisSoc's fork) was recently merged in the main repo and released as version 2.3.0.

To ensures compatibility with future changes pin the version to 2.3.0