### PR TITLE
Fix future3 installation for bookworm

### DIFF
--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -27,6 +27,7 @@ _jukebox_core_install_os_dependencies() {
     python3-rpi.gpio python3-gpiozero \
     espeak ffmpeg mpg123 \
     pulseaudio pulseaudio-module-bluetooth pulseaudio-utils caps \
+    libasound2-dev \
     --no-install-recommends \
     --allow-downgrades \
     --allow-remove-essential \

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -99,7 +99,7 @@ _jukebox_core_build_and_install_pyzmq() {
     fi
 
     sudo ZMQ_PREFIX="${ZMQ_PREFIX}" ZMQ_DRAFT_API=1 \
-         pip3 install --no-cache-dir --no-binary "pyzmq" --pre pyzmq
+         pip3 install --no-cache-dir --no-binary "pyzmq" --pre --break-system-packages pyzmq
   else
     echo "    Skipping. pyzmq already installed"
   fi
@@ -108,7 +108,7 @@ _jukebox_core_build_and_install_pyzmq() {
 _jukebox_core_install_python_requirements() {
   echo "  Install requirements"
   cd "${INSTALLATION_PATH}"  || exit_on_error
-  sudo pip3 install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt"
+  sudo pip3 install --no-cache-dir --break-system-packages -r "${INSTALLATION_PATH}/requirements.txt"
 }
 
 _jukebox_core_install_settings() {

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -33,6 +33,13 @@ _jukebox_core_install_os_dependencies() {
     --allow-remove-essential \
     --allow-change-held-packages
 
+  # add configuration that we break the global python system packages
+  # (required for bookworm, see 
+  # https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2050). This
+  # should be removed once the jukebox has been isolated to a dedicated
+  # venv
+  sudo python3 -m pip config set global.break-system-packages true
+
   sudo pip3 install --upgrade pip
 }
 
@@ -100,7 +107,7 @@ _jukebox_core_build_and_install_pyzmq() {
     fi
 
     sudo ZMQ_PREFIX="${ZMQ_PREFIX}" ZMQ_DRAFT_API=1 \
-         pip3 install --no-cache-dir --no-binary "pyzmq" --pre --break-system-packages pyzmq
+         pip3 install --no-cache-dir --no-binary "pyzmq" --pre pyzmq
   else
     echo "    Skipping. pyzmq already installed"
   fi
@@ -109,7 +116,7 @@ _jukebox_core_build_and_install_pyzmq() {
 _jukebox_core_install_python_requirements() {
   echo "  Install requirements"
   cd "${INSTALLATION_PATH}"  || exit_on_error
-  sudo pip3 install --no-cache-dir --break-system-packages -r "${INSTALLATION_PATH}/requirements.txt"
+  sudo pip3 install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt"
 }
 
 _jukebox_core_install_settings() {

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -73,6 +73,9 @@ _jukebox_webapp_register_as_system_service_with_nginx() {
   sudo mv -f /etc/nginx/sites-available/default /etc/nginx/sites-available/default.orig
   sudo cp -f "${INSTALLATION_PATH}/resources/default-settings/nginx.default" /etc/nginx/sites-available/default
 
+  # make sure nginx can access the home directory of the user
+  sudo chmod o+x /home/pi
+
   sudo service nginx restart
 }
 

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -4,7 +4,7 @@
 GD_ID_COMPILED_WEBAPP="1EE_1MdneGtKL5V7GyYZC0nb6ODQWTsPb" # https://drive.google.com/file/d/1EE_1MdneGtKL5V7GyYZC0nb6ODQWTsPb/view?usp=sharing
 
 # For ARMv7+
-NODE_SOURCE="https://deb.nodesource.com/setup_16.x"
+NODE_MAJOR=16
 # For ARMv6
 # To update version, follow these links
 # https://github.com/sdesalas/node-pi-zero
@@ -26,12 +26,18 @@ _jukebox_webapp_install_node() {
     # Zero and older versions of Pi with ARMv6 only
     # support experimental NodeJS
     if [[ $(uname -m) == "armv6l" ]]; then
-      NODE_SOURCE=${NODE_SOURCE_EXPERIMENTAL}
+      wget -O - ${NODE_SOURCE_EXPERIMENTAL} | sudo bash
+      sudo apt-get -qq -y install nodejs
+      sudo npm install --silent -g npm
+    else
+      # install NodeJS and npm as recommended in
+      # https://github.com/nodesource/distributions
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+      sudo apt-get update
+      sudo apt-get install nodejs npm -y
     fi
 
-    wget -O - ${NODE_SOURCE} | sudo bash
-    sudo apt-get -qq -y install nodejs
-    sudo npm install --silent -g npm
   fi
 }
 


### PR DESCRIPTION
Hey! as described in https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2050#issuecomment-1804785695 this PR fixes the installation of the future3/branch on bookworm. In particular it adds additional options for the `pip3` installations and it installs nodejs and npm from the official sources.

closes #2050