### PR TITLE
(maint) Remove setup-python-dependencies

### DIFF
--- a/.github/workflows/codeql-analysis_v3.yml
+++ b/.github/workflows/codeql-analysis_v3.yml
@@ -64,7 +64,6 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-        setup-python-dependencies: false
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
Fix warning `The setup-python-dependencies input is deprecated and no longer has any effect`.

This input is without effect, see also https://github.blog/changelog/2024-01-23-codeql-2-16-python-dependency-installation-disabled-new-queries-and-bug-fixes/