### PR TITLE
add autohotspot config checks

### DIFF
--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -759,6 +759,7 @@ check_config_file() {
             check_variable "WIFIipRouter"
         fi
     fi
+
     check_variable "EXISTINGuse"
     check_variable "AUDIOiFace"
 
@@ -775,6 +776,14 @@ check_config_file() {
     check_variable "MPDconfig"
     check_variable "DIRaudioFolders"
     check_variable "GPIOconfig"
+
+    # Feature optional. if config not present, defaults to NO
+    if [[ "$AUTOHOTSPOTconfig" == "YES" ]]; then
+        check_variable "AUTOHOTSPOTssid"
+        check_variable "AUTOHOTSPOTcountryCode"
+        check_variable "AUTOHOTSPOTpass"
+        check_variable "AUTOHOTSPOTip"
+    fi
 
     if [ "${fail}" == "true" ]; then
       exit 1

--- a/scripts/installscripts/buster-install-default.sh
+++ b/scripts/installscripts/buster-install-default.sh
@@ -778,11 +778,15 @@ check_config_file() {
     check_variable "GPIOconfig"
 
     # Feature optional. if config not present, defaults to NO
-    if [[ "$AUTOHOTSPOTconfig" == "YES" ]]; then
-        check_variable "AUTOHOTSPOTssid"
-        check_variable "AUTOHOTSPOTcountryCode"
-        check_variable "AUTOHOTSPOTpass"
-        check_variable "AUTOHOTSPOTip"
+    if [[ -z "${AUTOHOTSPOTconfig}" ]]; then
+        echo "INFO: \$AUTOHOTSPOTconfig is missing or not set"
+    else
+        if [[ "$AUTOHOTSPOTconfig" == "YES" ]]; then
+            check_variable "AUTOHOTSPOTssid"
+            check_variable "AUTOHOTSPOTcountryCode"
+            check_variable "AUTOHOTSPOTpass"
+            check_variable "AUTOHOTSPOTip"
+        fi
     fi
 
     if [ "${fail}" == "true" ]; then

--- a/scripts/installscripts/tests/test_installation.sh
+++ b/scripts/installscripts/tests/test_installation.sh
@@ -136,6 +136,18 @@ verify_conf_file() {
     fi
     check_variable "MPDconfig"
     check_variable "DIRaudioFolders"
+    check_variable "GPIOconfig"
+
+    # Feature optional. if config not present, defaults to NO
+    if [[ -n "${AUTOHOTSPOTconfig}" ]]; then
+        echo "\$AUTOHOTSPOTconfig is set to '$AUTOHOTSPOTconfig'"
+        if [[ "$AUTOHOTSPOTconfig" == "YES" ]]; then
+            check_variable "AUTOHOTSPOTssid"
+            check_variable "AUTOHOTSPOTcountryCode"
+            check_variable "AUTOHOTSPOTpass"
+            check_variable "AUTOHOTSPOTip"
+        fi
+    fi
 
     if [ "${fail}" == "true" ]; then
       exit 1


### PR DESCRIPTION

Unfortunately https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2086 lacked a thing.
The new "autohotspot" config parameters are not tested in non-interactive mode and test runs.
