### PR TITLE
Update gpio.md

### DIFF
--- a/documentation/builders/gpio.md
+++ b/documentation/builders/gpio.md
@@ -377,7 +377,9 @@ output_devices:
     type: RGBLED
     connect: gpio.gpioz.plugin.connectivity.register_volume_rgbled_callback
     kwargs:
-      pin: 18
+      red: 18
+      green: 13
+      blue: 19
 ```
 
 ### Bluetooth audio output LED


### PR DESCRIPTION
The example for RGBLED only used one pin for PWMLED.

Updated to list the arguments for red, green and blue pins.