### PR TITLE
Hotfix for pyzmq installation

### DIFF
--- a/docker/armv7/jukebox.Dockerfile
+++ b/docker/armv7/jukebox.Dockerfile
@@ -65,7 +65,7 @@ WORKDIR ${HOME}
 COPY --chown=${USER}:${USER} . ${INSTALLATION_PATH}/
 
 RUN pip install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
-RUN pip install --no-cache-dir --pre --no-binary pyzmq pyzmq
+RUN pip install --no-cache-dir --no-binary pyzmq pyzmq
 
 EXPOSE 5555 5556
 

--- a/docker/jukebox.Dockerfile
+++ b/docker/jukebox.Dockerfile
@@ -50,7 +50,7 @@ RUN [ "$(uname -m)" = "aarch64" ] && ARCH="arm64" || ARCH="$(uname -m)"; \
     rm -f libzmq.tar.gz;
 
 RUN export ZMQ_PREFIX=${PREFIX} && export ZMQ_DRAFT_API=1
-RUN pip install -v --no-binary pyzmq --pre pyzmq
+RUN pip install -v --no-binary pyzmq pyzmq
 
 EXPOSE 5555 5556
 

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -86,7 +86,7 @@ _jukebox_core_build_and_install_pyzmq() {
     fi
 
     ZMQ_PREFIX="${JUKEBOX_ZMQ_PREFIX}" ZMQ_DRAFT_API=1 \
-      pip install -v --no-binary pyzmq --pre pyzmq
+      pip install -v --no-binary pyzmq pyzmq
   else
     print_lc "    Skipping. pyzmq already installed"
   fi

--- a/src/jukebox/jukebox/version.py
+++ b/src/jukebox/jukebox/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 3
 VERSION_MINOR = 5
-VERSION_PATCH = 1
+VERSION_PATCH = 2
 VERSION_EXTRA = ""
 
 # build a version string in compliance with the SemVer specification


### PR DESCRIPTION
fixes #2271
pyzmq installation fails due to the latest prerelease.

Fix: removed the `--pre` argument to use the latest release, which is known to work.