### PR TITLE
Fix PlayerMPD.rewind to start with the first song (future3)

### DIFF
--- a/src/jukebox/components/playermpd/__init__.py
+++ b/src/jukebox/components/playermpd/__init__.py
@@ -350,7 +350,7 @@ class PlayerMPD:
         Note: Will not re-read folder config, but leave settings untouched"""
         logger.debug("Rewind")
         with self.mpd_lock:
-            self.mpd_client.play(1)
+            self.mpd_client.play(0)
 
     @plugs.tag
     def replay(self):


### PR DESCRIPTION
rewind() is documented to jump to the first song of the playlist. Instead, it jumped to the second song as `SONGPOS` in `MPDClient.play(SONGPOS)` is zero-indexed [1], so `mpd.play(1)` started the second song.

The change should probably be double-checked to be correct (or why it hasn't been found by now), but this is what I've observed during experimentation and doc reading.

[1] https://mpd.readthedocs.io/en/latest/protocol.html#the-queue :
> "The position is a 0-based index"

Related: #2294