### PR TITLE
Replace RPi.GPIO with rpi-lgpio for V2 legacy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,8 @@ If the code change results in a test failure, we will make our best effort to co
 
 * All code has to run under the stable and legacy version of Raspberry Pi OS (please check if currently even an older version is still supported).
 * For GPIO all code should work with **RPi.GPIO**. gpiozero is currently not intended to use.
+    > [!IMPORTANT]
+    > The original `RPi.GPIO` packages is currently not compatible with the 6.6 kernel (since bookworm). Therefore the lib `rpi-lgpio` is used as a replacement, which is api compliant. `RPi.GPIO` must not be installed directly or as a dependency as this breaks GPIO functionality (see `requirements-excluded`)!
 
 ### Additional Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ If the code change results in a test failure, we will make our best effort to co
 * All code has to run under the stable and legacy version of Raspberry Pi OS (please check if currently even an older version is still supported).
 * For GPIO all code should work with **RPi.GPIO**. gpiozero is currently not intended to use.
     > [!IMPORTANT]
-    > The original `RPi.GPIO` packages is currently not compatible with the 6.6 kernel (since bookworm). Therefore the lib `rpi-lgpio` is used as a replacement, which is api compliant. `RPi.GPIO` must not be installed directly or as a dependency as this breaks GPIO functionality (see `requirements-excluded`)!
+    > The original `RPi.GPIO` package is currently not compatible with the 6.6 kernel (since bookworm). Therefore the lib `rpi-lgpio` is used as a replacement, which is api compliant. `RPi.GPIO` **must not** be installed directly or as a dependency as this breaks GPIO functionality (see `requirements-excluded`)!
 
 ### Additional Resources
 

--- a/components/gpio_control/README.md
+++ b/components/gpio_control/README.md
@@ -1,5 +1,10 @@
 # GPIO CONTROL
 
+> [!IMPORTANT]
+> Since v2.9.0 the original `RPi.GPIO` library was replaced with `rpi-lgpio` to support the GPIO access in newer OS versions (>= kernel 6.6).
+> This new library is api compliant to the old one, but behaves differently in some aspects (see [rpi-lgpio differences](https://rpi-lgpio.readthedocs.io/en/latest/differences.html)).
+> Especially the `Debounce` difference changes the behavior of the `bouncetime` property! The actions are not triggered immediately anymore, but after the signal has been stable for the specified time, causing a delay. This also has impact to the usage of `hold_time` and `antibouncehack`!
+
 This service enables the control of different GPIO input & output devices for controlling the Phoniebox.
 It uses to a configuration file to configure the active devices.
 
@@ -74,7 +79,7 @@ However, a button has more parameters than these. In the following comprehensive
   
   Holding the button even longer than `hold_time` will cause no further action unless you are in the `Repeat` or `SecondFuncRepeat` mode.
   
-* **hold_time**: Reference time for this buttons `hold_mode` feature in seconds. Default is `0.3`. This setting is ignored if `hold_mode` is unset or `None`
+* **hold_time**: Reference time for this buttons `hold_mode` feature in seconds. Default is `0.3`. This setting is ignored if `hold_mode` is unset or `None`. Attention: `hold_time` is running **after** the action was triggered, so the total time will add up with `bouncetime`.
 * **functionCall2**: Secondary function, default is `None`. This setting is ignored unless `hold_mode` is set to `SecondFunc` or `SecondFuncRepeat`.
 * **functionCall2Args**: Arguments for secondary function, default is `None`. Arguments are ignored, if `functionCall2` does not take any.
 * **pull_up_down**: Configures the internal Pull up/down resistors. Valid settings:
@@ -85,7 +90,7 @@ However, a button has more parameters than these. In the following comprehensive
   * `falling` (Default). Triggers if the GPIO voltage goes down.
   * `rising`. Triggers only if the GPIO voltage goes up.
   * `both`. Triggers in both cases.
-* **bouncetime**: This is a setting of the GPIO library to limit bouncing effects during button usage. Default is `500` ms.
+* **bouncetime**: This is a setting of the GPIO library to limit bouncing effects during button usage. The action is only triggered after the signal has been stable for the defined time. Default is `500` ms.
 * **antibouncehack**: Despite the integrated bounce reduction of the GPIO library some users may notice false triggers of their buttons (e.g. unrequested / double actions when releasing the button). If you encounter such problems, try setting this to `True` to activate an additional countermeasure.
 
 > [!NOTE]

--- a/components/rfid-reader/RC522/requirements.txt
+++ b/components/rfid-reader/RC522/requirements.txt
@@ -1,4 +1,8 @@
 # RC522 related requirements
-# You need to install these with `sudo python3 -m pip install --upgrade --force-reinstall -q -r requirements.txt`
+# You need to install these with `sudo python3 -m pip install --upgrade --force-reinstall --no-deps -q -r requirements.txt`
 
+#pi-rc522 has RPi.GPIO as a dependecy which is broken since kernel 6.6.
+#Skip dependencies whith --no-deps and use the rpi-lgpio lib as a replacement, which should already be installed from the main installation.
+
+spidev # dep of pi-rc522
 pi-rc522==2.3.0

--- a/components/rfid-reader/RC522/requirements.txt
+++ b/components/rfid-reader/RC522/requirements.txt
@@ -1,7 +1,7 @@
 # RC522 related requirements
 # You need to install these with `sudo python3 -m pip install --upgrade --force-reinstall --no-deps -q -r requirements.txt`
 
-#pi-rc522 has RPi.GPIO as a dependecy which is broken since kernel 6.6.
+#pi-rc522 has RPi.GPIO as a dependency which is broken since kernel 6.6.
 #Skip dependencies whith --no-deps and use the rpi-lgpio lib as a replacement, which should already be installed from the main installation.
 
 spidev # dep of pi-rc522

--- a/components/rfid-reader/RC522/setup_rc522.sh
+++ b/components/rfid-reader/RC522/setup_rc522.sh
@@ -23,7 +23,7 @@ case "$choice" in
 esac
 
 printf "Installing Python requirements for RC522...\n"
-sudo python3 -m pip install --upgrade --force-reinstall -q -r "${JUKEBOX_HOME_DIR}"/components/rfid-reader/RC522/requirements.txt
+sudo python3 -m pip install --upgrade --force-reinstall --no-deps -q -r "${JUKEBOX_HOME_DIR}"/components/rfid-reader/RC522/requirements.txt
 
 printf "Activating SPI...\n"
 sudo raspi-config nonint do_spi 0

--- a/packages-excluded.txt
+++ b/packages-excluded.txt
@@ -1,0 +1,5 @@
+# Remove exluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
+# Define packages for apt-get. These must be removed with
+# 'sed 's/#.*//g' packages.txt | xargs sudo apt-get remove'
+
+python3-rpi.gpio

--- a/packages-excluded.txt
+++ b/packages-excluded.txt
@@ -1,4 +1,4 @@
-# Remove exluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
+# Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
 # Define packages for apt-get. These must be removed with
 # 'sed 's/#.*//g' packages.txt | xargs sudo apt-get remove'
 

--- a/packages.txt
+++ b/packages.txt
@@ -26,6 +26,5 @@ python3-pip
 python3-setuptools
 python3-wheel
 python3-mutagen
-python3-gpiozero
 python3-spidev
 wget

--- a/packages.txt
+++ b/packages.txt
@@ -28,3 +28,4 @@ python3-wheel
 python3-mutagen
 python3-gpiozero
 python3-spidev
+wget

--- a/requirements-excluded.txt
+++ b/requirements-excluded.txt
@@ -1,4 +1,4 @@
-# Remove exluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
+# Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
 # Libraries which must be excluded. These must be removed with
 # `sudo python3 -m pip uninstall -y -r requirements-excluded.txt` before you can run this.
 

--- a/requirements-excluded.txt
+++ b/requirements-excluded.txt
@@ -1,0 +1,5 @@
+# Remove exluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
+# Libraries which must be excluded. These must be removed with
+# `sudo python3 -m pip uninstall -y -r requirements-excluded.txt` before you can run this.
+
+RPi.GPIO

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@ evdev
 git+https://github.com/lthiery/SPI-Py.git#egg=spi-py
 yt-dlp
 pyserial
-RPi.GPIO
+# use shim to keep current RPi.GPIO behavior also under Bookworm - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
+rpi-lgpio
 
 # Type checking for python
 # typing

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -919,7 +919,7 @@ install_main() {
     source "${jukebox_dir}"/scripts/helperscripts/inc.helper.sh
     source "${jukebox_dir}"/scripts/helperscripts/inc.networkHelper.sh
 
-    # Remove exluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
+    # Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
     call_with_args_from_file "${jukebox_dir}"/packages-excluded.txt ${apt_get} ${allow_downgrades} remove
 
     # some packages are only available on raspberry pi's but not on test docker containers running on x86_64 machines
@@ -954,7 +954,7 @@ install_main() {
     echo "${VERSION_NO} - ${COMMIT_NO} - ${USED_BRANCH}" > ${jukebox_dir}/settings/version
     chmod 777 ${jukebox_dir}/settings/version
 
-    # Remove exluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
+    # Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
     ${pip_uninstall} -r "${jukebox_dir}"/requirements-excluded.txt
 
     # Install required spotify packages

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -948,6 +948,9 @@ install_main() {
     echo "${VERSION_NO} - ${COMMIT_NO} - ${USED_BRANCH}" > ${jukebox_dir}/settings/version
     chmod 777 ${jukebox_dir}/settings/version
 
+    # Remove RPi.GPIO, if still installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
+    sudo python3 -m pip uninstall rpi-gpio
+
     # Install required spotify packages
     if [ "${SPOTinstall}" == "YES" ]; then
         echo "Installing dependencies for Spotify support..."

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -949,7 +949,7 @@ install_main() {
     chmod 777 ${jukebox_dir}/settings/version
 
     # Remove RPi.GPIO, if still installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
-    sudo python3 -m pip uninstall rpi-gpio
+    sudo python3 -m pip uninstall -y -q rpi-gpio
 
     # Install required spotify packages
     if [ "${SPOTinstall}" == "YES" ]; then

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -35,6 +35,9 @@ JUKEBOX_BACKUP_DIR="${HOME_DIR}/BACKUP"
 
 # Get the Raspberry Pi OS codename (e.g. buster, bullseye, ...)
 OS_CODENAME="$( . /etc/os-release; printf '%s\n' "$VERSION_CODENAME"; )"
+# Get the Raspberry Pi OS version id (e.g. 11, 12, ...)
+OS_VERSION_ID="$( . /etc/os-release; printf '%s\n' "$VERSION_ID"; )"
+
 
 WIFI_INTERFACE="wlan0"
 
@@ -837,6 +840,7 @@ install_main() {
     local apt_get="sudo apt-get -qq --yes"
     local allow_downgrades="--allow-downgrades --allow-remove-essential --allow-change-held-packages"
     local pip_install="sudo python3 -m pip install --upgrade --force-reinstall -q"
+    local pip_uninstall="sudo python3 -m pip uninstall -y -q"
 
     clear
 
@@ -915,6 +919,8 @@ install_main() {
     source "${jukebox_dir}"/scripts/helperscripts/inc.helper.sh
     source "${jukebox_dir}"/scripts/helperscripts/inc.networkHelper.sh
 
+    # Remove exluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
+    call_with_args_from_file "${jukebox_dir}"/packages-excluded.txt ${apt_get} ${allow_downgrades} remove
 
     # some packages are only available on raspberry pi's but not on test docker containers running on x86_64 machines
     if [[ $(uname -m) =~ ^armv.+$ ]]; then
@@ -948,8 +954,8 @@ install_main() {
     echo "${VERSION_NO} - ${COMMIT_NO} - ${USED_BRANCH}" > ${jukebox_dir}/settings/version
     chmod 777 ${jukebox_dir}/settings/version
 
-    # Remove RPi.GPIO, if still installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
-    sudo python3 -m pip uninstall -y -q rpi-gpio
+    # Remove exluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469
+    ${pip_uninstall} -r "${jukebox_dir}"/requirements-excluded.txt
 
     # Install required spotify packages
     if [ "${SPOTinstall}" == "YES" ]; then
@@ -982,9 +988,18 @@ install_main() {
         sudo chmod 440 "${sudoers_mopidy}"
     fi
 
+    # prepare lgpio build for bullseye as the binaries are broken
+    local pip_install_options=""
+    if [ "${OS_VERSION_ID}" -le "11" ]; then
+        ${apt_get} install swig unzip
+        mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make > /dev/null && sudo make install > /dev/null
+        cd "${HOME_DIR}" && sudo rm -rf tmp > /dev/null
+        pip_install_options="--no-binary=lgpio"
+    fi
+
     # Install more required packages
     echo "Installing additional Python packages..."
-    ${pip_install} -r "${jukebox_dir}"/requirements.txt
+    ${pip_install} -r "${jukebox_dir}"/requirements.txt ${pip_install_options}
 
     samba_config
 

--- a/scripts/installscripts/tests/test_installation.sh
+++ b/scripts/installscripts/tests/test_installation.sh
@@ -333,7 +333,7 @@ call_with_args_from_file() {
     local package_file="$1"
     shift
 
-    sed 's/.*#egg=//g' ${package_file} | sed -E 's/(#|=|>|<).*//g' | xargs "$@"
+    sed 's/.*#egg=//g' ${package_file} | sed -E 's/(#|=|>|<|;).*//g' | xargs "$@"
 }
 
 verify_apt_packages() {
@@ -344,7 +344,9 @@ verify_apt_packages() {
     local packages_autohotspot_dhcpcd=$(call_with_args_from_file "${jukebox_dir}"/packages-autohotspot_dhcpcd.txt echo)
     local packages_autohotspot_NetworkManager=$(call_with_args_from_file "${jukebox_dir}"/packages-autohotspot_NetworkManager.txt echo)
 
-    printf "\nTESTING installed packages...\n\n"
+    local packages_excluded=$(call_with_args_from_file "${jukebox_dir}"/packages-excluded.txt echo)
+
+    printf "\nTESTING apt packages...\n\n"
 
     # also check for spotify packages if it has been installed
     if [[ "${SPOTinstall}" == "YES" ]]; then
@@ -378,6 +380,17 @@ verify_apt_packages() {
         fi
         ((tests++))
     done
+
+    for package in ${packages_excluded}
+    do
+        if [[ $(echo "${apt_list_installed}" | grep -i "${package}.*installed") ]]; then
+            echo "  ERROR: ${package} is installed (excluded)"
+            ((failed_tests++))
+        else
+            echo "  ${package} is not installed (excluded)"
+        fi
+        ((tests++))
+    done
 }
 
 verify_pip_packages() {
@@ -388,7 +401,9 @@ verify_pip_packages() {
     local modules_rc522=$(call_with_args_from_file "${jukebox_dir}"/components/rfid-reader/RC522/requirements.txt echo)
     local deviceName="${jukebox_dir}"/scripts/deviceName.txt
 
-    printf "\nTESTING installed pip modules...\n\n"
+    local modules_excluded=$(call_with_args_from_file "${jukebox_dir}"/requirements-excluded.txt echo)
+
+    printf "\nTESTING pip modules...\n\n"
 
     # also check for spotify pip modules if it has been installed
     if [[ "${SPOTinstall}" == "YES" ]]; then
@@ -415,8 +430,19 @@ verify_pip_packages() {
         if [[ $(echo "${pip_list_installed}" | grep -i "${module}") ]]; then
             echo "  ${module} is installed"
         else
-            echo "  ERROR: pip module ${module} is not installed"
+            echo "  ERROR: ${module} is not installed"
             ((failed_tests++))
+        fi
+        ((tests++))
+    done
+
+    for module in ${modules_excluded}
+    do
+        if [[ $(echo "${pip_list_installed}" | grep -i "${module}") ]]; then
+            echo "  ERROR: ${module} is installed (excluded)"
+            ((failed_tests++))
+        else
+            echo "  ${module} is not installed (excluded)"
         fi
         ((tests++))
     done


### PR DESCRIPTION
Following the discussion in #2313 replacing RPi.GPIO with [rpi-lgpio](https://rpi-lgpio.readthedocs.io/en/latest/index.html)

@hoffie @varac 