### PR TITLE
fix: docker build after pyzmq update

### DIFF
--- a/docker/Dockerfile.jukebox
+++ b/docker/Dockerfile.jukebox
@@ -44,7 +44,7 @@ RUN pip install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
 ENV ZMQ_PREFIX /opt/libzmq
 ENV ZMQ_DRAFT_API 1
 COPY --from=libzmq ${ZMQ_PREFIX} ${ZMQ_PREFIX}
-RUN pip install -v pyzmq --no-binary pyzmq
+RUN pip install -v "pyzmq<26" --no-binary pyzmq
 
 EXPOSE 5555 5556
 WORKDIR ${INSTALLATION_PATH}/src/jukebox

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ wheel
 
 # Jukebox Core
 # For USB inputs (reader, buttons) and bluetooth buttons
-cmake # To compile pyzmq>26 -> https://github.com/zeromq/pyzmq/issues/1976
 evdev
 mutagen
 pyalsaaudio

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ wheel
 
 # Jukebox Core
 # For USB inputs (reader, buttons) and bluetooth buttons
+cmake # To compile pyzmq>26 -> https://github.com/zeromq/pyzmq/issues/1976
 evdev
 mutagen
 pyalsaaudio


### PR DESCRIPTION
After `pyzmq` has released the latest version, Docker was not building properly anymore. Adding cmake as a Python dependency solves this problem