### PR TITLE
[maint] Ignore LICENSE file in markdown linter

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -32,6 +32,7 @@ globs:
 ignores:
   - "documentation/developers/docstring/*"
   - "src/**"
+  - "LICENSE"
 
 # Use a plugin to recognize math
 #markdownItPlugins:


### PR DESCRIPTION
Don't lint the LICENSE file