### PR TITLE
prevent installer rerun and remove update path

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -57,7 +57,17 @@ warn_githooks() {
   echo "$ cp .githooks/* .git/hooks/."
   echo "************************************************************"
   echo -e "\n"
+}
 
+warn_installer() {
+  echo -e "\n"
+  echo "************************************************************"
+  echo "ATTENTION: Installer sources have changed since last pull!"
+  echo ""
+  echo "Rerun the installer to apply changes"
+  echo "$ ./installation/install-jukebox.sh"
+  echo "************************************************************"
+  echo -e "\n"
 }
 
 # files_changed="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
@@ -65,6 +75,7 @@ webapp_changed="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD src
 webapp_dep_changed="$(git diff --name-only --no-commit-id ORIG_HEAD HEAD src/webapp/package.json)"
 python_req_changed="$(git diff --name-only --no-commit-id ORIG_HEAD HEAD requirements.txt)"
 githooks_changed="$(git diff --name-only --no-commit-id ORIG_HEAD HEAD .githooks)"
+installer_changed="$(git diff --name-only --no-commit-id ORIG_HEAD HEAD installation)"
 
 if [[ -n $python_req_changed ]]; then
     warn_python_requirements
@@ -78,6 +89,10 @@ fi
 
 if [[ -n $githooks_changed ]]; then
     warn_githooks
+fi
+
+if [[ -n $installer_changed ]]; then
+    warn_installer
 fi
 
 echo -e "\nTo see a summary of what happened since your last pull, do:"

--- a/documentation/builders/gpio.md
+++ b/documentation/builders/gpio.md
@@ -2,8 +2,7 @@
 
 ## Enabling GPIO
 
-The GPIO module needs to be enabled in your main configuration file ``shared/settings/jukebox.yaml``. Look for the
-this entry and modify it accordingly:
+The GPIO module needs to be enabled in your main configuration file ``shared/settings/jukebox.yaml``. Look for this entry and modify it accordingly:
 
 ```yml
 gpioz:

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -2,34 +2,14 @@
 
 ## Updating your Jukebox Version 3
 
-### Update from v3.2.1 and prior
+### Update from v3.5.0 and prior
 
-As there are some significant changes in the installation, a new setup on a fresh image is required.
+As there are some significant changes in the Jukebox installation, no updates can be performed with the installer.
+Please backup your './shared' folder and changed files and run a new installation on a fresh image.
+Restore your old files after the new installation was succefull and check if new mandatory settings have been added.
 
-### General
-
-Things on Version 3 are moving fast and you may want to keep up with recent changes. Since we are in Alpha Release stage,
-a fair number of fixes are expected to be committed in the near future.
-
-You will need to do three things to update your version from develop (or the next release candidate version)
-
-1. Pull the newest code base from Github
-2. Check for new entries in the configuration
-3. Re-build the WebUI
-
-```bash
-# Switch to develop (if desired)
-$ git checkout future3/develop
-
-# Get latest code
-$ git pull
-
-# Check if new (mandatory) options appeared in jukebox.yaml
-# with your favourite diff tool and merge them
+``` bash
 $ diff shared/settings/jukebox.yaml resources/default-settings/jukebox.default.yaml
-
-$ cd src/webapp
-$ ./run_rebuild.sh -u
 ```
 
 ## Migration Path from Version 2

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -6,7 +6,7 @@
 
 As there are some significant changes in the Jukebox installation, no updates can be performed with the installer.
 Please backup your './shared' folder and changed files and run a new installation on a fresh image.
-Restore your old files after the new installation was succefull and check if new mandatory settings have been added.
+Restore your old files after the new installation was successful and check if new mandatory settings have been added.
 
 ``` bash
 $ diff shared/settings/jukebox.yaml resources/default-settings/jukebox.default.yaml

--- a/installation/install-jukebox.sh
+++ b/installation/install-jukebox.sh
@@ -103,6 +103,18 @@ _check_os_type() {
   fi
 }
 
+_check_existing_installation() {
+    if [[ -e "${INSTALLATION_PATH}" ]]; then
+        print_lc "
+############## EXISTING INSTALLATION FOUND ##############
+Rerunning the installer over an existing installation is
+currently not supported (overwrites settings, etc).
+Please backup your 'shared' folder and manually changed
+files and run the installation on a fresh image."
+        exit 1
+    fi
+}
+
 _download_jukebox_source() {
   log "#########################################################"
   print_c "Downloading Phoniebox software from Github ..."
@@ -122,7 +134,7 @@ _download_jukebox_source() {
   if [[ -z "${GIT_HASH}" ]]; then
     exit_on_error "ERROR: Couldn't determine git hash from download."
   fi
-  mv "$git_repo_download" "$GIT_REPO_NAME"
+  mv "$git_repo_download" "$GIT_REPO_NAME" || exit_on_error "ERROR: Can't overwrite existing installation."
   log "\nDONE: Downloading Phoniebox software from Github"
   log "#########################################################"
 }
@@ -143,6 +155,7 @@ _setup_logging
 
 ### CHECK PREREQUISITE
 _check_os_type
+_check_existing_installation
 
 ### RUN INSTALLATION
 log "Current User: $CURRENT_USER"


### PR DESCRIPTION
Enforcement for https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2211#issuecomment-1923241614 to not let users rerun the installer and break their existing installation.

Rerunning the installer is currently not supported as it
* doesn't remember config used in a previous installation
* doesn't clean system files written before
* overwrites setting files in the shared folder
* (doesn't support uninstalling feature)

Also the update via pull doesn't cache changes in the installation scripts, therefore this can lead to incompatibilities.
Rebuilding the Web App on `main` and `develop` is not possible, without further user interaction, as Node is not installed by default.