### PR TITLE
Fix Spotify authentication 

### DIFF
--- a/requirements-spotify.txt
+++ b/requirements-spotify.txt
@@ -3,4 +3,4 @@
 Mopidy-Local
 Mopidy-MPD
 Mopidy-Iris==3.69.3
-Mopidy-Spotify==5.0.0a2
+Mopidy-Spotify==5.0.0a3

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -963,8 +963,8 @@ install_main() {
 
         # not yet available on apt.mopidy.com, so install manually
         local arch=$(dpkg --print-architecture)
-        local gst_plugin_spotify_name="gst-plugin-spotify_0.12.2-1_${arch}.deb"
-        wget -q https://github.com/kingosticks/gst-plugins-rs-build/releases/download/gst-plugin-spotify_0.12.2-1/${gst_plugin_spotify_name}
+        local gst_plugin_spotify_name="gst-plugin-spotify_0.14.0.alpha.1-1_${arch}.deb"
+        wget -q https://github.com/kingosticks/gst-plugins-rs-build/releases/download/gst-plugin-spotify_0.14.0-alpha.1-1/${gst_plugin_spotify_name}
         ${apt_get} install ./${gst_plugin_spotify_name}
         sudo rm -f ${gst_plugin_spotify_name}
 


### PR DESCRIPTION
This should fix #2429.

- [x] gst plug-in needs to be updated in install-jukebox.sh (gst-plugin-spotify_0.14.0.alpha.1-1_armhf.deb), see also https://github.com/mopidy/mopidy-spotify/discussions/405#discussioncomment-10881114

Everyone experiencing this issue is invited to test this fix.