### PR TITLE
add api version to mqtt.client for new version 2.0.0 compatibility

### DIFF
--- a/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
+++ b/components/smart-home-automation/MQTT-protocol/daemon_mqtt_client.py
@@ -10,6 +10,7 @@ from threading import *
 
 import inotify.adapters
 import paho.mqtt.client as mqtt
+import paho.mqtt.enums as mqtt_enum
 
 # ----------------------------------------------------------
 #  Prerequisites
@@ -590,7 +591,7 @@ def fetchData():
 
 
 # create client instance
-client = mqtt.Client(config.get("mqttClientId"))
+client = mqtt.Client(callback_api_version=mqtt_enum.CallbackAPIVersion.VERSION1, client_id=config.get("mqttClientId"))
 
 # configure authentication
 if config.get("mqttUsername") and config.get("mqttPassword"):


### PR DESCRIPTION
https://github.com/MiczFlor/RPi-Jukebox-RFID/discussions/2263

> Seems like a new Version (2.0.0) of the plugin was released last week, that included breaking changes.
https://github.com/eclipse/paho.mqtt.python/blob/v2.0.0/docs/migrations.rst