### PR TITLE
Fix Typo for is_debian_version_at_least_12

### DIFF
--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -106,7 +106,7 @@ is_debian_version_at_least() {
 
 _get_boot_file_path() {
     local filename="$1"
-    local is_debian_version_number_at_least_12=$(is_debian_version_at_least 12)
+    local is_debian_version_number_at_least_12=$(is_debian_version_at_least_12)
     if [ "$(is_debian_version_number_at_least_12)" = true ]; then
         echo "/boot/firmware/${filename}"
     else


### PR DESCRIPTION
blank in `is_debian_version_at_least 12` leads to optimisation being propagated in wrong config.txt