### PR TITLE
future3: Jukebox.Dockerfile - Reorder 'USER' command

### DIFF
--- a/docker/jukebox.Dockerfile
+++ b/docker/jukebox.Dockerfile
@@ -25,13 +25,18 @@ RUN apt-get update && apt-get install -qq -y \
     espeak mpc mpg123 git ffmpeg spi-tools netcat \
     python3 python3-venv python3-dev python3-mutagen
 
+# Copy in the source code using the correct permissions
+COPY --chown=${USER}:${USER} . ${INSTALLATION_PATH}/
+
+# Switch to the `$USER` (typically `pi`)
+USER ${USER}
+WORKDIR ${HOME}
+
+# Initialize venv
 ENV VIRTUAL_ENV=${INSTALLATION_PATH}/.venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-USER ${USER}
-WORKDIR ${HOME}
-COPY --chown=${USER}:${USER} . ${INSTALLATION_PATH}/
 
 RUN pip install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
 


### PR DESCRIPTION
This makes sure the 'venv' is created only after switching to the `$USER`.
This prevents permission errors if building the container in an environment where the user is not `pi`.

Closes issue #2198