### PR TITLE
Fix CoverartCacheManager

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ pyalsaaudio
 pulsectl
 python-mpd2
 ruamel.yaml
-python-slugify
 # For playlistgenerator
 requests
 # For the publisher event reactor loop:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ wheel
 # Jukebox Core
 # For USB inputs (reader, buttons) and bluetooth buttons
 evdev
+mutagen
 pyalsaaudio
 pulsectl
 python-mpd2

--- a/src/jukebox/components/playermpd/__init__.py
+++ b/src/jukebox/components/playermpd/__init__.py
@@ -99,7 +99,7 @@ import misc
 
 from jukebox.NvManager import nv_manager
 from .playcontentcallback import PlayContentCallbacks, PlayCardState
-from .coverart_cache_manager import CoverartCacheManager
+from .coverart_cache_manager import CoverartCacheManager, NO_CONTENT
 
 logger = logging.getLogger('jb.PlayerMPD')
 cfg = jukebox.cfghandler.get_handler('jukebox')
@@ -539,6 +539,9 @@ class PlayerMPD:
 
             if cache_filename:
                 return cache_filename
+
+            if cache_filename is NO_CONTENT:
+                return ''
 
             # Cache file does not exist
             # Fetch cover art binary

--- a/src/jukebox/components/playermpd/__init__.py
+++ b/src/jukebox/components/playermpd/__init__.py
@@ -524,40 +524,31 @@ class PlayerMPD:
         """
         Saves the album art image to a cache and returns the filename.
         """
-        base_filename = slugify(song_url)
+        metadata_list = self.mpd_client.listallinfo(song_url)
+        metadata = metadata_list[0] if metadata_list else {}
+
+        if 'albumartist' in metadata and 'album' in metadata:
+            base_filename = slugify(f"{metadata.get('albumartist', '')}-{metadata.get('album', '')}")
+        else:
+            base_filename = slugify(song_url)
+
+        cache_filename = self.coverart_cache_manager.find_file_by_hash(base_filename)
+
+        if cache_filename or cache_filename is NO_CONTENT:
+            return cache_filename or ''
 
         try:
-            metadata_list = self.mpd_client.listallinfo(song_url)
-            metadata = {}
-            if metadata_list:
-                metadata = metadata_list[0]
-
-            if 'albumartist' in metadata and 'album' in metadata:
-                base_filename = slugify(f"{metadata['albumartist']}-{metadata['album']}")
-
-            cache_filename = self.coverart_cache_manager.find_file_by_hash(base_filename)
-
-            if cache_filename:
-                return cache_filename
-
-            if cache_filename is NO_CONTENT:
-                return ''
-
-            # Cache file does not exist
             # Fetch cover art binary
             album_art_data = self.mpd_client.readpicture(song_url)
-
-            # Save to cache
-            cache_filename = self.coverart_cache_manager.save_to_cache(base_filename, album_art_data)
-
-            return cache_filename
+            # Save to cache and return the filename
+            return self.coverart_cache_manager.save_to_cache(base_filename, album_art_data)
 
         except mpd.base.CommandError as e:
-            logger.error(f"{e.__class__.__qualname__}: {e} at uri {song_url}")
+            logger.error(f'{e.__class__.__qualname__}: {e} at uri {song_url}')
         except Exception as e:
-            logger.error(f"{e.__class__.__qualname__}: {e} at uri {song_url}")
+            logger.error(f'{e.__class__.__qualname__}: {e} at uri {song_url}')
 
-        return ""
+        return ''
 
     @plugs.tag
     def get_album_coverart(self, albumartist: str, album: str):

--- a/src/jukebox/components/playermpd/__init__.py
+++ b/src/jukebox/components/playermpd/__init__.py
@@ -524,24 +524,14 @@ class PlayerMPD:
         """
         Saves the album art image to a cache and returns the filename.
         """
-        metadata_list = self.mpd_client.listallinfo(song_url)
-        metadata = metadata_list[0] if metadata_list else {}
-
-        if 'albumartist' in metadata and 'album' in metadata:
-            base_filename = slugify(f"{metadata.get('albumartist', '')}-{metadata.get('album', '')}")
-        else:
-            base_filename = slugify(song_url)
-
-        cache_filename = self.coverart_cache_manager.find_file_by_hash(base_filename)
+        cache_filename = self.coverart_cache_manager.find_file_by_hash(song_url)
 
         if cache_filename or cache_filename is NO_CONTENT:
             return cache_filename or ''
 
         try:
-            # Fetch cover art binary
             album_art_data = self.mpd_client.readpicture(song_url)
-            # Save to cache and return the filename
-            return self.coverart_cache_manager.save_to_cache(base_filename, album_art_data)
+            return self.coverart_cache_manager.save_to_cache(song_url, album_art_data)
 
         except mpd.base.CommandError as e:
             logger.error(f'{e.__class__.__qualname__}: {e} at uri {song_url}')

--- a/src/jukebox/components/playermpd/__init__.py
+++ b/src/jukebox/components/playermpd/__init__.py
@@ -535,7 +535,7 @@ class PlayerMPD:
     @plugs.tag
     def flush_coverart_cache(self):
         """
-        Deletes the Cover Art Cach
+        Deletes the Cover Art Cache
         """
 
         return self.coverart_cache_manager.flush_cache()

--- a/src/jukebox/components/playermpd/__init__.py
+++ b/src/jukebox/components/playermpd/__init__.py
@@ -87,7 +87,6 @@ import threading
 import logging
 import time
 import functools
-from slugify import slugify
 import components.player
 import jukebox.cfghandler
 import jukebox.utils as utils

--- a/src/jukebox/components/playermpd/coverart_cache_manager.py
+++ b/src/jukebox/components/playermpd/coverart_cache_manager.py
@@ -1,16 +1,20 @@
+from mutagen.mp3 import MP3
+from mutagen.id3 import ID3, APIC
 from pathlib import Path
 import hashlib
 import logging
-import jukebox.cfghandler
 from queue import Queue
 from threading import Thread
+import jukebox.cfghandler
 
+COVER_PREFIX = 'cover'
 NO_COVER_ART_EXTENSION = 'no-art'
-NO_CONTENT = ''
-NOT_CACHED = None
+NO_CACHE = ''
+CACHE_PENDING = 'CACHE_PENDING'
 
 logger = logging.getLogger('jb.CoverartCacheManager')
 cfg = jukebox.cfghandler.get_handler('jukebox')
+
 
 class CoverartCacheManager:
     def __init__(self):
@@ -18,48 +22,69 @@ class CoverartCacheManager:
         self.cache_folder_path = Path(coverart_cache_path).expanduser()
         self.write_queue = Queue()
         self.worker_thread = Thread(target=self.process_write_requests)
-        self.worker_thread.daemon = True  # Ensure thread closes with the program
+        self.worker_thread.daemon = True  # Ensure the thread closes with the program
         self.worker_thread.start()
 
     def generate_cache_key(self, base_filename: str) -> str:
-        return f'test-{hashlib.sha256(base_filename.encode()).hexdigest()}'
+        return f"{COVER_PREFIX}-{hashlib.sha256(base_filename.encode()).hexdigest()}"
 
-    def find_file_by_hash(self, base_filename: str) -> str:
+    def get_cache_filename(self, mp3_file_path: str) -> str:
+        base_filename = Path(mp3_file_path).stem
         cache_key = self.generate_cache_key(base_filename)
+
         for path in self.cache_folder_path.iterdir():
             if path.stem == cache_key:
-                if path.suffix == f'.{NO_COVER_ART_EXTENSION}':
-                    return NO_CONTENT
+                if path.suffix == f".{NO_COVER_ART_EXTENSION}":
+                    return NO_CACHE
                 return path.name
-        return NOT_CACHED
 
-    def save_to_cache(self, base_filename: str, album_art_data: dict):
-        self.write_queue.put((base_filename, album_art_data))
+        self.save_to_cache(mp3_file_path)
+        return CACHE_PENDING
 
-    def _save_to_cache(self, base_filename: str, album_art_data: dict) -> str:
+    def save_to_cache(self, mp3_file_path: str):
+        self.write_queue.put(mp3_file_path)
+
+    def _save_to_cache(self, mp3_file_path: str):
+        base_filename = Path(mp3_file_path).stem
         cache_key = self.generate_cache_key(base_filename)
-        file_extension = NO_COVER_ART_EXTENSION
-        data = b''
+        file_extension, data = self._extract_album_art(mp3_file_path)
 
-        if album_art_data:
-            mime_type = album_art_data.get('type', 'image/jpeg')
-            file_extension = 'jpg' if mime_type == 'image/jpeg' else mime_type.split('/')[-1]
-            data = album_art_data.get('binary', b'')
-
-        cache_filename = f'{cache_key}.{file_extension}'
-        full_path = self.cache_folder_path / cache_filename # Works due to pathlib
+        cache_filename = f"{cache_key}.{file_extension}"
+        full_path = self.cache_folder_path / cache_filename # Works due to Pathlib
 
         with full_path.open('wb') as file:
             file.write(data)
-            logger.debug(f'Created file: {cache_filename}')
+            logger.debug(f"Created file: {cache_filename}")
 
-        return cache_filename if data else NO_CONTENT
+        return cache_filename
+
+    def _extract_album_art(self, mp3_file_path: str) -> tuple:
+        try:
+            audio_file = MP3(mp3_file_path, ID3=ID3)
+        except Exception as e:
+            logger.error(f"Error reading MP3 file {mp3_file_path}: {e}")
+            return (NO_COVER_ART_EXTENSION, b'')
+
+        for tag in audio_file.tags.values():
+            if isinstance(tag, APIC):
+                mime_type = tag.mime
+                file_extension = 'jpg' if mime_type == 'image/jpeg' else mime_type.split('/')[-1]
+                return (file_extension, tag.data)
+
+        return (NO_COVER_ART_EXTENSION, b'')
 
     def process_write_requests(self):
         while True:
-            base_filename, album_art_data = self.write_queue.get()
+            mp3_file_path = self.write_queue.get()
             try:
-                self._save_to_cache(base_filename, album_art_data)
+                self._save_to_cache(mp3_file_path)
             except Exception as e:
-                logger.error(f'Error processing write request: {e}')
+                logger.error(f"Error processing write request: {e}")
             self.write_queue.task_done()
+
+    def flush_cache(self):
+        for path in self.cache_folder_path.iterdir():
+            if path.is_file():
+                path.unlink()
+                logger.debug(f"Deleted cached file: {path.name}")
+        logger.info("Cache flushed successfully.")

--- a/src/jukebox/components/playermpd/coverart_cache_manager.py
+++ b/src/jukebox/components/playermpd/coverart_cache_manager.py
@@ -1,6 +1,10 @@
 import os
 import jukebox.cfghandler
 
+NO_COVER_ART_EXTENSION = 'no-art'
+NO_CONTENT = ''
+NOT_CACHED = None
+
 cfg = jukebox.cfghandler.get_handler('jukebox')
 
 
@@ -12,15 +16,25 @@ class CoverartCacheManager:
     def find_file_by_hash(self, hash_value):
         for filename in os.listdir(self.cache_folder_path):
             if filename.startswith(hash_value):
+                if filename.endswith(f'.{NO_COVER_ART_EXTENSION}'):
+                    return NO_CONTENT
                 return filename
-        return None
+        return NOT_CACHED
 
     def save_to_cache(self, base_filename, album_art_data):
-        mime_type = album_art_data['type']
-        file_extension = 'jpg' if mime_type == 'image/jpeg' else mime_type.split('/')[-1]
+        if album_art_data:
+            mime_type = album_art_data['type']
+            file_extension = 'jpg' if mime_type == 'image/jpeg' else mime_type.split('/')[-1]
+            data = album_art_data['binary']
+        else:
+            file_extension = NO_COVER_ART_EXTENSION
+            data = b''
         cache_filename = f"{base_filename}.{file_extension}"
 
         with open(os.path.join(self.cache_folder_path, cache_filename), 'wb') as file:
-            file.write(album_art_data['binary'])
+            file.write(data)
 
-        return cache_filename
+        if data:
+            return cache_filename
+
+        return NO_CONTENT

--- a/src/jukebox/components/playermpd/coverart_cache_manager.py
+++ b/src/jukebox/components/playermpd/coverart_cache_manager.py
@@ -7,6 +7,7 @@ NOT_CACHED = None
 
 cfg = jukebox.cfghandler.get_handler('jukebox')
 
+
 class CoverartCacheManager:
     def __init__(self):
         coverart_cache_path = cfg.setndefault('webapp', 'coverart_cache_path', value='../../src/webapp/build/cover-cache')

--- a/src/jukebox/components/playermpd/coverart_cache_manager.py
+++ b/src/jukebox/components/playermpd/coverart_cache_manager.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import jukebox.cfghandler
 
 NO_COVER_ART_EXTENSION = 'no-art'
@@ -7,34 +7,32 @@ NOT_CACHED = None
 
 cfg = jukebox.cfghandler.get_handler('jukebox')
 
-
 class CoverartCacheManager:
     def __init__(self):
         coverart_cache_path = cfg.setndefault('webapp', 'coverart_cache_path', value='../../src/webapp/build/cover-cache')
-        self.cache_folder_path = os.path.expanduser(coverart_cache_path)
+        self.cache_folder_path = Path(coverart_cache_path).expanduser()
 
-    def find_file_by_hash(self, hash_value):
-        for filename in os.listdir(self.cache_folder_path):
-            if filename.startswith(hash_value):
-                if filename.endswith(f'.{NO_COVER_ART_EXTENSION}'):
+    def find_file_by_hash(self, hash_value: str) -> str:
+        for path in self.cache_folder_path.iterdir():
+            if path.name.startswith(hash_value):
+                if path.suffix == f'.{NO_COVER_ART_EXTENSION}':
                     return NO_CONTENT
-                return filename
+                return path.name
         return NOT_CACHED
 
-    def save_to_cache(self, base_filename, album_art_data):
-        if album_art_data:
-            mime_type = album_art_data['type']
-            file_extension = 'jpg' if mime_type == 'image/jpeg' else mime_type.split('/')[-1]
-            data = album_art_data['binary']
-        else:
-            file_extension = NO_COVER_ART_EXTENSION
-            data = b''
-        cache_filename = f"{base_filename}.{file_extension}"
+    def save_to_cache(self, base_filename: str, album_art_data: dict) -> str:
+        file_extension = NO_COVER_ART_EXTENSION
+        data = b''
 
-        with open(os.path.join(self.cache_folder_path, cache_filename), 'wb') as file:
+        if album_art_data:
+            mime_type = album_art_data.get('type', 'image/jpeg')
+            file_extension = 'jpg' if mime_type == 'image/jpeg' else mime_type.split('/')[-1]
+            data = album_art_data.get('binary', b'')
+
+        cache_filename = f"{base_filename}.{file_extension}"
+        full_path = self.cache_folder_path / cache_filename
+
+        with full_path.open('wb') as file:
             file.write(data)
 
-        if data:
-            return cache_filename
-
-        return NO_CONTENT
+        return cache_filename if data else NO_CONTENT

--- a/src/jukebox/components/playermpd/coverart_cache_manager.py
+++ b/src/jukebox/components/playermpd/coverart_cache_manager.py
@@ -50,7 +50,7 @@ class CoverartCacheManager:
         file_extension, data = self._extract_album_art(mp3_file_path)
 
         cache_filename = f"{cache_key}.{file_extension}"
-        full_path = self.cache_folder_path / cache_filename # Works due to Pathlib
+        full_path = self.cache_folder_path / cache_filename  # Works due to Pathlib
 
         with full_path.open('wb') as file:
             file.write(data)

--- a/src/jukebox/components/playermpd/coverart_cache_manager.py
+++ b/src/jukebox/components/playermpd/coverart_cache_manager.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import hashlib
 import logging
 import jukebox.cfghandler
+from queue import Queue
+from threading import Thread
 
 NO_COVER_ART_EXTENSION = 'no-art'
 NO_CONTENT = ''
@@ -10,14 +12,17 @@ NOT_CACHED = None
 logger = logging.getLogger('jb.CoverartCacheManager')
 cfg = jukebox.cfghandler.get_handler('jukebox')
 
-
 class CoverartCacheManager:
     def __init__(self):
         coverart_cache_path = cfg.setndefault('webapp', 'coverart_cache_path', value='../../src/webapp/build/cover-cache')
         self.cache_folder_path = Path(coverart_cache_path).expanduser()
+        self.write_queue = Queue()
+        self.worker_thread = Thread(target=self.process_write_requests)
+        self.worker_thread.daemon = True  # Ensure thread closes with the program
+        self.worker_thread.start()
 
     def generate_cache_key(self, base_filename: str) -> str:
-        return f'cover-{hashlib.sha256(base_filename.encode()).hexdigest()}'
+        return f'test-{hashlib.sha256(base_filename.encode()).hexdigest()}'
 
     def find_file_by_hash(self, base_filename: str) -> str:
         cache_key = self.generate_cache_key(base_filename)
@@ -28,7 +33,10 @@ class CoverartCacheManager:
                 return path.name
         return NOT_CACHED
 
-    def save_to_cache(self, base_filename: str, album_art_data: dict) -> str:
+    def save_to_cache(self, base_filename: str, album_art_data: dict):
+        self.write_queue.put((base_filename, album_art_data))
+
+    def _save_to_cache(self, base_filename: str, album_art_data: dict) -> str:
         cache_key = self.generate_cache_key(base_filename)
         file_extension = NO_COVER_ART_EXTENSION
         data = b''
@@ -38,11 +46,20 @@ class CoverartCacheManager:
             file_extension = 'jpg' if mime_type == 'image/jpeg' else mime_type.split('/')[-1]
             data = album_art_data.get('binary', b'')
 
-        cache_filename = f"{cache_key}.{file_extension}"
-        logger.debug(f'Created file: {cache_filename}')
-        full_path = self.cache_folder_path / cache_filename
+        cache_filename = f'{cache_key}.{file_extension}'
+        full_path = self.cache_folder_path / cache_filename # Works due to pathlib
 
         with full_path.open('wb') as file:
             file.write(data)
+            logger.debug(f'Created file: {cache_filename}')
 
         return cache_filename if data else NO_CONTENT
+
+    def process_write_requests(self):
+        while True:
+            base_filename, album_art_data = self.write_queue.get()
+            try:
+                self._save_to_cache(base_filename, album_art_data)
+            except Exception as e:
+                logger.error(f'Error processing write request: {e}')
+            self.write_queue.task_done()

--- a/src/jukebox/components/playermpd/coverart_cache_manager.py
+++ b/src/jukebox/components/playermpd/coverart_cache_manager.py
@@ -1,10 +1,13 @@
 from pathlib import Path
+import hashlib
+import logging
 import jukebox.cfghandler
 
 NO_COVER_ART_EXTENSION = 'no-art'
 NO_CONTENT = ''
 NOT_CACHED = None
 
+logger = logging.getLogger('jb.CoverartCacheManager')
 cfg = jukebox.cfghandler.get_handler('jukebox')
 
 
@@ -13,15 +16,20 @@ class CoverartCacheManager:
         coverart_cache_path = cfg.setndefault('webapp', 'coverart_cache_path', value='../../src/webapp/build/cover-cache')
         self.cache_folder_path = Path(coverart_cache_path).expanduser()
 
-    def find_file_by_hash(self, hash_value: str) -> str:
+    def generate_cache_key(self, base_filename: str) -> str:
+        return f'cover-{hashlib.sha256(base_filename.encode()).hexdigest()}'
+
+    def find_file_by_hash(self, base_filename: str) -> str:
+        cache_key = self.generate_cache_key(base_filename)
         for path in self.cache_folder_path.iterdir():
-            if path.name.startswith(hash_value):
+            if path.stem == cache_key:
                 if path.suffix == f'.{NO_COVER_ART_EXTENSION}':
                     return NO_CONTENT
                 return path.name
         return NOT_CACHED
 
     def save_to_cache(self, base_filename: str, album_art_data: dict) -> str:
+        cache_key = self.generate_cache_key(base_filename)
         file_extension = NO_COVER_ART_EXTENSION
         data = b''
 
@@ -30,7 +38,8 @@ class CoverartCacheManager:
             file_extension = 'jpg' if mime_type == 'image/jpeg' else mime_type.split('/')[-1]
             data = album_art_data.get('binary', b'')
 
-        cache_filename = f"{base_filename}.{file_extension}"
+        cache_filename = f"{cache_key}.{file_extension}"
+        logger.debug(f'Created file: {cache_filename}')
         full_path = self.cache_folder_path / cache_filename
 
         with full_path.open('wb') as file:

--- a/src/jukebox/components/rpc_command_alias.py
+++ b/src/jukebox/components/rpc_command_alias.py
@@ -75,6 +75,10 @@ cmd_alias_definitions = {
         'method': 'repeat',
         'note': 'Repeat',
         'ignore_card_removal_action': True},
+    'flush_coverart_cache': {
+        'package': 'player',
+        'plugin': 'ctrl',
+        'method': 'flush_coverart_cache'},
 
     # VOLUME
     'set_volume': {

--- a/src/webapp/src/components/Library/lists/albums/album-list/album-list-item.js
+++ b/src/webapp/src/components/Library/lists/albums/album-list/album-list-item.js
@@ -29,7 +29,9 @@ const AlbumListItem = ({ albumartist, album, isButton = true }) => {
         album: album
       });
       if (result) {
-        setCoverImage(`/cover-cache/${result}`);
+        if(result !== 'CACHE_PENDING') {
+          setCoverImage(`/cover-cache/${result}`);
+        }
       };
     }
 


### PR DESCRIPTION
Previously, an ERROR was logged for each song without cover art when the Web UI was open.
This commit avoids the error, caches the no-cover-art result and saves a roundtrip to mpd for all no-cover-art songs.

Note: This will start creating an empty file for each song without cover art in order to speed up the listing. This might be surprising at first, but is in line with how the current caching mechanism works.