### PR TITLE
 Improve the run_rpc_tool script

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,11 +15,13 @@ per-file-ignores =
 count = True
 max-complexity = 12
 statistics = True
-filename = *.py,*.py.*
+filename = *.py
 extend-exclude =
     # Ignore all scratch development directories
     scratch*,
     # Ignore dirs and files that have not been ported yet
     */jukebox/NvManager.py
-    # ignore GitHub Codespaces
+    # ignore Python venv's
     .venv/*
+    # ignore node modules
+    */node_modules/*

--- a/documentation/developers/coreapps.md
+++ b/documentation/developers/coreapps.md
@@ -53,11 +53,13 @@ Run this once to register and configure the RFID readers with the Jukebox. Can b
 
 Command Line Interface to the Jukebox RPC Server.
 
-A command line tool for sending RPC commands to the running jukebox app. This uses the same interface as the WebUI. Can be used for additional control or for debugging.
+A command line tool for sending RPC commands to the running jukebox app. This uses the same interface as the WebUI. Can be used for additional control or for debugging. Use `./run_rpc_tool.py` to start the tool in interactive mode.
 
 The tool features auto-completion and command history.
 
 The list of available commands is fetched from the running Jukebox service.
+
+The tool can also be used to send commands directly, when passing a `-c` argument, e.g. `./run_rpc_tool.py -c host.shutdown`.
 
 
 ### `run_publicity_sniffer.py`

--- a/src/jukebox/run_rpc_tool.py
+++ b/src/jukebox/run_rpc_tool.py
@@ -313,7 +313,7 @@ def runcmd(cmd):
     """
     Just run a command.
     Right now duplicates more or less main()
-    @TODO remove duplication of code
+    :todo remove duplication of code
     """
 
     # Split on whitespaces to separate cmd and arg list
@@ -338,7 +338,6 @@ def runcmd(cmd):
         print("Could not reach RPC Server. Jukebox running? Correct Port?\n")
         print('-' * 70 + "\n\n")
         return
-
     except Exception as e:
         print(f":: Exception response =\n{e}\n")
         return

--- a/src/jukebox/run_rpc_tool.py
+++ b/src/jukebox/run_rpc_tool.py
@@ -309,6 +309,43 @@ def main(scr):
             scr.addstr(f"\n:: Response =\n{response}\n\n")
 
 
+def runcmd(cmd):
+    """
+    Just run a command.
+    Right now duplicates more or less main()
+    @TODO remove duplication of code
+    """
+
+    # Split on whitespaces to separate cmd and arg list
+    dec = [v for v in cmd.strip().split(' ') if len(v) > 0]
+    if len(dec) == 0:
+        return
+    # Split cmd on '.' into package.plugin.method
+    # Remove duplicate '.' along the way
+    sl = [v for v in dec[0].split('.') if len(v) > 0]
+    fargs = [tonum(a) for a in dec[1:]]
+    response = None
+    method = None
+    if not (2 <= len(sl) <= 3):
+        print(":: Error = Ill-formatted command\n")
+        return
+    if len(sl) == 3:
+        method = sl[2]
+    try:
+        response = client.enque(sl[0], sl[1], method, args=fargs)
+    except zmq.error.Again:
+        print("\n\n" + '-' * 70 + "\n")
+        print("Could not reach RPC Server. Jukebox running? Correct Port?\n")
+        print('-' * 70 + "\n\n")
+        return
+
+    except Exception as e:
+        print(f":: Exception response =\n{e}\n")
+        return
+    else:
+        print(f"\n:: Response =\n{response}\n\n")
+
+
 if __name__ == '__main__':
     default_tcp = 5555
     default_ws = 5556
@@ -324,6 +361,9 @@ if __name__ == '__main__':
                             help=f"Use tcp protocol on PORT [default: {default_tcp}]",
                             nargs='?', const=default_tcp,
                             metavar="PORT", default=None)
+    port_group.add_argument("-c", "--command",
+                            help="Send command to Jukebox server",
+                            default=None)
     args = argparser.parse_args()
 
     if args.websocket is not None:
@@ -335,6 +375,10 @@ if __name__ == '__main__':
 
     client = rpc.RpcClient(url)
 
-    curses.wrapper(main)
+    if args.command is not None:
+        runcmd(args.command)
+        exit(0)
+    else:
+        curses.wrapper(main)
 
     print(">>> RPC Client exited!")


### PR DESCRIPTION
Improve the script to use commands directly, e.g. `run_rpc_tool.py -c host.shutdown`. The CLI Client (C implementation) could be removed later.