### PR TITLE
Update Pulseaudio docs for Docker on Mac

### DIFF
--- a/docker/jukebox.Dockerfile
+++ b/docker/jukebox.Dockerfile
@@ -21,7 +21,7 @@ RUN usermod -aG pulse ${USER}
 # Install all Jukebox dependencies
 RUN apt-get update && apt-get install -qq -y \
     --allow-downgrades --allow-remove-essential --allow-change-held-packages \
-    gcc at wget \
+    g++ at wget \
     espeak mpc mpg123 git ffmpeg spi-tools netcat \
     python3 python3-venv python3-dev python3-mutagen
 

--- a/documentation/developers/docker.md
+++ b/documentation/developers/docker.md
@@ -49,6 +49,9 @@ They can be run individually or in combination. To do that, we use
 1. [Install Docker & Compose (Mac)](https://docs.docker.com/docker-for-mac/install/)
 2. [Install pulseaudio](https://gist.github.com/seongyongkim/b7d630a03e74c7ab1c6b53473b592712) (Other references: [[1]](https://devops.datenkollektiv.de/running-a-docker-soundbox-on-mac.html), [[2]](https://stackoverflow.com/a/50939994/1062438))
 
+> [!NOTE]
+> In order for Pulseaudio to work properly with Docker on your Mac, you need to start Pulseaudio in a specific way. Otherwise MPD will throw an exception. See [Pulseaudio issues on Mac](#pulseaudio-issue-on-mac) for more info.
+
 ``` bash
 // Build Images
 $ docker-compose -f docker/docker-compose.yml -f docker/docker-compose.mac.yml build
@@ -169,6 +172,38 @@ details.
 
 ### `mpd` container
 
+#### Pulseaudio issue on Mac
+
+If you notice the following exception while running MPD in Docker, it refers to a incorrect setup of your Mac host Pulseaudio.
+
+```
+mpd      | ALSA lib pulse.c:242:(pulse_connect) PulseAudio: Unable to connect: Connection refused
+mpd      | exception: Failed to read mixer for 'Global ALSA->Pulse stream': failed to attach to pulse: Connection refused
+```
+
+To fix the issue, try the following.
+
+1. Stop your Pulseaudio service
+    ```
+    brew service stop pulseaudio
+    ```
+2. Start Pulseaudio with this command
+    ```
+    pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
+    ```
+3. Check if daemon is working
+    ```
+    pulseaudio --check -v
+    ```
+
+Everything else should have been set up properly as a [prerequisite](#mac)
+
+* [Source](https://gist.github.com/seongyongkim/b7d630a03e74c7ab1c6b53473b592712)
+
+
+
+#### Other error messages
+
 When starting the `mpd` container, you will see the following errors.
 You can ignore them, MPD will run.
 
@@ -212,6 +247,16 @@ jukebox    | 171:__init__.py        - jb.host.lnx          - MainThread      - E
 ...
 jukebox    | 319:server.py          - jb.pub.server        - host.timer.cputemp - ERROR    - Publish command from different thread 'host.timer.cputemp' than publisher was created from 'MainThread'!
 ```
+
+#### Pulseaudio and Volume issues
+
+If you encounter the following error, refer to [Pulseaudio issues on Mac](#pulseaudio-issue-on-mac).
+
+```
+jukebox  | 21.12.2023 08:50:09 -  629:plugs.py           - jb.plugin            - MainThread      - ERROR    - Ignoring failed package load finalizer: 'volume.finalize()'
+jukebox  | 21.12.2023 08:50:09 -  630:plugs.py           - jb.plugin            - MainThread      - ERROR    - Reason: NameError: name 'pulse_control' is not defined
+```
+
 
 ## Appendix
 


### PR DESCRIPTION
I noticed a few missing docs for Pulseaudio on Mac, hence I added them for other developers.