### PR TITLE
Fix for nginx with disabled ipv6

### DIFF
--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -299,6 +299,21 @@ verify_file_contains_string() {
     log "  CHECK"
 }
 
+verify_file_does_not_contain_string() {
+    local string="$1"
+    local file="$2"
+    log "  Verify '${string}' not found in '${file}'"
+
+    if [[ -z "${string}" || -z "${file}" ]]; then
+        exit_on_error "ERROR: at least one parameter value is missing!"
+    fi
+
+    if grep -iq "${string}" "${file}"; then
+        exit_on_error "ERROR: '${string}' found in '${file}'"
+    fi
+    log "  CHECK"
+}
+
 verify_file_contains_string_once() {
     local string="$1"
     local file="$2"

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -117,6 +117,10 @@ _jukebox_webapp_register_as_system_service_with_nginx() {
   sudo cp -f "${INSTALLATION_PATH}/resources/default-settings/nginx.default" "${WEBAPP_NGINX_SITE_DEFAULT_CONF}"
   sudo sed -i "s|%%INSTALLATION_PATH%%|${INSTALLATION_PATH}|g" "${WEBAPP_NGINX_SITE_DEFAULT_CONF}"
 
+  if [ "$DISABLE_IPv6" = true ] ; then
+    sudo sed -i '/listen \[::\]:80/d' "${WEBAPP_NGINX_SITE_DEFAULT_CONF}"
+  fi
+
   # make sure nginx can access the home directory of the user
   sudo chmod o+x "${HOME_PATH}"
 
@@ -146,6 +150,10 @@ _jukebox_webapp_check() {
 
     verify_apt_packages nginx
     verify_files_exists "${WEBAPP_NGINX_SITE_DEFAULT_CONF}"
+
+    if [ "$DISABLE_IPv6" = true ] ; then
+      verify_file_does_not_contain_string "listen [::]:80" "${WEBAPP_NGINX_SITE_DEFAULT_CONF}"
+    fi
 
     verify_service_enablement nginx.service enabled
 }


### PR DESCRIPTION
fixes #1889

Note for Release:

If ipv6 is disabled during setup, nginx fails to start.
To fix this on an existing installation please run: 
`sed -i '/listen \[::\]:80/d' /etc/nginx/sites-available/default`