### PR TITLE
fix youtube-dl package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 # related libraries.
 evdev
 git+https://github.com/lthiery/SPI-Py.git#egg=spi-py
-youtube-dl
+git+https://github.com/ytdl-org/youtube-dl@master
 pyserial
 RPi.GPIO
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 # related libraries.
 evdev
 git+https://github.com/lthiery/SPI-Py.git#egg=spi-py
-git+https://github.com/ytdl-org/youtube-dl@master
+git+https://github.com/ytdl-org/youtube-dl@master#egg=youtube-dl
 pyserial
 RPi.GPIO
 


### PR DESCRIPTION
The official pip package isn't working anymore.
Installing from git fixes this.