### PR TITLE
installation: untar libzmq in venv folder instead of /usr/local

### DIFF
--- a/docker/jukebox.Dockerfile
+++ b/docker/jukebox.Dockerfile
@@ -42,14 +42,14 @@ RUN pip install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
 
 ENV ZMQ_TMP_DIR libzmq
 ENV ZMQ_VERSION 4.3.5
-ENV ZMQ_PREFIX /usr/local
+ENV ZMQ_PREFIX ${VIRTUAL_ENV}
+ENV ZMQ_DRAFT_API 1
 
 RUN [ "$(uname -m)" = "aarch64" ] && ARCH="arm64" || ARCH="$(uname -m)"; \
     wget https://github.com/pabera/libzmq/releases/download/v${ZMQ_VERSION}/libzmq5-${ARCH}-${ZMQ_VERSION}.tar.gz -O libzmq.tar.gz; \
     tar -xzf libzmq.tar.gz -C ${ZMQ_PREFIX}; \
     rm -f libzmq.tar.gz;
 
-RUN export ZMQ_PREFIX=${PREFIX} && export ZMQ_DRAFT_API=1
 RUN pip install -v --no-binary pyzmq pyzmq
 
 EXPOSE 5555 5556

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -2,7 +2,7 @@
 
 # Constants
 JUKEBOX_ZMQ_TMP_DIR="${HOME_PATH}/libzmq"
-JUKEBOX_ZMQ_PREFIX="/usr/local"
+JUKEBOX_ZMQ_PREFIX="${VIRTUAL_ENV}"
 JUKEBOX_ZMQ_VERSION="4.3.5"
 
 JUKEBOX_PULSE_CONFIG="${HOME_PATH}"/.config/pulse/default.pa
@@ -61,9 +61,8 @@ _jukebox_core_download_prebuilt_libzmq_with_drafts() {
 
   cd "${JUKEBOX_ZMQ_TMP_DIR}" || exit_on_error
   wget --quiet https://github.com/pabera/libzmq/releases/download/v${JUKEBOX_ZMQ_VERSION}/libzmq5-${ARCH}-${JUKEBOX_ZMQ_VERSION}.tar.gz -O ${zmq_tar_filename} || exit_on_error "Download failed"
-  tar -xzf ${zmq_tar_filename}
+  tar -xzf ${zmq_tar_filename} -C ${JUKEBOX_ZMQ_PREFIX}
   rm -f ${zmq_tar_filename}
-  sudo rsync -a ./* ${JUKEBOX_ZMQ_PREFIX}/
 }
 
 _jukebox_core_build_and_install_pyzmq() {


### PR DESCRIPTION
- on a linux-host docker build, the user can't write to /usr/local and installing pyzmq fails
- untar libzmq to venv instead
- normal installation also changed because it's sensible to have all pyzmq dependencies in the venv
- jukebox.Dockerfile: removing ZMQ_PREFIX=${PREFIX} since PREFIX variable doesn't exist in docker environment
- jukebox.Dockerfile: use ENV to set ZMQ_DRAFT_API