### PR TITLE
fix audio interface name in setup

### DIFF
--- a/components/bluetooth-sink-switch/README.md
+++ b/components/bluetooth-sink-switch/README.md
@@ -148,7 +148,7 @@ CMDBLUETOOTHTOGGLE="1364237231134"
 
 Speakers and Headphones can have very different maximum volume levels. This sometimes leads to very strong volume level changes when switching between speakers and headphones. Restricting the maximum volume with the Phoniebox-integrated max-volume setting does no yield the desired effect, as this is a single setting and does not differentiate between different audio sinks.
 
-The solution is adding a `softvol` component to the /etc/asound.conf. You may already have one set up, if your soundcard does not have a hardware volume control. Then it is easy! The `softvol` copmonent adds a systemwide ALSA-based volume control for a hardware soundcard. You will need to give it a name, that does **not** exist! Check with `$ amixer scontrols` first, which names are already taken. Here, I have choosen *Master*. This will work even if your soundcard has a hardware volume control.
+The solution is adding a `softvol` component to the /etc/asound.conf. You may already have one set up, if your soundcard does not have a hardware volume control. Then it is easy! The `softvol` copmonent adds a systemwide ALSA-based volume control for a hardware soundcard. You will need to give it a name, that does **not** exist! Check with `$ sudo amixer scontrols` first, which names are already taken. Here, I have choosen *Master*. This will work even if your soundcard has a hardware volume control.
 
 The `softvol` component has a feature called *max_db*  to limit the maximum volume, which we are going to utilize here. With that we are limiting the maximum volume of the speakers systemwide and independent of MPD or other Phoniebox settings.
 
@@ -204,7 +204,7 @@ $ speaker-test -D hifiberry
 and changing the default volume control in another console
 
 ~~~bash
-$ alsamixer 
+$ sudo alsamixer 
 ~~~
 
 If you are experimenting with a softvol and want to get rid of it again - that is not an easy task. Most promising approach is to insert the SD-Card into a different Linux machine delete the file `/var/lib/alsa/asound.state`. This must be done from a different computer, as this file gets written during shutdown. More infos about the softvol may be found [here](https://alsa.opensrc.org/Softvol)

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -545,8 +545,8 @@ config_audio_interface() {
 # CONFIGURE AUDIO INTERFACE (iFace)
 #
 # The default RPi audio interface is '${default_audio_interface}'.
-# But this does not work for every setup. Here a list of
-# available iFace names:
+# But this does not work for every setup.
+# Here a list of available iFace names:
 
 ${audio_interfaces}
 "

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -535,23 +535,30 @@ config_audio_interface() {
 
     clear
 
+    local amixer_scontrols=$(sudo amixer scontrols)
+    local audio_interfaces=$(echo "${amixer_scontrols}" | sed "s|.*'\(.*\)'.*|\1|g")
+    local first_audio_interface=$(echo "${audio_interfaces}" | head -1)
+    local default_audio_interface="${first_audio_interface:-PCM}"
+
     echo "#####################################################
 #
 # CONFIGURE AUDIO INTERFACE (iFace)
 #
-# The default RPi audio interface is 'Headphone'.
+# The default RPi audio interface is '${default_audio_interface}'.
 # But this does not work for every setup. Here a list of
 # available iFace names:
+
+${audio_interfaces}
 "
-    amixer scontrols
+
     echo " "
-    read -rp "Use Headphone as iFace? [Y/n] " response
+    read -rp "Use '${default_audio_interface}' as iFace? [Y/n] " response
     case "$response" in
         [nN][oO]|[nN])
             read -rp "Type the iFace name you want to use:" AUDIOiFace
             ;;
         *)
-            AUDIOiFace="Headphone"
+            AUDIOiFace="${default_audio_interface}"
             ;;
     esac
     # append variables to config file

--- a/scripts/installscripts/tests/run_installation_tests.sh
+++ b/scripts/installscripts/tests/run_installation_tests.sh
@@ -18,7 +18,7 @@ echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selecti
 # n dont configure wifi
 # y configure autohotspot
 # y use autohotspot default config
-# y Headphone as iface
+# y use default audio iface
 # n no spotify
 # y configure mpd
 # y audio default location

--- a/scripts/installscripts/tests/run_installation_tests2.sh
+++ b/scripts/installscripts/tests/run_installation_tests2.sh
@@ -17,7 +17,7 @@ echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selecti
 # y confirm interactive
 # n dont configure wifi
 # n dont configure autohotspot
-# y PCM as iface
+# y use default audio iface
 # n no spotify
 # y configure mpd
 # y audio default location

--- a/scripts/installscripts/tests/run_installation_tests3.sh
+++ b/scripts/installscripts/tests/run_installation_tests3.sh
@@ -17,7 +17,7 @@ echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selecti
 # y confirm interactive
 # n dont configure wifi
 # n dont configure autohotspot
-# y Headphone as iface
+# y use default audio iface
 # y spotify with myuser, mypassword, myclient_id, myclient_secret
 # y configure mpd
 # y audio default location


### PR DESCRIPTION
closes #2274 

- read out audio interface names with `sudo` to get the correct entries
- use the first entry as default iface name
- fallback to `PCM` if no entries are present (e.g. Pi Zero)
- Wiki has been updated for usage of `sudo amixer scontrols`