### PR TITLE
Fix path to config.txt for bookworm support

### DIFF
--- a/ci/Dockerfile.debian
+++ b/ci/Dockerfile.debian
@@ -5,7 +5,6 @@ FROM debian:${DEBIAN_CODENAME}-slim as base
 ARG DEBIAN_CODENAME
 
 ENV DOCKER_RUNNING=true
-RUN touch /boot/cmdlinetxt
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && echo "--- install packages (1) ---" \

--- a/components/audio/PirateAudioHAT/README.md
+++ b/components/audio/PirateAudioHAT/README.md
@@ -17,9 +17,9 @@ NOTE: changes to the installation should find their way into the script `setup_p
 
 1. Connect Pirate Audio Hat to your Raspberry Pi
 2. Install Phoniebox (develop branch!)
-3. Stop and disable the GPIO button service:
-   `sudo systemctl stop phoniebox-gpio-buttons.service`
-   `sudo systemctl disable phoniebox-gpio-buttons.service`
+3. Stop and disable the GPIO control service:
+   `sudo systemctl stop phoniebox-gpio-control.service`
+   `sudo systemctl disable phoniebox-gpio-control.service`
 4. Add the following two lines to `config.txt`.
     (Up to Bullseye, the `config.txt` file is located at `/boot/`. Since Bookworm, the location changed to `/boot/firmware/`, [see here](https://www.raspberrypi.com/documentation/computers/config_txt.html)).
    `gpio=25=op,dh`

--- a/components/audio/PirateAudioHAT/README.md
+++ b/components/audio/PirateAudioHAT/README.md
@@ -20,7 +20,8 @@ NOTE: changes to the installation should find their way into the script `setup_p
 3. Stop and disable the GPIO button service:
    `sudo systemctl stop phoniebox-gpio-buttons.service`
    `sudo systemctl disable phoniebox-gpio-buttons.service`
-4. Add the following two lines to /boot/config.txt
+4. Add the following two lines to `config.txt`.
+    (Up to Bullseye, the `config.txt` file is located at `/boot/`. Since Bookworm, the location changed to `/boot/firmware/`, [see here](https://www.raspberrypi.com/documentation/computers/config_txt.html)).
    `gpio=25=op,dh`
    `dtoverlay=hifiberry-dac`
 5. Add settings to /etc/asound.conf (create it, if it does not exist yet)

--- a/components/audio/PirateAudioHAT/README.md
+++ b/components/audio/PirateAudioHAT/README.md
@@ -1,89 +1,16 @@
 # How to setup a Pimoroni PirateAudio HAT
 
-These instructions are for the following Pimoroni PirateAudio HATs:
+> [!NOTE]
+> The display of the HATs currently only work with the 'spotify' edition, not with 'classic'!
+> See [here](https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/1109)
 
-<https://shop.pimoroni.com/?q=pirate+audio>
+These instructions are for the [Pimoroni PirateAudio HATs](https://shop.pimoroni.com/collections/audio?q=pirate%20audio)
 
-The PirateAudio HATs use the same DAC as the hifiberry, so some of the instructions
-from <https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/HiFiBerry-Soundcard-Details> can be applied as well.
+## Installation
 
-The `setup_pirateAudioHAT.sh` script can be used to set it up to work with Phoniebox.
+Run the `setup_pirateAudioHAT.sh` script to set it up to work with Phoniebox.
 
-## Install steps in writing
+## Troubleshooting
 
-(Discussions regarding *Pirate Audio HAT* should take place in the same thread where the below instructions were taken from: [#950](https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/950)
-
-NOTE: changes to the installation should find their way into the script `setup_pirateAudioHAT.sh`. Please create pull requests *after* having tested your changes. :)
-
-1. Connect Pirate Audio Hat to your Raspberry Pi
-2. Install Phoniebox (develop branch!)
-3. Stop and disable the GPIO control service:
-   `sudo systemctl stop phoniebox-gpio-control.service`
-   `sudo systemctl disable phoniebox-gpio-control.service`
-4. Add the following two lines to `config.txt`.
-    (Up to Bullseye, the `config.txt` file is located at `/boot/`. Since Bookworm, the location changed to `/boot/firmware/`, [see here](https://www.raspberrypi.com/documentation/computers/config_txt.html)).
-   `gpio=25=op,dh`
-   `dtoverlay=hifiberry-dac`
-5. Add settings to /etc/asound.conf (create it, if it does not exist yet)
-
-   ```bash
-   pcm.hifiberry {
-        type            softvol
-        slave.pcm       "plughw:CARD=sndrpihifiberry,DEV=0"
-        control.name    "Master"
-        control.card    1
-    }
-    pcm.!default {
-        type            plug
-        slave.pcm       "hifiberry"
-    }
-    ctl.!default {
-        type            hw
-        card            1
-    }
-    ```
-
-6. Add the following section to /etc/mpd.conf
-
-   ```bash
-   audio_output {
-            enabled         "yes"
-            type            "alsa"
-            name            "HiFiBerry DAC+ Lite"
-            device          "hifiberry"
-            auto_resample   "no"
-            auto_channels   "no"
-            auto_format     "no"
-            dop             "no"
-    }
-    ```
-
-7. Set mixer_control name in /etc/mpd.conf
-    `mixer_control      "Master"`
-8. Enable SPI
-    `sudo raspi-config nonint do_spi 0`
-9. Install Python dependencies
-    `sudo apt-get install python3-pil python3-numpy`
-10. Install Mopidy plugins
-    `sudo pip3 install Mopidy-PiDi pidi-display-pil pidi-display-st7789 mopidy-raspberry-gpio`
-11. Add the following sections to /etc/mopidy/mopidy.conf:
-  
-    ```bash
-    [raspberry-gpio]
-    enabled = true
-    bcm5 = play_pause,active_low,150
-    bcm6 = volume_down,active_low,150
-    bcm16 = next,active_low,150
-    bcm20 = volume_up,active_low,150
-    bcm24 = volume_up,active_low,150
-    
-    [pidi]
-    enabled = true
-    display = st7789
-    ```
-
-    **Attention:** Early revisions of PirateAudio HAT used bcm20 for Volume up, later revisions use bcm24. see also <https://github.com/pimoroni/pirate-audio/issues/63#issuecomment-916860634>
-
-12. Enable access for modipy user
-    `sudo usermod -a -G spi,i2c,gpio,video mopidy`
-13. Reboot Raspberry Pi
+The PirateAudio HATs use the same DAC as the HiFiBerry, so some of the instructions
+from [HiFiBerry Soundcard Details](https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/HiFiBerry-Soundcard-Details) can be applied as well.

--- a/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
+++ b/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
@@ -3,6 +3,8 @@
 HOME_DIR="/home/pi"
 JUKEBOX_HOME_DIR="${HOME_DIR}/RPi-Jukebox-RFID"
 
+source "${JUKEBOX_HOME_DIR}"/scripts/helperscripts/inc.systemHelper.sh
+
 question() {
     local question=$1
     read -p "${question} (y/n)? " choice
@@ -21,17 +23,19 @@ printf "Stopping and disabling GPIO button service...\n"
 sudo systemctl stop phoniebox-gpio-buttons.service
 sudo systemctl disable phoniebox-gpio-buttons.service
 
-printf "Adding settings to /boot/config.txt...\n"
-if [[ ! -f /boot/config.txt.bak ]]; then
-    sudo cp /boot/config.txt /boot/config.txt.bak
+boot_config_path=$(get_boot_config_path)
+boot_config_path_backup="${boot_config_path}.bak"
+printf "Adding settings to ${boot_config_path}...\n"
+if [[ ! -f "${boot_config_path_backup}" ]]; then
+    sudo cp "${boot_config_path}" "${boot_config_path_backup}"
 fi
 
 # Only add the two lines, if they do not exist already
-if ! sudo grep -qe "gpio=25=op,dh" /boot/config.txt; then
-    echo "gpio=25=op,dh" | sudo tee -a /boot/config.txt > /dev/null
+if ! sudo grep -qe "gpio=25=op,dh" "${boot_config_path}"; then
+    echo "gpio=25=op,dh" | sudo tee -a "${boot_config_path}" > /dev/null
 fi
-if ! sudo grep -qe "dtoverlay=hifiberry-dac" /boot/config.txt; then
-    echo "dtoverlay=hifiberry-dac" | sudo tee -a /boot/config.txt > /dev/null
+if ! sudo grep -qe "dtoverlay=hifiberry-dac" "${boot_config_path}"; then
+    echo "dtoverlay=hifiberry-dac" | sudo tee -a "${boot_config_path}" > /dev/null
 fi
 
 printf "Adding settings to /etc/asound.conf...\n"

--- a/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
+++ b/components/audio/PirateAudioHAT/setup_pirateAudioHAT.sh
@@ -18,10 +18,10 @@ question() {
 printf "Please make sure that the Pirate Audio HAT is connected...\n"
 question "Continue"
 
-printf "Stopping and disabling GPIO button service...\n"
+printf "Stopping and disabling GPIO control service...\n"
 #TODO this might not be necessary
-sudo systemctl stop phoniebox-gpio-buttons.service
-sudo systemctl disable phoniebox-gpio-buttons.service
+sudo systemctl stop phoniebox-gpio-control.service
+sudo systemctl disable phoniebox-gpio-control.service
 
 boot_config_path=$(get_boot_config_path)
 boot_config_path_backup="${boot_config_path}.bak"

--- a/scripts/helperscripts/inc.systemHelper.sh
+++ b/scripts/helperscripts/inc.systemHelper.sh
@@ -1,0 +1,35 @@
+is_raspbian() {
+    if [[ $( . /etc/os-release; printf '%s\n' "$ID"; ) == *"raspbian"* ]]; then
+        echo true
+    else
+        echo false
+    fi
+}
+
+get_debian_version_number() {
+    source /etc/os-release
+    echo "$VERSION_ID"
+}
+
+_get_boot_file_path() {
+    local filename="$1"
+    if [ "$(is_raspbian)" = true ]; then
+        local debian_version_number=$(get_debian_version_number)
+
+        # Bullseye and lower
+        if [ "$debian_version_number" -le 11 ]; then
+            echo "/boot/${filename}"
+        # Bookworm and higher
+        elif [ "$debian_version_number" -ge 12 ]; then
+            echo "/boot/firmware/${filename}"
+        else
+            echo "unknown"
+        fi
+    else
+        echo "unknown"
+    fi
+}
+
+get_boot_config_path() {
+    echo $(_get_boot_file_path "config.txt")
+}


### PR DESCRIPTION
Up to Bullseye, the `config.txt` file is located at `/boot/`. Since Bookworm, the location changed to `/boot/firmware/`, [see here](https://www.raspberrypi.com/documentation/computers/config_txt.html).

- Added logic to retrieve correct path from future3 as helperscript
- fixed gpio service name in pirateHat setup

closes #2262 