### PR TITLE
[Bugfix] setup_autohotspot.sh for multiple wifi country codes, use first

### DIFF
--- a/installation/routines/setup_autohotspot.sh
+++ b/installation/routines/setup_autohotspot.sh
@@ -14,7 +14,7 @@ AUTOHOTSPOT_TARGET_PATH="/usr/bin/autohotspot"
 _get_interface() {
     # interfaces may vary
     WIFI_INTERFACE=$(iw dev | grep "Interface"| awk '{ print $2 }')
-    WIFI_REGION=$(iw reg get | grep country | awk '{ print $2}' | cut -d: -f1)
+    WIFI_REGION=$(iw reg get | grep country |  head -n 1 | awk '{ print $2}' | cut -d: -f1)
 
     # fix for CI runs on docker
     if [ "${CI_RUNNING}" == "true" ]; then


### PR DESCRIPTION
With "iw reg get | grep country" received
"country DE: DFS-ETSI
country 99: DFS-UNSET"
on a RPI4 fresh install.