### PR TITLE
Bugfix: re-enable Mifare Ultralight C support

### DIFF
--- a/components/rfid-reader/RC522/setup_rc522.sh
+++ b/components/rfid-reader/RC522/setup_rc522.sh
@@ -16,6 +16,13 @@ question() {
 printf "Please make sure that the RC522 reader is wired up correctly to the GPIO ports before continuing...\n"
 question "Continue"
 
+printf "Use backward-compatible card ID (not suggested for new installations)?\n"
+read -p "(y/n) " choice
+case "$choice" in
+  y|Y ) printf "OFF" > "${JUKEBOX_HOME_DIR}"/settings/Rfidreader_Rc522_Readmode_UID;;
+  * ) printf "ON" > "${JUKEBOX_HOME_DIR}"/settings/Rfidreader_Rc522_Readmode_UID;;
+esac
+
 printf "Installing Python requirements for RC522...\n"
 sudo python3 -m pip install --upgrade --force-reinstall -q -r "${JUKEBOX_HOME_DIR}"/components/rfid-reader/RC522/requirements.txt
 
@@ -27,12 +34,6 @@ cp "${JUKEBOX_HOME_DIR}"/scripts/Reader.py.experimental "${JUKEBOX_HOME_DIR}"/sc
 printf "MFRC522" > "${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
 sudo chown pi:www-data "${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
 sudo chmod 644 "${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
-
-read -p "Use backward-compatible card ID (not suggested for new installations) (y/n)? " choice
-case "$choice" in
-  y|Y ) printf "OFF" > "${JUKEBOX_HOME_DIR}"/settings/Rfidreader_Rc522_Readmode_UID;;
-  * ) printf "ON" > "${JUKEBOX_HOME_DIR}"/settings/Rfidreader_Rc522_Readmode_UID;;
-esac
 
 printf "Restarting phoniebox-rfid-reader service...\n"
 sudo systemctl restart phoniebox-rfid-reader.service

--- a/components/rfid-reader/RC522/setup_rc522.sh
+++ b/components/rfid-reader/RC522/setup_rc522.sh
@@ -28,6 +28,12 @@ printf "MFRC522" > "${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
 sudo chown pi:www-data "${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
 sudo chmod 644 "${JUKEBOX_HOME_DIR}"/scripts/deviceName.txt
 
+read -p "Use backward-compatible card ID (not suggested for new installations) (y/n)? " choice
+case "$choice" in
+  y|Y ) printf "OFF" > "${JUKEBOX_HOME_DIR}"/settings/Rfidreader_Rc522_Readmode_UID;;
+  * ) printf "ON" > "${JUKEBOX_HOME_DIR}"/settings/Rfidreader_Rc522_Readmode_UID;;
+esac
+
 printf "Restarting phoniebox-rfid-reader service...\n"
 sudo systemctl start phoniebox-rfid-reader.service
 

--- a/components/rfid-reader/RC522/setup_rc522.sh
+++ b/components/rfid-reader/RC522/setup_rc522.sh
@@ -35,6 +35,6 @@ case "$choice" in
 esac
 
 printf "Restarting phoniebox-rfid-reader service...\n"
-sudo systemctl start phoniebox-rfid-reader.service
+sudo systemctl restart phoniebox-rfid-reader.service
 
 printf "Done.\n"

--- a/scripts/Reader.py.experimental
+++ b/scripts/Reader.py.experimental
@@ -54,7 +54,7 @@ class Mfrc522Reader(object):
         import pirc522
         self.device = pirc522.RFID()
 
-    def readCard(self):
+    def readCard_legacy(self):
         # Scan for cards
         self.device.wait_for_tag()
         (error, tag_type) = self.device.request()
@@ -69,6 +69,17 @@ class Mfrc522Reader(object):
                 return card_id
         logger.debug("No Device ID found.")
         return None
+
+    def readCard(self):
+        # Scan for cards
+        uid = self.device.read_id(as_number=True)
+        if not uid:
+            logger.debug("No Device ID found.")
+            return None
+        card_id = str(uid)
+        logger.info("Card detected.")
+        logger.info(card_id)
+        return card_id
 
     @staticmethod
     def cleanup():

--- a/scripts/Reader.py.experimental
+++ b/scripts/Reader.py.experimental
@@ -50,11 +50,11 @@ class UsbReader(object):
 
 
 class Mfrc522Reader(object):
-    def __init__(self, mode_legacy=True):
+    def __init__(self, readmode_uid=False):
         import pirc522
         self.device = pirc522.RFID()
-        self.mode_legacy = mode_legacy
-        self.readCard = self.readCard_legacy if self.mode_legacy else self.readCard_normal
+        self.readmode_uid = readmode_uid
+        self.readCard = self.readCard_normal if self.readmode_uid else self.readCard_legacy
 
     def readCard_legacy(self):
         # Scan for cards
@@ -202,13 +202,13 @@ class Reader(object):
             with open(path + '/deviceName.txt', 'r') as f:
                 device_name = f.read().rstrip().split(';', 1)[0]
             try:
-                with open(path + '/../settings/Mode_Legacy', 'r') as f:
-                    mode_legacy = f.read().rstrip().split(';', 1)[0] == 'ON'
+                with open(path + '/../settings/Rfidreader_Rc522_Readmode_UID', 'r') as f:
+                    readmode_uid = f.read().rstrip().split(';', 1)[0] == 'ON'
             except FileNotFoundError:
-                mode_legacy = True
+                readmode_uid = False
 
             if device_name == 'MFRC522':
-                self.reader = Mfrc522Reader(mode_legacy)
+                self.reader = Mfrc522Reader(readmode_uid)
             elif device_name == 'RDM6300':
                 # The Rdm6300Reader supports 2 Additional Number Formats which can bee choosen by an optional parameter dictionary:
                 # {'numberformat':'card_id_float'} or {'numberformat':'card_id_dec'}

--- a/scripts/Reader.py.experimental
+++ b/scripts/Reader.py.experimental
@@ -201,8 +201,11 @@ class Reader(object):
         else:
             with open(path + '/deviceName.txt', 'r') as f:
                 device_name = f.read().rstrip().split(';', 1)[0]
-            with open(path + '/../settings/Mode_Legacy', 'r') as f:
-                mode_legacy = f.read().rstrip().split(';', 1)[0] == 'ON'
+            try:
+                with open(path + '/../settings/Mode_Legacy', 'r') as f:
+                    mode_legacy = f.read().rstrip().split(';', 1)[0] == 'ON'
+            except FileNotFoundError:
+                mode_legacy = True
 
             if device_name == 'MFRC522':
                 self.reader = Mfrc522Reader(mode_legacy)

--- a/scripts/Reader.py.experimental
+++ b/scripts/Reader.py.experimental
@@ -201,10 +201,10 @@ class Reader(object):
         else:
             with open(path + '/deviceName.txt', 'r') as f:
                 device_name = f.read().rstrip().split(';', 1)[0]
-            try:
+            if os.path.isfile(path + '/../settings/Rfidreader_Rc522_Readmode_UID'):
                 with open(path + '/../settings/Rfidreader_Rc522_Readmode_UID', 'r') as f:
                     readmode_uid = f.read().rstrip().split(';', 1)[0] == 'ON'
-            except FileNotFoundError:
+            else:
                 readmode_uid = False
 
             if device_name == 'MFRC522':

--- a/scripts/Reader.py.experimental
+++ b/scripts/Reader.py.experimental
@@ -50,9 +50,11 @@ class UsbReader(object):
 
 
 class Mfrc522Reader(object):
-    def __init__(self):
+    def __init__(self, mode_legacy=True):
         import pirc522
         self.device = pirc522.RFID()
+        self.mode_legacy = mode_legacy
+        self.readCard = self.readCard_legacy if self.mode_legacy else self.readCard_normal
 
     def readCard_legacy(self):
         # Scan for cards
@@ -70,7 +72,7 @@ class Mfrc522Reader(object):
         logger.debug("No Device ID found.")
         return None
 
-    def readCard(self):
+    def readCard_normal(self):
         # Scan for cards
         uid = self.device.read_id(as_number=True)
         if not uid:
@@ -199,9 +201,11 @@ class Reader(object):
         else:
             with open(path + '/deviceName.txt', 'r') as f:
                 device_name = f.read().rstrip().split(';', 1)[0]
+            with open(path + '/../settings/Mode_Legacy', 'r') as f:
+                mode_legacy = f.read().rstrip().split(';', 1)[0] == 'ON'
 
             if device_name == 'MFRC522':
-                self.reader = Mfrc522Reader()
+                self.reader = Mfrc522Reader(mode_legacy)
             elif device_name == 'RDM6300':
                 # The Rdm6300Reader supports 2 Additional Number Formats which can bee choosen by an optional parameter dictionary:
                 # {'numberformat':'card_id_float'} or {'numberformat':'card_id_dec'}

--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -110,14 +110,14 @@ fi
 SECONDSWIPEPAUSECONTROLS=`cat $PATHDATA/../settings/Second_Swipe_Pause_Controls`
 
 ##############################################
-# Legacy mode
+# RFID reader rc522 readmode UID
 # 1. create a default if file does not exist
-if [ ! -f $PATHDATA/../settings/Mode_Legacy ]; then
-    echo "ON" > $PATHDATA/../settings/Mode_Legacy
-    chmod 777 $PATHDATA/../settings/Mode_Legacy
+if [ ! -f $PATHDATA/../settings/Rfidreader_Rc522_Readmode_UID ]; then
+    echo "OFF" > $PATHDATA/../settings/Rfidreader_Rc522_Readmode_UID
+    chmod 777 $PATHDATA/../settings/Rfidreader_Rc522_Readmode_UID
 fi
 # 2. then|or read value from file
-MODELEGACY=`cat $PATHDATA/../settings/Mode_Legacy`
+RFIDREADERRC522READMODEUID=`cat $PATHDATA/../settings/Rfidreader_Rc522_Readmode_UID`
 
 ##############################################
 # Audio_iFace_Name
@@ -342,7 +342,7 @@ CMDSEEKBACK=`grep 'CMDSEEKBACK' $PATHDATA/../settings/rfid_trigger_play.conf|tai
 # SECONDSWIPE
 # SECONDSWIPEPAUSE
 # SECONDSWIPEPAUSECONTROLS
-# MODELEGACY
+# RFIDREADERRC522READMODEUID
 # AUDIOIFACENAME
 # AUDIOIFACEACTIVE
 # VOLUMEMANAGER
@@ -380,7 +380,7 @@ echo "SWIPEORPLACE=\"${SWIPEORPLACE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SECONDSWIPE=\"${SECONDSWIPE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SECONDSWIPEPAUSE=\"${SECONDSWIPEPAUSE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SECONDSWIPEPAUSECONTROLS=\"${SECONDSWIPEPAUSECONTROLS}\"" >> "${PATHDATA}/../settings/global.conf"
-echo "MODELEGACY=\"${MODELEGACY}\"" >> "${PATHDATA}/../settings/global.conf"
+echo "RFIDREADERRC522READMODEUID=\"${RFIDREADERRC522READMODEUID}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOIFACENAME=\"${AUDIOIFACENAME}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOIFACEACTIVE=\"${AUDIOIFACEACTIVE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "VOLUMEMANAGER=\"${VOLUMEMANAGER}\"" >> "${PATHDATA}/../settings/global.conf"

--- a/scripts/inc.writeGlobalConfig.sh
+++ b/scripts/inc.writeGlobalConfig.sh
@@ -110,6 +110,16 @@ fi
 SECONDSWIPEPAUSECONTROLS=`cat $PATHDATA/../settings/Second_Swipe_Pause_Controls`
 
 ##############################################
+# Legacy mode
+# 1. create a default if file does not exist
+if [ ! -f $PATHDATA/../settings/Mode_Legacy ]; then
+    echo "ON" > $PATHDATA/../settings/Mode_Legacy
+    chmod 777 $PATHDATA/../settings/Mode_Legacy
+fi
+# 2. then|or read value from file
+MODELEGACY=`cat $PATHDATA/../settings/Mode_Legacy`
+
+##############################################
 # Audio_iFace_Name
 # 1. create a default if file does not exist
 if [ ! -f $PATHDATA/../settings/Audio_iFace_Name ]; then
@@ -332,6 +342,7 @@ CMDSEEKBACK=`grep 'CMDSEEKBACK' $PATHDATA/../settings/rfid_trigger_play.conf|tai
 # SECONDSWIPE
 # SECONDSWIPEPAUSE
 # SECONDSWIPEPAUSECONTROLS
+# MODELEGACY
 # AUDIOIFACENAME
 # AUDIOIFACEACTIVE
 # VOLUMEMANAGER
@@ -369,6 +380,7 @@ echo "SWIPEORPLACE=\"${SWIPEORPLACE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SECONDSWIPE=\"${SECONDSWIPE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SECONDSWIPEPAUSE=\"${SECONDSWIPEPAUSE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "SECONDSWIPEPAUSECONTROLS=\"${SECONDSWIPEPAUSECONTROLS}\"" >> "${PATHDATA}/../settings/global.conf"
+echo "MODELEGACY=\"${MODELEGACY}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOIFACENAME=\"${AUDIOIFACENAME}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "AUDIOIFACEACTIVE=\"${AUDIOIFACEACTIVE}\"" >> "${PATHDATA}/../settings/global.conf"
 echo "VOLUMEMANAGER=\"${VOLUMEMANAGER}\"" >> "${PATHDATA}/../settings/global.conf"

--- a/scripts/installscripts/tests/run_installation_tests2.sh
+++ b/scripts/installscripts/tests/run_installation_tests2.sh
@@ -24,10 +24,11 @@ echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selecti
 # y use gpio
 # y RFID registration
 # 2 use RC522 reader
-# yes, reader is connected
+# y, reader is connected
+# y, use legacy readermode
 # n No reboot
 
-./../install-jukebox.sh <<< $'y\nn\n\nn\n\ny\n\nn\n\ny\n\ny\n\ny\n\ny\ny\n2\ny\nn\n'
+./../install-jukebox.sh <<< $'y\nn\n\nn\n\ny\n\nn\n\ny\n\ny\n\ny\n\ny\ny\n2\ny\ny\nn\n'
 INSTALLATION_EXITCODE=$?
 
 # Test installation


### PR DESCRIPTION
Make use of read_id function from pirc522 package to re-enable Mifare Ultralight C support.

Since the change of the pirc522 repo, cf. #2066, #2075, #2078, I have realized issues with Mifare Ultralight C stickers in my setup (RPi Zero 2). Moving from the previous "more manual" check of uid to the read_id function of the pirc522 package fixes this issue.

ATTENTION:
Previously, a non-standard representation of NFC card uid was returned by the Mfrc522Reader class. With this change a standard representation of the NFCs uid is return which breaks all currently stored links between cards and actions. Writing a converter appears not possible due to the way "uids" were put together previously. Like in future3 the old variant was labelled "legacy".