### PR TITLE
Replace RPi.GPIO with rpi-lgpio for V3 future3

### DIFF
--- a/.github/workflows/codeql-analysis_v3.yml
+++ b/.github/workflows/codeql-analysis_v3.yml
@@ -37,24 +37,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-          python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        # Install necessary packages
-        sudo apt-get update
-        sudo apt-get install libasound2-dev pulseaudio
-        python3 -m venv .venv
-        source ".venv/bin/activate"
-
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        # Set the `CODEQL_EXTRACTOR_PYTHON_ANALYSIS_VERSION` environment variable to the Python executable
-        # that includes the dependencies
-        echo "CODEQL_EXTRACTOR_PYTHON_ANALYSIS_VERSION=$(which python)" >> $GITHUB_ENV
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/documentation/developers/rfid/mfrc522_spi.md
+++ b/documentation/developers/rfid/mfrc522_spi.md
@@ -38,7 +38,7 @@ Mandatory IRQ pin. This can be any GPIO pin.
 
 Reset pin for hardware reset. This is an optional pin. If not used,
 
-- hardware reset will only be performed by power-on-reset. This has been tested on works fine.
+- hardware reset will only be performed by power-on-reset. This has been tested and works fine.
 - you **must** tie the reset pin of the MFRC522 board **high**!
 
 ### mode_legacy *(default=false)*
@@ -76,8 +76,6 @@ MISO.
 ## Hardware
 
 MFRC522 boards can be picked up from many places for little money.
-
-Good quality ones can be found e.g. here
 
 ### Cards/Tags
 

--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -400,7 +400,7 @@ verify_optional_service_enablement() {
 #   1    : textfile to read
 get_args_from_file() {
     local package_file="$1"
-    sed 's/.*#egg=//g' ${package_file} | sed -E 's/(#|=|>|<).*//g' | xargs echo
+    sed 's/.*#egg=//g' ${package_file} | sed -E 's/(#|=|>|<|;).*//g' | xargs echo
 }
 
 # Check if all passed packages are installed. Fail on first missing.
@@ -436,6 +436,25 @@ verify_pip_modules() {
     do
         if [[ ! $(echo "${pip_list_installed}" | grep -i "^${module} ") ]]; then
             exit_on_error "ERROR: ${module} is not installed"
+        fi
+    done
+    log "  CHECK"
+}
+
+# Check if all passed modules are not installed. Fail on first found.
+verify_pip_modules_not() {
+    local modules="$@"
+    log "  Verify modules are not installed: '${modules}'"
+
+    if [[ -z "${modules}" ]]; then
+        exit_on_error "ERROR: at least one parameter value is missing!"
+    fi
+
+    local pip_list_installed=$(pip list 2>/dev/null)
+    for module in ${modules}
+    do
+        if [[ $(echo "${pip_list_installed}" | grep -i "^${module} ") ]]; then
+            exit_on_error "ERROR: ${module} is installed"
         fi
     done
     log "  CHECK"

--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -130,7 +130,7 @@ validate_url() {
 download_from_url() {
     local url=$1
     local output_filename=$2
-    wget --quiet ${url} -O ${output_filename} || exit_on_error "Download failed"
+    wget ${url} -O ${output_filename} || exit_on_error "Download failed"
     return $?
 }
 

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -21,6 +21,20 @@ _jukebox_core_install_os_dependencies() {
     --allow-change-held-packages
 }
 
+_jukebox_core_build_and_install_lgpio() {
+    local tmp_path="${HOME_PATH}/tmp"
+    local lg_filename="lg"
+    local lg_zip_filename="${lg_filename}.zip"
+
+    sudo apt-get -y install swig unzip python3-dev python3-setuptools
+    mkdir -p "${tmp_path}" && cd "${tmp_path}" || exit_on_error
+    download_from_url "http://abyz.me.uk/lg/${lg_zip_filename}" "${lg_zip_filename}"
+    unzip ${lg_zip_filename} || exit_on_error
+    cd "${lg_filename}" || exit_on_error
+    make && sudo make install
+    cd "${INSTALLATION_PATH}" && sudo rm -rf "${tmp_path}"
+}
+
 _jukebox_core_install_python_requirements() {
   print_lc "  Install Python requirements"
 
@@ -36,17 +50,7 @@ _jukebox_core_install_python_requirements() {
   # prepare lgpio build for bullseye as the binaries are broken
   local pip_install_options=""
   if [ "$(is_debian_version_at_least 12)" = false ]; then
-    local tmp_path="${HOME_PATH}/tmp"
-    local lg_filename="lg"
-    local lg_zip_filename="${lg_filename}.zip"
-
-    sudo apt-get -y install swig unzip
-    mkdir -p "${tmp_path}" && cd "${tmp_path}" || exit_on_error
-    wget --quiet http://abyz.me.uk/lg/${lg_zip_filename} || exit_on_error "Download failed"
-    unzip ${lg_zip_filename} || exit_on_error
-    cd "${lg_filename}" || exit_on_error
-    make && sudo make install
-    cd "${INSTALLATION_PATH}" && sudo rm -rf "${tmp_path}"
+    _jukebox_core_build_and_install_lgpio
     pip_install_options="--no-binary=lgpio"
   fi
 

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -30,6 +30,8 @@ _jukebox_core_install_python_requirements() {
   source "$VIRTUAL_ENV/bin/activate"
 
   pip install --upgrade pip
+  # Remove RPi.GPIO, if still installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
+  pip uninstall rpi-gpio
   pip install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt"
 }
 

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -24,15 +24,33 @@ _jukebox_core_install_os_dependencies() {
 _jukebox_core_install_python_requirements() {
   print_lc "  Install Python requirements"
 
-  cd "${INSTALLATION_PATH}"  || exit_on_error
+  cd "${INSTALLATION_PATH}" || exit_on_error
 
   python3 -m venv $VIRTUAL_ENV
   source "$VIRTUAL_ENV/bin/activate"
 
   pip install --upgrade pip
-  # Remove RPi.GPIO, if still installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
-  pip uninstall rpi-gpio
-  pip install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt"
+  # Remove excluded libs, if installed - see - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
+  pip uninstall -y -r "${INSTALLATION_PATH}"/requirements-excluded.txt
+
+  # prepare lgpio build for bullseye as the binaries are broken
+  local pip_install_options=""
+  if [ "$(is_debian_version_at_least 12)" = false ]; then
+    local tmp_path="${HOME_PATH}/tmp"
+    local lg_filename="lg"
+    local lg_zip_filename="${lg_filename}.zip"
+
+    sudo apt-get -y install swig unzip
+    mkdir -p "${tmp_path}" && cd "${tmp_path}" || exit_on_error
+    wget --quiet http://abyz.me.uk/lg/${lg_zip_filename} || exit_on_error "Download failed"
+    unzip ${lg_zip_filename} || exit_on_error
+    cd "${lg_filename}" || exit_on_error
+    make && sudo make install
+    cd "${INSTALLATION_PATH}" && sudo rm -rf "${tmp_path}"
+    pip_install_options="--no-binary=lgpio"
+  fi
+
+  pip install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt" ${pip_install_options}
 }
 
 _jukebox_core_configure_pulseaudio() {
@@ -121,6 +139,9 @@ _jukebox_core_check() {
 
     local pip_modules=$(get_args_from_file "${INSTALLATION_PATH}/requirements.txt")
     verify_pip_modules pyzmq $pip_modules
+
+    local pip_modules_excluded=$(get_args_from_file "${INSTALLATION_PATH}/requirements-excluded.txt")
+    verify_pip_modules_not $pip_modules_excluded
 
     log "  Verify ZMQ version '${JUKEBOX_ZMQ_VERSION}'"
     local zmq_version=$(python -c 'import zmq; print(f"{zmq.zmq_version()}")')

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -30,7 +30,7 @@ _jukebox_core_install_python_requirements() {
   source "$VIRTUAL_ENV/bin/activate"
 
   pip install --upgrade pip
-  # Remove excluded libs, if installed - see - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
+  # Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
   pip uninstall -y -r "${INSTALLATION_PATH}"/requirements-excluded.txt
 
   # prepare lgpio build for bullseye as the binaries are broken

--- a/packages-core.txt
+++ b/packages-core.txt
@@ -15,3 +15,4 @@ python3
 python3-venv
 python3-dev
 rsync
+wget

--- a/requirements-excluded.txt
+++ b/requirements-excluded.txt
@@ -1,5 +1,9 @@
-# Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
+# Remove excluded libs, if installed
 # Libraries which must be excluded. These must be removed with
 # You need to uninstall these with `python -m pip uninstall -y -r requirements.txt`
 
+# RPi.GPIO uses direct /sys/class/gpio/ access, which is removed since kernel 6.6 (bookworm)
+# see also
+# - https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
+# - https://github.com/MiczFlor/RPi-Jukebox-RFID/discussions/2295
 RPi.GPIO

--- a/requirements-excluded.txt
+++ b/requirements-excluded.txt
@@ -1,0 +1,5 @@
+# Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
+# Libraries which must be excluded. These must be removed with
+# You need to uninstall these with `python -m pip uninstall -y -r requirements.txt`
+
+RPi.GPIO

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,8 @@ requests
 tornado
 
 # RPi's GPIO packages:
-RPi.GPIO
+# use shim to keep current RPi.GPIO behavior also under Bookworm - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
+rpi-lgpio
 gpiozero
 
 # PyZMQ is a special case:

--- a/src/cli_client/pbc.c
+++ b/src/cli_client/pbc.c
@@ -130,7 +130,7 @@ void * connect_and_send_request(t_request * tr)
     snprintf(json_request,MAX_REQEST_STRLEN,"{\"package\": \"%s\", \"plugin\": \"%s\", \"method\": \"%s\", %s\"id\":%d}",tr->package,tr->object,tr->method,kwargs,123);
     json_len = strlen(json_request);
 
-    if (g_verbose) printf("Sending Request (%ld Bytes):\n%s\n",json_len,json_request);
+    if (g_verbose) printf("Sending Request (%d Bytes):\n%s\n",json_len,json_request);
 
     send_zmq_request_and_wait_response(json_request,json_len,json_response,MAX_REQEST_STRLEN,tr->address);
 

--- a/src/cli_client/pbc.c
+++ b/src/cli_client/pbc.c
@@ -130,7 +130,7 @@ void * connect_and_send_request(t_request * tr)
     snprintf(json_request,MAX_REQEST_STRLEN,"{\"package\": \"%s\", \"plugin\": \"%s\", \"method\": \"%s\", %s\"id\":%d}",tr->package,tr->object,tr->method,kwargs,123);
     json_len = strlen(json_request);
 
-    if (g_verbose) printf("Sending Request (%d Bytes):\n%s\n",json_len,json_request);
+    if (g_verbose) printf("Sending Request (%ld Bytes):\n%s\n",json_len,json_request);
 
     send_zmq_request_and_wait_response(json_request,json_len,json_response,MAX_REQEST_STRLEN,tr->address);
 

--- a/src/jukebox/components/rfid/hardware/rc522_spi/rc522_spi.py
+++ b/src/jukebox/components/rfid/hardware/rc522_spi/rc522_spi.py
@@ -1,7 +1,6 @@
 # Standard imports from python packages
 import logging
 
-import RPi.GPIO as GPIO
 import pirc522
 
 import jukebox.cfghandler
@@ -87,7 +86,7 @@ class ReaderClass(ReaderBaseClass):
                                    pin_rst=pin_rst,
                                    pin_irq=pin_irq,
                                    antenna_gain=antenna_gain,
-                                   pin_mode=GPIO.BCM)
+                                   pin_mode='BCM')
 
     def cleanup(self):
         self.device.cleanup()

--- a/src/jukebox/components/rfid/hardware/rc522_spi/requirements.txt
+++ b/src/jukebox/components/rfid/hardware/rc522_spi/requirements.txt
@@ -1,6 +1,4 @@
 # RC522 related requirements
 # You need to install these with `python -m pip install --upgrade --force-reinstall -q -r requirements.txt`
 
-pi-rc522==2.3.0
-
-
+git+https://github.com/hoffie/pi-rc522-gpiozero

--- a/src/jukebox/components/rfid/hardware/rc522_spi/requirements.txt
+++ b/src/jukebox/components/rfid/hardware/rc522_spi/requirements.txt
@@ -1,4 +1,4 @@
 # RC522 related requirements
 # You need to install these with `python -m pip install --upgrade --force-reinstall -q -r requirements.txt`
 
-git+https://github.com/hoffie/pi-rc522-gpiozero
+git+https://github.com/hoffie/pi-rc522-gpiozero@1dc878c


### PR DESCRIPTION
Following the discussion in https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313 replacing RPi.GPIO with [rpi-lgpio](https://rpi-lgpio.readthedocs.io/en/latest/index.html)

- [x] Clarify if we need a check mechanism to not accidentally install RPi.GPIO as dependency in the future - see comment from @AlvinSchiller https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2469#issuecomment-2564880847
- [x] Make sure that rc522 does not install RPi.GPIO as dependency (—no-deps) - pointer: https://github.com/MiczFlor/RPi-Jukebox-RFID/blob/0ee5bc3f0da45ad935e7b046c4ce7653c9ed00a6/src/jukebox/components/rfid/configure/__init__.py#L29-L37
- [x] build rpi-lgpio also manually on Bullseye - see #2469 

@hoffie @varac 