### PR TITLE
Reactivate delete artifact 

### DIFF
--- a/.github/workflows/test_docker_debian_codename_sub_v3.yml
+++ b/.github/workflows/test_docker_debian_codename_sub_v3.yml
@@ -138,7 +138,7 @@ jobs:
       with:
         name: ${{ steps.vars.outputs.image_file_name }}
         path: ${{ steps.vars.outputs.image_file_path }}
-        retention-days: 1
+        retention-days: 2
 
 
   # Run tests with build image
@@ -177,15 +177,15 @@ jobs:
         args: |
           ./${{ matrix.test_script }}
 
-  ## cleanup after test execution
-  #cleanup:
-  #  # run only if tests didn't fail: keep the artifact to make job reruns possible
-  #  if: ${{ !failure() }}
-  #  needs: [build, test]
-  #  runs-on: ${{ inputs.runs_on }}
-  #
-  #  steps:
-  #      - name: Artifact Delete Docker Image
-  #        uses: geekyeggo/delete-artifact@v4
-  #        with:
-  #          name: ${{ needs.build.outputs.image_file_name }}
+  # cleanup after test execution
+  cleanup:
+   # run only if tests didn't fail: keep the artifact to make job reruns possible
+   if: ${{ !failure() }}
+   needs: [build, test]
+   runs-on: ${{ inputs.runs_on }}
+  
+   steps:
+       - name: Artifact Delete Docker Image
+         uses: geekyeggo/delete-artifact@v5
+         with:
+           name: ${{ needs.build.outputs.image_file_name }}

--- a/.github/workflows/test_docker_debian_codename_sub_v3.yml
+++ b/.github/workflows/test_docker_debian_codename_sub_v3.yml
@@ -189,3 +189,4 @@ jobs:
          uses: geekyeggo/delete-artifact@v5
          with:
            name: ${{ needs.build.outputs.image_file_name }}
+           failOnError: false


### PR DESCRIPTION
The action [GeekyEggo/delete-artifact ](https://github.com/GeekyEggo/delete-artifact) has been released in v5.
This fixes the need of a token and we can use it again for PRs.