### PR TITLE
Future3/bump-libzmq

### DIFF
--- a/documentation/developers/known-issues.md
+++ b/documentation/developers/known-issues.md
@@ -1,9 +1,18 @@
 # Known Issues
 
-## Browsers
+## Installing limzmq in Docker fails
 
-The Web UI will **not** work with Firefox, due to an issue with websockets and pyzmq. Please use a different
-browser for now.
+To speed up the Docker build process, we are distributing pre-build versions of libzmq with drafts flag at the latest version. In case the download fails because the respective architecture build does not exist, you can build the version yourself. Just replace the command to download the pre-built library with the following command
+
+```
+# Compile ZMQ
+RUN cd ${HOME} && mkdir ${ZMQ_TMP_DIR} && cd ${ZMQ_TMP_DIR}; \
+    wget https://github.com/zeromq/libzmq/releases/download/v${ZMQ_VERSION}/zeromq-${ZMQ_VERSION}.tar.gz -O libzmq.tar.gz; \
+    tar -xzf libzmq.tar.gz; \
+    rm -f libzmq.tar.gz; \
+    zeromq-${ZMQ_VERSION}/configure --prefix=${ZMQ_PREFIX} --enable-drafts; \
+    make && make install
+```
 
 ## Configuration
 

--- a/documentation/developers/libzmq.md
+++ b/documentation/developers/libzmq.md
@@ -1,0 +1,68 @@
+# `libzmq` for Raspberry Pi
+
+## `libzmp` Releases
+
+The Jukebox requires `libzmq` to work properly. We provide downloadable builds to speed up the installation process of the Phoniebox.
+
+* https://github.com/pabera/libzmq/releases
+
+> [!NOTE]
+> We can't use stable builds that are distributed by zeromq directly because the Jukebox requires draft builds to support WebSockets. These draft builds are not officially provided through zeromq for Raspberry Pi architecture (e.g. `armv6` or `armv7`).
+
+## Building `libzmp`
+
+If you need to update the `libzmq` version in the future, follow these steps.
+
+### Install Cross-Compilation Environment
+
+First, you need to install Dockcross. Dockcross provides Docker images for cross-compilation.
+
+1. **Pull the Dockcross Image**: For Raspberry Pi B, 4 or Zero 2 we need `linux-armv7`, for older models `linux-armv6`. The following example shows how to compile for `armv7` (32 bit, `arm32v7`). If you want to compile for another target, change the commands accordingly. For Docker Development environments, other targets like `arm64` or `x86_64` become relevant.
+
+```bash
+docker pull dockcross/linux-armv7
+```
+
+3. **Create a Dockcross Script**: After pulling the image, you create a Dockcross script which will be used to run the cross-compilation tools in the Docker container.
+
+```bash
+docker run --rm dockcross/linux-armv7 > ./dockcross-linux-armv7
+chmod +x ./dockcross-linux-armv7
+```
+
+This command creates a script named `dockcross-linux-armv7` in your current directory.
+
+### Cross-Compiling libzmq
+
+With Dockcross installed, you can now modify your `libzmq` compilation process to use the Dockcross environment.
+
+1. **Download `libzmq` Source**: Similar to your original process, download the `libzmq` source code:
+
+```bash
+ZMQ_VERSION=4.3.5
+wget https://github.com/zeromq/libzmq/releases/download/v${ZMQ_VERSION}/zeromq-${ZMQ_VERSION}.tar.gz -O libzmq.tar.gz
+tar -xzf libzmq.tar.gz
+```
+
+2. **Cross-Compilation using Dockcross**:
+
+Modify your build process to run inside the Dockcross environment:
+
+```bash
+./dockcross-linux-armv7 bash -c '\
+cd zeromq-${ZMQ_VERSION} && \
+./configure --prefix=/usr/local --enable-drafts && \
+make -j$(nproc) && \
+make install DESTDIR=$(pwd)/../installed'
+```
+
+> [!NOTE]
+> In the script above, you need to update ${ZMQ_VERSION} to the actual value as the script does not jave access to your host machine ENV variables.
+
+This command configures and builds `libzmq` inside the Docker container. The `DESTDIR` variable is used to specify where to install the files inside the container.
+
+3. **Compress the Compiled Binaries**: After compilation, the binaries are located in the `installed` directory inside your `zeromq-${ZMQ_VERSION}` directory.
+
+```
+tar -czvf libzmq5-armv7-${ZMQ_VERSION}.tar.gz -C installed/usr/local --exclude='.' include lib
+```

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Constants
-GD_ID_COMPILED_LIBZMQ_ARMV7="1KP6BqLF-i2dCUsHhOUpOwwuOmKsB5GKY" # ARMv7: https://drive.google.com/file/d/1KP6BqLF-i2dCUsHhOUpOwwuOmKsB5GKY/view?usp=sharing
+GD_ID_COMPILED_LIBZMQ_ARMV7="1950psO7Mbs4GdWBMqIzdTAZPLnKhDg7F" # ARMv7: https://drive.google.com/file/d/1950psO7Mbs4GdWBMqIzdTAZPLnKhDg7F/view?usp=sharing
 GD_ID_COMPILED_LIBZMQ_ARMV6="1iygOm-G1cg_3YERuVRT6FhGBE34ZkwgV" # ARMv6: https://drive.google.com/file/d/1iygOm-G1cg_3YERuVRT6FhGBE34ZkwgV/view?usp=sharing
 GD_ID_COMPILED_PYZMQ_ARMV7=""
 GD_ID_COMPILED_PYZMQ_ARMV6="1lDsV_pVcXbg6YReHb9AldMkyRZCpc6-n" # https://drive.google.com/file/d/1lDsV_pVcXbg6YReHb9AldMkyRZCpc6-n/view?usp=sharing

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # Constants
-GD_ID_COMPILED_LIBZMQ_ARMV7="1950psO7Mbs4GdWBMqIzdTAZPLnKhDg7F" # ARMv7: https://drive.google.com/file/d/1950psO7Mbs4GdWBMqIzdTAZPLnKhDg7F/view?usp=sharing
-GD_ID_COMPILED_LIBZMQ_ARMV6="1iygOm-G1cg_3YERuVRT6FhGBE34ZkwgV" # ARMv6: https://drive.google.com/file/d/1iygOm-G1cg_3YERuVRT6FhGBE34ZkwgV/view?usp=sharing
-GD_ID_COMPILED_PYZMQ_ARMV7=""
+GD_ID_COMPILED_LIBZMQ_ARMV6="17VTgriCsYmAm72YKkga97jO0nExtq6G-" # armv6: https://drive.google.com/file/d/17VTgriCsYmAm72YKkga97jO0nExtq6G-/view?usp=sharing
+GD_ID_COMPILED_LIBZMQ_ARMV7="1950psO7Mbs4GdWBMqIzdTAZPLnKhDg7F" # armv7: https://drive.google.com/file/d/1950psO7Mbs4GdWBMqIzdTAZPLnKhDg7F/view?usp=sharing
 GD_ID_COMPILED_PYZMQ_ARMV6="1lDsV_pVcXbg6YReHb9AldMkyRZCpc6-n" # https://drive.google.com/file/d/1lDsV_pVcXbg6YReHb9AldMkyRZCpc6-n/view?usp=sharing
+GD_ID_COMPILED_PYZMQ_ARMV7=""
 
 ZMQ_TMP_DIR="libzmq"
 ZMQ_PREFIX="/usr/local"


### PR DESCRIPTION
- Bumps version of `libzmq` to latest draft release: v4.3.5
- Fixes Firefox issue
- Removes dependency for Google Drive download of `libzmq`