### PR TITLE
Future3/lift 64bit restriction

### DIFF
--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -76,7 +76,7 @@ get_architecture() {
 }
 
 is_raspbian() {
-    if [[ $( . /etc/os-release; printf '%s\n' "$ID"; ) == *"raspbian"* ]]; then
+    if [[ $( . /etc/os-release; printf '%s\n' "$ID"; ) == *"raspbian"* ]] || [[ -f /etc/apt/sources.list.d/raspi.list ]]; then
         echo true
     else
         echo false

--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -75,23 +75,11 @@ get_architecture() {
     echo $arch
 }
 
-is_raspbian() {
-    if [[ $( . /etc/os-release; printf '%s\n' "$ID"; ) == *"raspbian"* ]] || [[ -f /etc/apt/sources.list.d/raspi.list ]]; then
-        echo true
-    else
-        echo false
-    fi
-}
-
-get_debian_version_number() {
-    source /etc/os-release
-    echo "$VERSION_ID"
-}
-
 _get_boot_file_path() {
     local filename="$1"
-    if [ "$(is_raspbian)" = true ]; then
-        local debian_version_number=$(get_debian_version_number)
+    local os_release_id=$( . /etc/os-release; printf '%s\n' "$ID"; )
+    if [[ "$os_release_id" == *"raspbian"* ]] || [[ "$os_release_id" == *"debian"* ]]; then
+        local debian_version_number=$( . /etc/os-release; printf '%s\n' "$VERSION_ID"; )
 
         # Bullseye and lower
         if [ "$debian_version_number" -le 11 ]; then

--- a/installation/install-jukebox.sh
+++ b/installation/install-jukebox.sh
@@ -86,23 +86,6 @@ Check install log for details:"
   exit 1
 }
 
-# Check if current distro is a 32-bit version
-# Support for 64-bit Distros has not been checked (or precisely: is known not to work)
-# All Raspberry Pi OS versions report as machine "armv6l" or "armv7l", if 32-bit (even the ARMv8 cores!)
-_check_os_type() {
-  local os_type=$(uname -m)
-
-  print_lc "\nChecking OS type '$os_type'"
-
-  if [[ $os_type == "armv7l" || $os_type == "armv6l" ]]; then
-    print_lc "  ... OK!\n"
-  else
-    print_lc "ERROR: Only 32-bit operating systems are supported. Please use a 32-bit version of Raspberry Pi OS!"
-    print_lc "For Pi 4 models or newer running a 64-bit kernels, also see this: https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2041"
-    exit 1
-  fi
-}
-
 _check_existing_installation() {
     if [[ -e "${INSTALLATION_PATH}" ]]; then
         print_lc "
@@ -154,7 +137,6 @@ _load_sources() {
 _setup_logging
 
 ### CHECK PREREQUISITE
-_check_os_type
 _check_existing_installation
 
 ### RUN INSTALLATION


### PR DESCRIPTION
Closes #2402 

This PR removes the check for 64bit OS in the installer script.

This PR extends the check for raspian OS to an alternate condition, which is the presence of `/etc/apt/sources.list.d/raspi.list` as some installations of raspian displaying `debian` instead of `raspian` in `/etc/os-release`.

Related:
#2402 
#2041 
#2313 