### PR TITLE
fix: play_card function with second_swipe support

### DIFF
--- a/documentation/builders/card-database.md
+++ b/documentation/builders/card-database.md
@@ -21,15 +21,17 @@ using the alias option:
 '0002':
     # A RPC command using the alias definition with one arguments
     # Here: Trigger music playback through the card interface
-    alias: play_card
-    args: [path/to/folder]
+    alias: play_folder
+    args:
+    - /path/to/folder
 '0003':
     # A RPC command using keyword arguments. Args and kwargs can also be mixed.
     # Args and Kwargs translate directly into the function python call
     # Some as in '0002' but using kwargs
-    alias: play_card
+    alias: play_album
     kwargs:
-        folder: path/to/folder
+        albumartist: Some Artist Name
+        recursive: A song Name
 ```
 
 > [!NOTE]

--- a/documentation/builders/rpc-commands.md
+++ b/documentation/builders/rpc-commands.md
@@ -37,21 +37,21 @@ The keyword ``method`` is optional. If needs to be used depends on the function 
 ## Aliases
 
 Not so complicated, right? It will get even easier. For common commands we have defined aliases. An alias simply maps
-to a pre-defined RPC command, e.g. ``play_card`` maps to ``player.ctrl.play_card``.
+to a pre-defined RPC command, e.g. ``play_folder`` maps to ``player.ctrl.play_folder``.
 
 Instead of
 
 ```yml
 package: player
 plugin: ctrl
-method: play_card
+method: play_folder
 args: [path/to/folder]
 ```
 
 you can simply specify instead:
 
 ```yml
-alias: play_card
+alias: play_folder
 args: [path/to/folder]
 ```
 
@@ -60,10 +60,10 @@ Using in alias is optional. But if the keyword is present in the configuration i
 ## Arguments
 
 Arguments can be specified in similar fashion to Python function arguments: as positional arguments and / or
-keyword arguments. Let's check out play_card, which is defined as:
+keyword arguments. Let's check out play_folder, which is defined as:
 
 ```python
-play_card(...) -> player.ctrl.play_card(folder: str, recursive: bool = False)
+play_folder(...) -> player.ctrl.play_folder(folder: str, recursive: bool = False)
     :noindex:
 
     :param folder: Folder path relative to music library path
@@ -79,19 +79,19 @@ In the following examples, we will always use the alias for smaller configuratio
 do exactly the same, but use different ways of specifying the command.
 
 ```yml
-alias: play_card
+alias: play_folder
 args: [path/to/folder, True]
 ```
 
 ```yml
-alias: play_card
+alias: play_folder
 args: [path/to/folder]
 kwargs:
     recursive: True
 ```
 
 ```yml
-alias: play_card
+alias: play_folder
 kwargs:
     folder: path/to/folder
     recursive: True

--- a/documentation/developers/docstring/README.md
+++ b/documentation/developers/docstring/README.md
@@ -850,11 +850,6 @@ Internal status
   - last played folder: Needed to detect second swipe
 
 
-Saving {'player_status': {'last_played_folder': 'TraumfaengerStarkeLieder', 'CURRENTSONGPOS': '0', 'CURRENTFILENAME': 'TraumfaengerStarkeLieder/01.mp3'},
-'audio_folder_status':
-{'TraumfaengerStarkeLieder': {'ELAPSED': '1.0', 'CURRENTFILENAME': 'TraumfaengerStarkeLieder/01.mp3', 'CURRENTSONGPOS': '0', 'PLAYSTATUS': 'stop', 'RESUME': 'OFF', 'SHUFFLE': 'OFF', 'LOOP': 'OFF', 'SINGLE': 'OFF'},
-'Giraffenaffen': {'ELAPSED': '1.0', 'CURRENTFILENAME': 'TraumfaengerStarkeLieder/01.mp3', 'CURRENTSONGPOS': '0', 'PLAYSTATUS': 'play', 'RESUME': 'OFF', 'SHUFFLE': 'OFF', 'LOOP': 'OFF', 'SINGLE': 'OFF'}}}
-
 References:
 https://github.com/Mic92/python-mpd2
 https://python-mpd2.readthedocs.io/en/latest/topics/commands.html

--- a/documentation/developers/docstring/README.md
+++ b/documentation/developers/docstring/README.md
@@ -40,14 +40,12 @@
     * [replay](#components.playermpd.PlayerMPD.replay)
     * [toggle](#components.playermpd.PlayerMPD.toggle)
     * [replay\_if\_stopped](#components.playermpd.PlayerMPD.replay_if_stopped)
-    * [play\_card](#components.playermpd.PlayerMPD.play_card)
     * [get\_single\_coverart](#components.playermpd.PlayerMPD.get_single_coverart)
     * [get\_folder\_content](#components.playermpd.PlayerMPD.get_folder_content)
     * [play\_folder](#components.playermpd.PlayerMPD.play_folder)
     * [play\_album](#components.playermpd.PlayerMPD.play_album)
     * [get\_volume](#components.playermpd.PlayerMPD.get_volume)
     * [set\_volume](#components.playermpd.PlayerMPD.set_volume)
-  * [play\_card\_callbacks](#components.playermpd.play_card_callbacks)
 * [components.playermpd.coverart\_cache\_manager](#components.playermpd.coverart_cache_manager)
 * [components.rpc\_command\_alias](#components.rpc_command_alias)
 * [components.synchronisation.rfidcards](#components.synchronisation.rfidcards)
@@ -975,25 +973,6 @@ Re-start playing the last-played folder unless playlist is still playing
 > but we keep it as it is specifically implemented in box 2.X
 
 
-<a id="components.playermpd.PlayerMPD.play_card"></a>
-
-#### play\_card
-
-```python
-@plugs.tag
-def play_card(folder: str, recursive: bool = False)
-```
-
-Main entry point for trigger music playing from RFID reader. Decodes second swipe options before playing folder content
-
-Checks for second (or multiple) trigger of the same folder and calls first swipe / second swipe action
-accordingly.
-
-**Arguments**:
-
-- `folder`: Folder path relative to music library path
-- `recursive`: Add folder recursively
-
 <a id="components.playermpd.PlayerMPD.get_single_coverart"></a>
 
 #### get\_single\_coverart
@@ -1088,22 +1067,6 @@ Set the volume
 For volume control do not use directly, but use through the plugin 'volume',
 as the user may have configured a volume control manager other than MPD
 
-
-<a id="components.playermpd.play_card_callbacks"></a>
-
-#### play\_card\_callbacks
-
-Callback handler instance for play_card events.
-
-- is executed when play_card function is called
-States:
-- See :class:`PlayCardState`
-See :class:`PlayContentCallbacks`
-
-
-<a id="components.playermpd.coverart_cache_manager"></a>
-
-# components.playermpd.coverart\_cache\_manager
 
 <a id="components.rpc_command_alias"></a>
 

--- a/resources/default-settings/cards.example.yaml
+++ b/resources/default-settings/cards.example.yaml
@@ -53,10 +53,10 @@
 'T':
       package: player
       plugin: ctrl
-      method: play_card
+      method: play_folder
       args: [path/to/music/folder]
 'G':
-      alias: play_card
+      alias: play_folder
       args: path/to/music/folder
 'V+':
       alias: change_volume

--- a/src/jukebox/components/playermpd/__init__.py
+++ b/src/jukebox/components/playermpd/__init__.py
@@ -169,8 +169,8 @@ class PlayerMPD:
             self.music_player_status.save_to_json()
             self.current_folder_status = {}
             # self.music_player_status['player_status']['last_played_folder'] = ''
-        else:
-            last_played_folder = self.music_player_status['player_status'].get('last_played_folder')
+        # else:
+            # last_played_folder = self.music_player_status['player_status'].get('last_played_folder')
             # if last_played_folder:
             #     # current_folder_status is a dict, but last_played_folder a str
             #     self.current_folder_status = self.music_player_status['audio_folder_status'][last_played_folder]
@@ -620,7 +620,6 @@ class PlayerMPD:
             song = self.mpd_retry_with_mutex(self.mpd_client.find, 'file', song_url)
 
         return song
-
 
     # ---------------
     # Volume

--- a/src/jukebox/components/playermpd/__init__.py
+++ b/src/jukebox/components/playermpd/__init__.py
@@ -512,16 +512,6 @@ class PlayerMPD:
 
             self.mpd_client.play()
 
-    @plugs.tag
-    def play_card(self, method: str, **kwargs):
-        allowed_methods = ['play_single', 'play_folder', 'play_album']
-
-        if method in allowed_methods:
-            method = getattr(self, method, None)
-            method(**kwargs)
-        else:
-            logger.debug(f"Method {method} is not allowed.")
-
     # ---------------
     # Cover Art
     # ---------------

--- a/src/jukebox/components/rpc_command_alias.py
+++ b/src/jukebox/components/rpc_command_alias.py
@@ -12,12 +12,6 @@ See [RPC Commands](../../builders/rpc-commands.md)
 # --------------------------------------------------------------
 cmd_alias_definitions = {
     # Player
-    'play_card': {
-        'title': 'Play music folder triggered by card swipe',
-        'note': "This function you'll want to use most often",
-        'package': 'player',
-        'plugin': 'ctrl',
-        'method': 'play_card'},
     'play_album': {
         'title': 'Play Album triggered by card swipe',
         'note': "This function plays the content of a given album",

--- a/src/jukebox/jukebox/utils.py
+++ b/src/jukebox/jukebox/utils.py
@@ -197,9 +197,9 @@ def generate_cmd_alias_rst(stream):
     print(".. |--| unicode:: U+2014", file=stream)
     print(".. |->| unicode:: U+21d2\n", file=stream)
 
-    # 'play_card':
-    #    Executes   : player.ctrl.play_card()
-    #    Signature  : player.ctrl.play_card(folder=None)
+    # 'play_folder':
+    #    Executes   : player.ctrl.play_folder()
+    #    Signature  : player.ctrl.play_folder(folder=None)
     #    Description: Main entry point for trigger music playing from RFID reader
     for cmd, action in cmd_alias_definitions.items():
         try:


### PR DESCRIPTION
Until now, 3 functions existed to be registered to a card: `play_single`, `play_album` and `play_folder`. None of these functions supported "Second Swipe". Instead, another function existed, called `play_card` which had Second Swipe support, but it ended up to call `play_folder`, ingoring the other 2 functions all together

This PR aims at solving this problem and to prepare for https://github.com/hoffie/RPi-Jukebox-RFID/commit/c4805cebb848e8aaafd69c43f497b09436e67169

* [x] Refactor `play_card` in `PlayerMPD`
* [ ] Adapting UI to assign only `play_card` command instead of `play_single`, `play_album` or `play_folder`
* [ ] Handle cards.yaml and rewrite commands to use `play_card`