### PR TITLE
github actions update

### DIFF
--- a/.github/workflows/test_docker_debian.yml
+++ b/.github/workflows/test_docker_debian.yml
@@ -41,8 +41,6 @@ jobs:
 
   # Build container and run tests
   run:
-    permissions:
-      actions: write
     name: ${{ matrix.debian_codename }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test_docker_debian.yml
+++ b/.github/workflows/test_docker_debian.yml
@@ -41,6 +41,8 @@ jobs:
 
   # Build container and run tests
   run:
+    permissions:
+      actions: write
     name: ${{ matrix.debian_codename }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test_docker_debian_codename_sub.yml
+++ b/.github/workflows/test_docker_debian_codename_sub.yml
@@ -124,7 +124,7 @@ jobs:
           BASE_TEST_IMAGE=${{ steps.vars.outputs.image_tag_name_local_base }}
 
     - name: Artifact Upload Docker Image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.vars.outputs.image_file_name }}
         path: ${{ steps.vars.outputs.image_file_path }}

--- a/.github/workflows/test_docker_debian_codename_sub.yml
+++ b/.github/workflows/test_docker_debian_codename_sub.yml
@@ -177,6 +177,6 @@ jobs:
 
     steps:
         - name: Artifact Delete Docker Image
-          uses: geekyeggo/delete-artifact@v2
+          uses: geekyeggo/delete-artifact@v4
           with:
             name: ${{ needs.build.outputs.image_file_name }}

--- a/.github/workflows/test_docker_debian_codename_sub.yml
+++ b/.github/workflows/test_docker_debian_codename_sub.yml
@@ -170,8 +170,6 @@ jobs:
 
   # cleanup after test execution
   cleanup:
-    permissions:
-      actions: write
     # run only if tests didn't fail: keep the artifact to make job reruns possible
     if: ${{ !failure() }}
     needs: [build, test]

--- a/.github/workflows/test_docker_debian_codename_sub.yml
+++ b/.github/workflows/test_docker_debian_codename_sub.yml
@@ -170,6 +170,8 @@ jobs:
 
   # cleanup after test execution
   cleanup:
+    permissions:
+      actions: write
     # run only if tests didn't fail: keep the artifact to make job reruns possible
     if: ${{ !failure() }}
     needs: [build, test]

--- a/.github/workflows/test_docker_debian_codename_sub.yml
+++ b/.github/workflows/test_docker_debian_codename_sub.yml
@@ -168,15 +168,15 @@ jobs:
         args: |
           ./${{ matrix.test_script }}
 
-  # cleanup after test execution
-  cleanup:
-    # run only if tests didn't fail: keep the artifact to make job reruns possible
-    if: ${{ !failure() }}
-    needs: [build, test]
-    runs-on: ${{ inputs.runs_on }}
-
-    steps:
-        - name: Artifact Delete Docker Image
-          uses: geekyeggo/delete-artifact@v4
-          with:
-            name: ${{ needs.build.outputs.image_file_name }}
+  ## cleanup after test execution
+  # cleanup:
+    ## run only if tests didn't fail: keep the artifact to make job reruns possible
+    #if: ${{ !failure() }}
+    #needs: [build, test]
+    #runs-on: ${{ inputs.runs_on }}
+    #
+    #steps:
+    #    - name: Artifact Delete Docker Image
+    #      uses: geekyeggo/delete-artifact@v4
+    #      with:
+    #        name: ${{ needs.build.outputs.image_file_name }}

--- a/.github/workflows/test_docker_debian_codename_sub.yml
+++ b/.github/workflows/test_docker_debian_codename_sub.yml
@@ -182,3 +182,5 @@ jobs:
           uses: geekyeggo/delete-artifact@v4
           with:
             name: ${{ needs.build.outputs.image_file_name }}
+            # Ignore failes. On PRs no write persmissions are granted.
+            failOnError: false

--- a/.github/workflows/test_docker_debian_codename_sub.yml
+++ b/.github/workflows/test_docker_debian_codename_sub.yml
@@ -150,7 +150,7 @@ jobs:
       uses: docker/setup-buildx-action@v3.0.0
 
     - name: Artifact Download Docker Image
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ needs.build.outputs.image_file_name }}
 

--- a/.github/workflows/test_docker_debian_codename_sub.yml
+++ b/.github/workflows/test_docker_debian_codename_sub.yml
@@ -182,5 +182,3 @@ jobs:
           uses: geekyeggo/delete-artifact@v4
           with:
             name: ${{ needs.build.outputs.image_file_name }}
-            # Ignore failes. On PRs no write persmissions are granted.
-            failOnError: false


### PR DESCRIPTION
upload-artifact and download-artifact in v4

[Bump actions/download-artifact from 3 to 4](https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2230)
[Bump actions/upload-artifact from 3 to 4](https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2195)
[Bump geekyeggo/delete-artifact from 2 to 4](https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2193)
-> Possible solution for needed write access token on PRs if implemented  (https://github.com/GeekyEggo/delete-artifact/issues/19)