### PR TITLE
fix: correct function name reference in is_debian_version_at_least()

### DIFF
--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -95,7 +95,7 @@ _get_debian_version_number() {
 
 is_debian_version_at_least() {
     local expected_version=$1
-    local debian_version_number=$(get_debian_version_number)
+    local debian_version_number=$(_get_debian_version_number)
 
     if [ "$debian_version_number" -ge "$expected_version" ]; then
         echo true


### PR DESCRIPTION
Fixed typo where _get_debian_version_number was called without leading underscore, 
causing "command not found" error in boot file path detection.