### PR TITLE
Remove Spotify username and password

### DIFF
--- a/misc/sampleconfigs/mopidy.conf.sample
+++ b/misc/sampleconfigs/mopidy.conf.sample
@@ -32,8 +32,6 @@ locale = de_DE
 
 [spotify]
 enabled = true
-username = %spotify_username%
-password = %spotify_password%
 client_id = %spotify_client_id%
 client_secret = %spotify_client_secret%
 #bitrate = 160

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -618,8 +618,6 @@ config_spotify() {
 # Please note your client_id and client_secret!
 #
 "
-            read -rp "Type your Spotify username: " SPOTIuser
-            read -rp "Type your Spotify password: " SPOTIpass
             read -rp "Type your client_id: " SPOTIclientid
             read -rp "Type your client_secret: " SPOTIclientsecret
             ;;
@@ -631,8 +629,6 @@ config_spotify() {
     # append variables to config file
     {
         echo "SPOTinstall=\"$(_escape_for_shell "$SPOTinstall")\"";
-        echo "SPOTIuser=\"$(_escape_for_shell "$SPOTIuser")\"";
-        echo "SPOTIpass=\"$(_escape_for_shell "$SPOTIpass")\"";
         echo "SPOTIclientid=\"$(_escape_for_shell "$SPOTIclientid")\"";
         echo "SPOTIclientsecret=\"$(_escape_for_shell "$SPOTIclientsecret")\""
     } >> "${HOME_DIR}/PhonieboxInstall.conf"
@@ -756,8 +752,6 @@ check_config_file() {
         echo "ERROR: \$SPOTinstall is missing or not set!" && fail=true
     else
         if [ "$SPOTinstall" == "YES" ]; then
-            check_variable "SPOTIuser"
-            check_variable "SPOTIpass"
             check_variable "SPOTIclientid"
             check_variable "SPOTIclientsecret"
         fi
@@ -1096,8 +1090,6 @@ install_main() {
         sudo locale-gen
         sudo cp "${jukebox_dir}"/misc/sampleconfigs/mopidy.conf.sample "${mopidy_conf}"
         # Change vars to match install config
-        sudo sed -i 's|%spotify_username%|'"$(escape_for_sed "$SPOTIuser")"'|' "${mopidy_conf}"
-        sudo sed -i 's|%spotify_password%|'"$(escape_for_sed "$SPOTIpass")"'|' "${mopidy_conf}"
         sudo sed -i 's|%spotify_client_id%|'"$(escape_for_sed "$SPOTIclientid")"'|' "${mopidy_conf}"
         sudo sed -i 's|%spotify_client_secret%|'"$(escape_for_sed "$SPOTIclientsecret")"'|' "${mopidy_conf}"
         # for $DIRaudioFolders using | as alternate regex delimiter because of the folder path slash

--- a/scripts/installscripts/tests/run_installation_spotify.sh
+++ b/scripts/installscripts/tests/run_installation_spotify.sh
@@ -34,8 +34,6 @@ y
 
 y
 a!b"c§d$e%f&g/h(i)j=k?l´m`n²o³p{q[r]s}t\u+v*w~x#y'\''zß,ä;ö.ü:Ä-Ö_Ü 1@2€3^4°5|67890
-a!b"c§d$e%f&g/h(i)j=k?l´m`n²o³p{q[r]s}t\u+v*w~x#y'\''zß,ä;ö.ü:Ä-Ö_Ü 1@2€3^4°5|67890
-myclient_id
 myclient+SECRET/0123456789=
 
 y

--- a/scripts/installscripts/tests/test_installation.sh
+++ b/scripts/installscripts/tests/test_installation.sh
@@ -170,8 +170,6 @@ verify_conf_file() {
     else
         echo "\$SPOTinstall is set to '$SPOTinstall'"
         if [ "$SPOTinstall" == "YES" ]; then
-            check_variable "SPOTIuser"
-            check_variable "SPOTIpass"
             check_variable "SPOTIclientid"
             check_variable "SPOTIclientsecret"
         fi
@@ -459,8 +457,6 @@ verify_spotify_config() {
 
         printf "\nTESTING spotify config...\n\n"
 
-        check_file_contains_string "username = ${SPOTIuser}" "${mopidy_conf}"
-        check_file_contains_string "password = ${SPOTIpass}" "${mopidy_conf}"
         check_file_contains_string "client_id = ${SPOTIclientid}" "${mopidy_conf}"
         check_file_contains_string "client_secret = ${SPOTIclientsecret}" "${mopidy_conf}"
         check_file_contains_string "media_dir = ${DIRaudioFolders}" "${mopidy_conf}"


### PR DESCRIPTION
Spotify authentication uses only client ID and secret, so no need for username and password. See also https://github.com/MiczFlor/RPi-Jukebox-RFID/wiki/Spotify-FAQ