### PR TITLE
Fix button SecondFunc trigger

### DIFF
--- a/components/gpio_control/GPIODevices/simple_button.py
+++ b/components/gpio_control/GPIODevices/simple_button.py
@@ -138,13 +138,11 @@ class SimpleButton:
 
     def longPressHandler(self, *args):
         logger.info('{}: longPressHandler, mode: {}'.format(self.name, self.hold_mode))
-        # instant action (except Postpone mode)
-        if self.hold_mode != "Postpone":
-            self.when_pressed(*args)
 
         # action(s) after hold_time
         if self.hold_mode == "Repeat":
-            # Repeated call of main action (multiple times if button is held long enough)
+            # Repeated call of main action (instantly and multiple times if button is held long enough)
+            self.when_pressed(*args)
             while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_pressed(*args)
 
@@ -157,13 +155,21 @@ class SimpleButton:
 
         elif self.hold_mode == "SecondFunc":
             # Call of secondary action (once)
+            # execute main action if not held past hold_time
             if checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_held(*args)
+            else:
+                self.when_pressed(*args)
             while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 pass
 
         elif self.hold_mode == "SecondFuncRepeat":
             # Repeated call of secondary action (multiple times if button is held long enough)
+            # execute main action if not held past hold_time
+            if checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
+                self.when_held(*args)
+            else:
+                self.when_pressed(*args)
             while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_held(*args)
 

--- a/components/gpio_control/GPIODevices/simple_button.py
+++ b/components/gpio_control/GPIODevices/simple_button.py
@@ -106,11 +106,7 @@ class SimpleButton:
             if inval != GPIO.LOW:
                 return None
 
-        if self.hold_mode in ('Repeat', 'Postpone', 'SecondFunc', 'SecondFuncRepeat'):
-            return self.longPressHandler(*args)
-        else:
-            logger.info('{}: execute callback'.format(self.name))
-            return self.when_pressed(*args)
+        return self._handleCallbackFunction(*args)
 
     @property
     def when_pressed(self):
@@ -136,10 +132,9 @@ class SimpleButton:
     def set_callbackFunction(self, callbackFunction):
         self.when_pressed = callbackFunction
 
-    def longPressHandler(self, *args):
-        logger.info('{}: longPressHandler, mode: {}'.format(self.name, self.hold_mode))
+    def _handleCallbackFunction(self, *args):
+        logger.info('{}: handleCallbackFunction, mode: {}'.format(self.name, self.hold_mode))
 
-        # action(s) after hold_time
         if self.hold_mode == "Repeat":
             # Repeated call of main action (instantly and multiple times if button is held long enough)
             self.when_pressed(*args)
@@ -172,6 +167,9 @@ class SimpleButton:
                 self.when_pressed(*args)
             while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_held(*args)
+
+        else:
+            self.when_pressed(*args)
 
     def __del__(self):
         logger.debug('remove event detection')

--- a/components/gpio_control/GPIODevices/simple_button.py
+++ b/components/gpio_control/GPIODevices/simple_button.py
@@ -145,28 +145,28 @@ class SimpleButton:
             # Postponed call of main action (once)
             if checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_pressed(*args)
-            while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
-                pass
+                while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
+                    pass
 
         elif self.hold_mode == "SecondFunc":
             # Call of secondary action (once)
             # execute main action if not held past hold_time
             if checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_held(*args)
+                while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
+                    pass
             else:
                 self.when_pressed(*args)
-            while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
-                pass
 
         elif self.hold_mode == "SecondFuncRepeat":
             # Repeated call of secondary action (multiple times if button is held long enough)
             # execute main action if not held past hold_time
             if checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_held(*args)
+                while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
+                    self.when_held(*args)
             else:
                 self.when_pressed(*args)
-            while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
-                self.when_held(*args)
 
         else:
             self.when_pressed(*args)

--- a/components/gpio_control/GPIODevices/simple_button.py
+++ b/components/gpio_control/GPIODevices/simple_button.py
@@ -136,13 +136,14 @@ class SimpleButton:
         logger.info('{}: handleCallbackFunction, mode: {}'.format(self.name, self.hold_mode))
 
         if self.hold_mode == "Repeat":
-            # Repeated call of main action (instantly and multiple times if button is held long enough)
+            # Instantly call primary action
             self.when_pressed(*args)
+            # Repeated call of primary action if button is held long enough
             while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_pressed(*args)
 
         elif self.hold_mode == "Postpone":
-            # Postponed call of main action (once)
+            # Postponed call of primary action (once)
             if checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_pressed(*args)
                 while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
@@ -150,7 +151,7 @@ class SimpleButton:
 
         elif self.hold_mode == "SecondFunc":
             # Call of secondary action (once)
-            # execute main action if not held past hold_time
+            # execute primary action if not held past hold_time
             if checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_held(*args)
                 while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
@@ -160,7 +161,7 @@ class SimpleButton:
 
         elif self.hold_mode == "SecondFuncRepeat":
             # Repeated call of secondary action (multiple times if button is held long enough)
-            # execute main action if not held past hold_time
+            # execute primary action if not held past hold_time
             if checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):
                 self.when_held(*args)
                 while checkGpioStaysInState(self.hold_time, self.pin, GPIO.LOW):

--- a/components/gpio_control/README.md
+++ b/components/gpio_control/README.md
@@ -61,12 +61,11 @@ However, a button has more parameters than these. In the following comprehensive
 * **functionCallArgs**: Arguments for primary function, defaults to `None`. Arguments are ignored, if `functionCall` does not take any.
 * **hold_mode**: Specifies what shall happen if the button is held pressed for longer than `hold_time`:
   * `None` (Default): Nothing special will happen.
-  * `Repeat`: The configured `functionCall` is repeated after each `hold_time` interval.
+  * `Repeat`: The configured `functionCall` is instantly called and repeatedly after each `hold_time` interval.
   * `Postpone`: The function will not be called before `hold_time`, i.e. the button needs to be pressed this long to activate the function
-  * `SecondFunc`: Holding the button for at least `hold_time` will additionally execute the function `functionCall2` with `functionCall2Args`.
+  * `SecondFunc`: Pressing the button (shorter than `hold_time`) will execute the function `functionCall` with `functionCallArgs`. Holding the button for at least `hold_time` will execute the function `functionCall2` with `functionCall2Args`.
   * `SecondFuncRepeat`: Like SecondFunc, but `functionCall2` is repeated after each `hold_time` interval.
   
-  In every `hold_mode` except `Postpone`, the main action `functionCall` gets executed instantly.
   
   Holding the button even longer than `hold_time` will cause no further action unless you are in the `Repeat` or `SecondFuncRepeat` mode.
   

--- a/components/gpio_control/README.md
+++ b/components/gpio_control/README.md
@@ -82,10 +82,10 @@ However, a button has more parameters than these. In the following comprehensive
   * `pull_off`. Use this to deactivate internal pull-up/pulldown resistors. This is useful if your wiring includes your own (external) pull up / down resistors.
 * **edge**: Configures the events in which the GPIO library shall trigger the callback function. Valid settings:
   * `falling` (Default). Triggers if the GPIO voltage goes down.
-  * `rising`. Trigegrs only if the GPIO voltage goes up.
+  * `rising`. Triggers only if the GPIO voltage goes up.
   * `both`. Triggers in both cases.
 * **bouncetime**: This is a setting of the GPIO library to limit bouncing effects during button usage. Default is `500` ms.
-* **antibouncehack**: Despite the integrated bounce reduction of the GPIO library some users may notice false triggers of their buttons (e.g. unrequested / double actions when releasing the button). If you encounter such problems, try setting this setting to `True` to activate an additional countermeasure.
+* **antibouncehack**: Despite the integrated bounce reduction of the GPIO library some users may notice false triggers of their buttons (e.g. unrequested / double actions when releasing the button). If you encounter such problems, try setting this to `True` to activate an additional countermeasure.
 
 Note: If you prefer, you may also use `Type: SimpleButton` instead of `Type: Button` - this makes no difference.
 

--- a/components/gpio_control/README.md
+++ b/components/gpio_control/README.md
@@ -59,13 +59,17 @@ functionCall: functionCallPlayerPause
 However, a button has more parameters than these. In the following comprehensive list you can also find the default values which are used automatically if you leave out these settings:
 
 * **functionCallArgs**: Arguments for primary function, defaults to `None`. Arguments are ignored, if `functionCall` does not take any.
+
+> [!IMPORTANT]
+> Since v2.8.0 the behavior of `hold_mode` `SecondFunc` and `SecondFuncRepeat` has changed. The secondary function is no longer triggered additionally to the primary function.
+> Now its called exclusively if `hold_time` is reached. The primary function will only be triggered if the button is pressed shorter then `hold_time`! 
+> Existing configurations may need to adapt to this.
 * **hold_mode**: Specifies what shall happen if the button is held pressed for longer than `hold_time`:
   * `None` (Default): Nothing special will happen.
   * `Repeat`: The configured `functionCall` is instantly called and repeatedly after each `hold_time` interval.
   * `Postpone`: The function will not be called before `hold_time`, i.e. the button needs to be pressed this long to activate the function
   * `SecondFunc`: Pressing the button (shorter than `hold_time`) will execute the function `functionCall` with `functionCallArgs`. Holding the button for at least `hold_time` will execute the function `functionCall2` with `functionCall2Args`.
   * `SecondFuncRepeat`: Like SecondFunc, but `functionCall2` is repeated after each `hold_time` interval.
-  
   
   Holding the button even longer than `hold_time` will cause no further action unless you are in the `Repeat` or `SecondFuncRepeat` mode.
   

--- a/components/gpio_control/test/test_SimpleButton.py
+++ b/components/gpio_control/test/test_SimpleButton.py
@@ -150,7 +150,7 @@ class TestButton:
         simple_button.hold_mode = 'SecondFunc'
         calls = mockedSecAction.call_count
         simple_button.callbackFunctionHandler(simple_button.pin)
-        mockedAction.assert_called_once()
+        mockedAction.assert_not_called()
         assert mockedSecAction.call_count - calls == 1
 
     def test_hold_SecondFunc_shorter_holdtime(self, simple_button):
@@ -170,7 +170,7 @@ class TestButton:
         simple_button.hold_mode = 'SecondFuncRepeat'
         calls = mockedSecAction.call_count
         simple_button.callbackFunctionHandler(simple_button.pin)
-        mockedAction.assert_called_once()
+        mockedAction.assert_not_called()
         assert mockedSecAction.call_count - calls == 3
 
     def test_hold_SecondFuncRepeat_shorter_holdtime(self, simple_button):


### PR DESCRIPTION
I had this change laying around for some time, but with the gathered reports in https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/1666 it may be worth to bring it in.

---

Introduce changes to the button function calling behavior, to not trigger both function if the button is held. Though this behavior is documented, it is still counter intuitive and likely the uncommon case.

For the "SecondFunc" `hold_mode` the new behavior is:
- `SecondFunc`
  - only main function is executed if button is NOT held past `hold_time`
  - only secondary function is executed if button is held past `hold_time`
- `SecondFuncRepeat`
  - only main function is executed if button is NOT held past `hold_time`
  - only secondary function is executed if button is held past `hold_time` and repeatedly if button is futher held past `hold_time`


Other `hold_mode`s have not been affected and behave the same:
- `None` (no changes)
  - main function is executed instantly
- `Repeat` (no changes)
  - main function is executed instantly and repeatedly if button is held past `hold_time`
- `Postpone` (no changes)
  - main function is executed if button is held past `hold_time`

closes https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/1666