### PR TITLE
Docs: Fix GPIO shutdown button naming

### DIFF
--- a/documentation/builders/gpio.md
+++ b/documentation/builders/gpio.md
@@ -112,7 +112,7 @@ A button to shutdown the Jukebox if it is pressed for more than 3 seconds. Note 
 
 ```yml
 input_devices:
-  IncreaseVolume:
+  Shutdown:
     type: LongPressButton
     kwargs:
       pin: 3


### PR DESCRIPTION
The GPIO docs use `IncreaseVolume` as a name for the shutdown button. This should obviously be `Shutdown` or something similar.