### PR TITLE
Minor doc improvements

### DIFF
--- a/documentation/builders/audio.md
+++ b/documentation/builders/audio.md
@@ -13,14 +13,14 @@ Audio outputs run via PulseAudio and the basic configuration should be easy.
 There is a [configuration tool](../developers/coreapps.md#run_configure_audio.py),
 to setup the configuration for the Jukebox Core App.
 
-To set up the audio
+### To set up the audio
 
 1. Follow the setup steps according to your sound card
 2. Check that the sound output works [as described below](audio.md#checking-system-sound-output)
 3. Run the the tool [run_configure_audio](../developers/coreapps.md#run_configure_audio.py)
 4. [Fine-tune audio parameters](audio.md#additional-options)
 
-## Checking system sound output
+#### Checking system sound output
 
 Run the following steps in a console:
 
@@ -53,7 +53,7 @@ volume level for this sink:
 $ paplay -d sink_name /usr/share/sounds/alsa/Front_Center.wav
 ```
 
-# Bluetooth
+## Bluetooth
 
 Bluetooth setup consists of three steps
 

--- a/documentation/builders/installation.md
+++ b/documentation/builders/installation.md
@@ -85,22 +85,24 @@ Run the following command in your SSH terminal and follow the instructions
 cd; bash <(wget -qO- https://raw.githubusercontent.com/MiczFlor/RPi-Jukebox-RFID/future3/main/installation/install-jukebox.sh)
 ```
 
-This will get the latest stable release from the branch future3/main.
+This will get the latest **stable release** from the branch *future3/main*.
+
 To install directly from a specific branch and/or a different repository
 specify the variables like this:
 
 ```bash
-
 cd; GIT_USER='MiczFlor' GIT_BRANCH='future3/develop' bash <(wget -qO- https://raw.githubusercontent.com/MiczFlor/RPi-Jukebox-RFID/future3/develop/installation/install-jukebox.sh)
 ```
 
 This will switch directly to the specified feature branch during installation.
 
 > [!NOTE]
-> For all branches *except* the current Release, you will need to build the Web App locally on the Pi. This is not part of the installation process due to memory limitation issues. See [Steps to install](../developers/development-environment.md#steps-to-install)
+> For all branches *except* the current Release future3/main, you will need to build the Web App locally on the Pi. This is not part of the installation process due to memory limitation issues. See [Developer steps to install](../developers/development-environment.md#steps-to-install)
 
 If you suspect an error you can monitor the installation-process with
 
 ```bash
 cd; tail -f INSTALL-<fullname>.log
 ```
+
+After successful installation, continue with [configuring your Phoniebox](configuration.md).

--- a/documentation/developers/coreapps.md
+++ b/documentation/developers/coreapps.md
@@ -21,7 +21,7 @@ For debugging, it is usually desirable to run the Jukebox directly from the cons
 
 ## Configuration Tools
 
-Before running the configuration tools, stop the Jukebox Core service.
+Before running the configuration tools, stop the Jukebox Core service `systemctl --user stop jukebox-daemon`. Make sure to start the service afterwards.
 See [Best practice procedure](../builders/configuration.md#best-practice-procedure).
 
 ### `run_configure_audio.py`

--- a/documentation/developers/coreapps.md
+++ b/documentation/developers/coreapps.md
@@ -21,7 +21,8 @@ For debugging, it is usually desirable to run the Jukebox directly from the cons
 
 ## Configuration Tools
 
-Before running the configuration tools, stop the Jukebox Core service. See [Best practice procedure](../builders/configuration.md#best-practice-procedure).
+Before running the configuration tools, stop the Jukebox Core service.
+See [Best practice procedure](../builders/configuration.md#best-practice-procedure).
 
 ### `run_configure_audio.py`
 

--- a/documentation/developers/coreapps.md
+++ b/documentation/developers/coreapps.md
@@ -21,8 +21,7 @@ For debugging, it is usually desirable to run the Jukebox directly from the cons
 
 ## Configuration Tools
 
-Before running the configuration tools, stop the Jukebox Core service `systemctl --user stop jukebox-daemon`. Make sure to start the service afterwards.
-See [Best practice procedure](../builders/configuration.md#best-practice-procedure).
+Before running the configuration tools, stop the Jukebox Core service. See [Best practice procedure](../builders/configuration.md#best-practice-procedure).
 
 ### `run_configure_audio.py`
 

--- a/documentation/developers/pyhton.md
+++ b/documentation/developers/pyhton.md
@@ -8,7 +8,7 @@
 Before you can run Python code, you need to enable the virtual environment. On the Raspberry Pi, it's located in the project root `~/RPi-Jukebox-RFID/.venv`. Depending on your setup, the absolute path can vary.
 
 ```
-$ ~/RPi-Jukebox-RFID/.venv/bin/activate
+$ source ~/RPi-Jukebox-RFID/.venv/bin/activate
 ```
 
 If the virtual environment has been activated correctly, your terminal will now show a prefix (`.venv`). If you want to leave the venv again execute deactivate.

--- a/documentation/developers/pyhton.md
+++ b/documentation/developers/pyhton.md
@@ -14,5 +14,5 @@ $ source ~/RPi-Jukebox-RFID/.venv/bin/activate
 If the virtual environment has been activated correctly, your terminal will now show a prefix (`.venv`). If you want to leave the venv again execute deactivate.
 
 ```
-$ ~/RPi-Jukebox-RFID/.venv/bin/deactivate
+$ deactivate
 ```


### PR DESCRIPTION
* Improve formatting of audio documentation to make the steps more clear (fixes also #2014)
* Link the installation documentation to the configuration
* fix missing `source` in venv description 