### PR TITLE
hotfix pyzmq installation on bullseye (pin version <26)

### DIFF
--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -120,6 +120,20 @@ _jukebox_core_check() {
     local pip_modules=$(get_args_from_file "${INSTALLATION_PATH}/requirements.txt")
     verify_pip_modules pyzmq $pip_modules
 
+    log "  Verify ZMQ version '${JUKEBOX_ZMQ_VERSION}'"
+    local zmq_version=$(python -c 'import zmq; print(f"{zmq.zmq_version()}")')
+    if [[ "${zmq_version}" != "${JUKEBOX_ZMQ_VERSION}" ]]; then
+        exit_on_error "ERROR: ZMQ version '${zmq_version}' differs from expected '${JUKEBOX_ZMQ_VERSION}'!"
+    fi
+    log "  CHECK"
+
+    log "  Verify ZMQ has 'DRAFT-API' activated"
+    local zmq_hasDraftApi=$(python -c 'import zmq; print(f"{zmq.DRAFT_API}")')
+    if [[ "${zmq_hasDraftApi}" != "True" ]]; then
+        exit_on_error "ERROR: ZMQ has 'DRAFT-API' '${zmq_hasDraftApi}' differs from expected 'True'!"
+    fi
+    log "  CHECK"
+
     verify_files_chmod_chown 644 "${CURRENT_USER}" "${CURRENT_USER_GROUP}" "${JUKEBOX_PULSE_CONFIG}"
 
     verify_files_chmod_chown 644 "${CURRENT_USER}" "${CURRENT_USER_GROUP}" "${SETTINGS_PATH}/jukebox.yaml"

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -86,7 +86,7 @@ _jukebox_core_build_and_install_pyzmq() {
     fi
 
     ZMQ_PREFIX="${JUKEBOX_ZMQ_PREFIX}" ZMQ_DRAFT_API=1 \
-      pip install -v --no-binary pyzmq pyzmq
+      pip install -v --no-binary pyzmq 'pyzmq<26'
   else
     print_lc "    Skipping. pyzmq already installed"
   fi

--- a/src/jukebox/jukebox/version.py
+++ b/src/jukebox/jukebox/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 3
 VERSION_MINOR = 5
-VERSION_PATCH = 2
+VERSION_PATCH = 3
 VERSION_EXTRA = ""
 
 # build a version string in compliance with the SemVer specification


### PR DESCRIPTION
As the newest release of pyzmq has some incompatibilities with bullseye, the version is pinned to below 26 as a hotfix.
Further checks are added to verify that the installed ZMQ version is as expected and that DRAFT_API Support is enabled.

fixes #2344