### PR TITLE
docs: Manually upgrade to the latest version

### DIFF
--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -15,7 +15,7 @@ $ diff shared/settings/jukebox.yaml resources/default-settings/jukebox.default.y
 ## Manually upgrade to the latest version
 
 > [!CAUTION]
-> This documentation is only recommended for users running on `future3/develop` branch. For optimal system updates, it is strongly recommended to utilize the upgrade feature when transitioning to the next version. Manual updates may necessitate specific migration steps and, if overlooked, could result in system failure. Please use these steps with caution.
+> This documentation is only recommended for users running on `future3/develop` branch. For optimal system updates, it is strongly recommended to utilize the upgrade feature when transitioning to the next version (The Upgrade Feature will come in the future [#2304](https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2304)). Manual updates may necessitate specific migration steps and, if overlooked, could result in system failure. Please use these steps with caution.
 
 If you only want to update a few recent commits, this following explanation outlines the steps to do so
 

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -103,7 +103,7 @@ Revert to Backup If Needed:
     cd ~/RPi-Jukebox-RFID/src/webapp
     rm -rf build
     mv build-backup build
-        ```
+    ```
 
 ## Migration Path from Version 2
 

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -76,7 +76,6 @@ Be aware, in case you have made changes to the software, stash them to keep them
         rm -rf webapp-build-latest.tar.gz
         ```
 
-
 1. Reboot the Phoniebox:
 
    ```bash
@@ -86,24 +85,24 @@ Be aware, in case you have made changes to the software, stash them to keep them
 1. Verify the version of your Phoniebox in the settings tab.
 
 Revert to Backup If Needed:
-   - Checkout the backup branch:
+- Checkout the backup branch:
 
-        ```bash
-        git checkout backup-before-pull
-        ```
+    ```bash
+    git checkout backup-before-pull
+    ```
 
-   - Reapply stashed changes (if any):
+- Reapply stashed changes (if any):
 
-        ```bash
-        git stash pop
-        ```
+    ```bash
+    git stash pop
+    ```
 
-   - Revert Web App:
+- Revert Web App:
 
-        ```bash
-        cd ~/RPi-Jukebox-RFID/src/webapp
-        rm -rf build
-        mv build-backup build
+    ```bash
+    cd ~/RPi-Jukebox-RFID/src/webapp
+    rm -rf build
+    mv build-backup build
         ```
 
 ## Migration Path from Version 2

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -15,7 +15,7 @@ $ diff shared/settings/jukebox.yaml resources/default-settings/jukebox.default.y
 ## Manually upgrade to the latest version
 
 > [!CAUTION]
-> For optimal system updates, it is strongly recommended to utilize the upgrade feature when transitioning to the next version. Manual updates may necessitate specific migration steps and, if overlooked, could result in system failure.
+> This documentation is only recommended for users running on `future3/develop` branch. For optimal system updates, it is strongly recommended to utilize the upgrade feature when transitioning to the next version. Manual updates may necessitate specific migration steps and, if overlooked, could result in system failure. Please use these steps with caution.
 
 If you only want to update a few recent commits, this following explanation outlines the steps to do so
 
@@ -44,9 +44,10 @@ Be aware, in case you have made changes to the software, stash them to keep them
         git stash push -m "Backup before pull"
         ```
 
-    - Create a Backup Branch:
+    - Create a Backup Branch (and potentially delete it in case it already exists):
 
         ```bash
+        git branch -D backup-before-pull
         git branch backup-before-pull
         ```
 
@@ -61,6 +62,7 @@ Be aware, in case you have made changes to the software, stash them to keep them
 
     ```bash
     cd ~/RPi-Jukebox-RFID/src/webapp
+    rm -rf build-backup
     mv build build-backup
     ```
 
@@ -99,7 +101,7 @@ Revert to Backup If Needed:
    - Revert Web App:
 
         ```bash
-        ccd ~/RPi-Jukebox-RFID/src/webapp
+        cd ~/RPi-Jukebox-RFID/src/webapp
         rm -rf build
         mv build-backup build
         ```

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -17,14 +17,14 @@ $ diff shared/settings/jukebox.yaml resources/default-settings/jukebox.default.y
 > [!CAUTION]
 > For optimal system updates, it is strongly recommended to utilize the upgrade feature when transitioning to the next version. Manual updates may necessitate specific migration steps and, if overlooked, could result in system failure.
 
-If you only want to update a few recent comments, this following explanation outlines the steps to do so
+If you only want to update a few recent commits, this following explanation outlines the steps to do so
 
 Typically, 4 steps need to be considered
 
 1. Backup Local Changes (Optional)
 1. Pull the latest version from Github
-1. Replace the Web App with the most recent built
-1. Optional: Update the config files if required.
+1. Replace the Web App with the most recent build
+1. Optional: Update the config files
 
 ### Fetch the most recent version from Github
 
@@ -35,7 +35,7 @@ cd ~/RPi-Jukebox-RFID/
 ```
 
 Second, get the latest version from Github. Depending on how sufficient you are with Git, you can also checkout a specific branch or version.
-Be awere, in case you have made changes to the software, stash them to keep them safe.
+Be aware, in case you have made changes to the software, stash them to keep them safe.
 
 1. Backup Local Changes (Optional):
     - Stash your local changes:

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -85,6 +85,7 @@ Be aware, in case you have made changes to the software, stash them to keep them
 1. Verify the version of your Phoniebox in the settings tab.
 
 Revert to Backup If Needed:
+
 - Checkout the backup branch:
 
     ```bash

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -12,6 +12,98 @@ Restore your old files after the new installation was successful and check if ne
 $ diff shared/settings/jukebox.yaml resources/default-settings/jukebox.default.yaml
 ```
 
+## Manually upgrade to the latest version
+
+> [!CAUTION]
+> For optimal system updates, it is strongly recommended to utilize the upgrade feature when transitioning to the next version. Manual updates may necessitate specific migration steps and, if overlooked, could result in system failure.
+
+If you only want to update a few recent comments, this following explanation outlines the steps to do so
+
+Typically, 4 steps need to be considered
+
+1. Backup Local Changes (Optional)
+1. Pull the latest version from Github
+1. Replace the Web App with the most recent built
+1. Optional: Update the config files if required.
+
+### Fetch the most recent version from Github
+
+First, SSH into your Phoniebox.
+
+```bash
+cd ~/RPi-Jukebox-RFID/
+```
+
+Second, get the latest version from Github. Depending on how sufficient you are with Git, you can also checkout a specific branch or version.
+Be awere, in case you have made changes to the software, stash them to keep them safe.
+
+1. Backup Local Changes (Optional):
+    - Stash your local changes:
+
+        ```bash
+        git stash push -m "Backup before pull"
+        ```
+
+    - Create a Backup Branch:
+
+        ```bash
+        git branch backup-before-pull
+        ```
+
+1. Pull Latest Changes:
+
+   ```bash
+   git pull
+   ```
+
+1. Update Web App:
+    1. Backup the current webapp build
+
+    ```bash
+    cd ~/RPi-Jukebox-RFID/src/webapp
+    mv build build-backup
+    ```
+
+    1. Go to the [Github Release page](https://github.com/MiczFlor/RPi-Jukebox-RFID/releases) find the latest `Pre-release` release (typically Alpha).
+    1. Under "Assets", find the latest Web App release called "webapp-build-latest.tar.gz" and copy the URL.
+    1. On your Phoniebox, download the file and extract the archive. Afterwards, delete the archive
+
+    ```bash
+    wget {URL}
+    tar -xzf webapp-build-latest.tar.gz
+    rm -rf webapp-build-latest.tar.gz
+    ```
+
+
+1. Reboot the Phoniebox:
+
+   ```bash
+   sudo reboot
+   ```
+
+1. Verify the version of your Phoniebox in the settings tab.
+
+**Revert to Backup If Needed:**
+   - Checkout the backup branch:
+
+        ```bash
+        git checkout backup-before-pull
+        ```
+
+   - Reapply stashed changes (if any):
+
+        ```bash
+        git stash pop
+        ```
+
+   - Revert Web App:
+
+        ```bash
+        ccd ~/RPi-Jukebox-RFID/src/webapp
+        rm -rf build
+        mv build-backup build
+        ```
+
 ## Migration Path from Version 2
 
 There is no update path coming from Version 2.x of the Jukebox.

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -83,7 +83,7 @@ Be awere, in case you have made changes to the software, stash them to keep them
 
 1. Verify the version of your Phoniebox in the settings tab.
 
-**Revert to Backup If Needed:**
+Revert to Backup If Needed:
    - Checkout the backup branch:
 
         ```bash

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -34,7 +34,7 @@ First, SSH into your Phoniebox.
 cd ~/RPi-Jukebox-RFID/
 ```
 
-Second, get the latest version from Github. Depending on how sufficient you are with Git, you can also checkout a specific branch or version.
+Second, get the latest version from Github. Depending on your proficiency with Git, you can also checkout a specific branch or version.
 Be aware, in case you have made changes to the software, stash them to keep them safe.
 
 1. Backup Local Changes (Optional):

--- a/documentation/builders/update.md
+++ b/documentation/builders/update.md
@@ -60,21 +60,21 @@ Be aware, in case you have made changes to the software, stash them to keep them
 1. Update Web App:
     1. Backup the current webapp build
 
-    ```bash
-    cd ~/RPi-Jukebox-RFID/src/webapp
-    rm -rf build-backup
-    mv build build-backup
-    ```
+        ```bash
+        cd ~/RPi-Jukebox-RFID/src/webapp
+        rm -rf build-backup
+        mv build build-backup
+        ```
 
     1. Go to the [Github Release page](https://github.com/MiczFlor/RPi-Jukebox-RFID/releases) find the latest `Pre-release` release (typically Alpha).
     1. Under "Assets", find the latest Web App release called "webapp-build-latest.tar.gz" and copy the URL.
     1. On your Phoniebox, download the file and extract the archive. Afterwards, delete the archive
 
-    ```bash
-    wget {URL}
-    tar -xzf webapp-build-latest.tar.gz
-    rm -rf webapp-build-latest.tar.gz
-    ```
+        ```bash
+        wget {URL}
+        tar -xzf webapp-build-latest.tar.gz
+        rm -rf webapp-build-latest.tar.gz
+        ```
 
 
 1. Reboot the Phoniebox:


### PR DESCRIPTION
Providing a page to manually update the Phoniebox update in case someone wants to get the most recent Git updates (This is not necessarily a safe path in all situations)