### PR TITLE
fix evdev breakingchange

### DIFF
--- a/src/jukebox/components/rfid/hardware/generic_usb/generic_usb.py
+++ b/src/jukebox/components/rfid/hardware/generic_usb/generic_usb.py
@@ -66,7 +66,7 @@ def _is_keyboard(device: evdev.InputDevice) -> bool:
         is_keyboard_res = mandatory_keys.issubset(device_key_list) and reserved_key.isdisjoint(device_key_list)
     except KeyError:
         is_keyboard_res = False
-    logger.debug(f"is_keyboard test for '{device.name}' at '{device.fn}' is '{is_keyboard_res}'")
+    logger.debug(f"is_keyboard test for '{device.name}' at '{device.path}' is '{is_keyboard_res}'")
     return is_keyboard_res
 
 


### PR DESCRIPTION
The new versions of evdev (1.8.0 and 1.9.0) introduce breaking changes.
https://python-evdev.readthedocs.io/en/latest/changelog.html

- "InputDevice.fn" was used in usb-rfid-reader registration output. Use "InputDevice.path" now as adviced.
- "InputDevice.syn()" is not used in this project

Closes #2497