### PR TITLE
Fix pyzmq installation from source with drafts support

### DIFF
--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -98,8 +98,8 @@ _jukebox_core_build_and_install_pyzmq() {
       _jukebox_core_download_prebuild_libzmq_with_drafts
     fi
 
-    sudo ZMQ_PREFIX=${ZMQ_PREFIX} ZMQ_DRAFT_API=1 \
-      pip3 install --no-cache-dir --pre pyzmq
+    sudo ZMQ_PREFIX="${ZMQ_PREFIX}" ZMQ_DRAFT_API=1 \
+         pip3 install --no-cache-dir --no-binary "pyzmq" --pre pyzmq
   else
     echo "    Skipping. pyzmq already installed"
   fi

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -74,7 +74,7 @@ _jukebox_core_build_and_install_pyzmq() {
   # we need to compile the latest version in Github
   # As soon WebSockets support is stable in ZMQ, this can be removed
   # Sources:
-  # https://pyzmq.readthedocs.io/en/latest/draft.html
+  # https://pyzmq.readthedocs.io/en/latest/howto/draft.html
   # https://github.com/MonsieurV/ZeroMQ-RPi/blob/master/README.md
   echo "  Build and install pyzmq with WebSockets Support"
 


### PR DESCRIPTION
See the pyzmq instructions: https://github.com/zeromq/pyzmq/blob/main/docs/source/howto/draft.md published at https://pyzmq.readthedocs.io/en/latest/howto/draft.html nowadays