### PR TITLE
maint: Update actions

### DIFF
--- a/.github/workflows/codeql-analysis_v3.yml
+++ b/.github/workflows/codeql-analysis_v3.yml
@@ -51,9 +51,9 @@ jobs:
 
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        # Set the `CODEQL-PYTHON` environment variable to the Python executable
+        # Set the `CODEQL_EXTRACTOR_PYTHON_ANALYSIS_VERSION` environment variable to the Python executable
         # that includes the dependencies
-        echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
+        echo "CODEQL_EXTRACTOR_PYTHON_ANALYSIS_VERSION=$(which python)" >> $GITHUB_ENV
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis_v3.yml
+++ b/.github/workflows/codeql-analysis_v3.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
           python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -22,9 +22,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/src/jukebox/misc/loggingext.py
+++ b/src/jukebox/misc/loggingext.py
@@ -24,6 +24,7 @@ Example: YAML snippet, setting WARNING as default level everywhere and DEBUG for
       jb.awesome_module:
         level: DEBUG
 
+
 > [!NOTE]
 > The name (and hierarchy path) of the logger can be arbitrary and must not necessarily match the module name (still makes
 > sense).

--- a/src/jukebox/misc/loggingext.py
+++ b/src/jukebox/misc/loggingext.py
@@ -24,7 +24,6 @@ Example: YAML snippet, setting WARNING as default level everywhere and DEBUG for
       jb.awesome_module:
         level: DEBUG
 
-
 > [!NOTE]
 > The name (and hierarchy path) of the logger can be arbitrary and must not necessarily match the module name (still makes
 > sense).


### PR DESCRIPTION
- Update actions/checkout to v4
- Update actions/setup-python to v5

fixes Node.js 16 deprecation warning:
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ `

Switch from `CODEQL_PYTHON` to `CODEQL_EXTRACTOR_PYTHON_ANALYSIS_VERSION`.