### PR TITLE
Fix rpi-lgpio installation on non-ARM systems

### DIFF
--- a/docker/Dockerfile.jukebox
+++ b/docker/Dockerfile.jukebox
@@ -38,7 +38,7 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install all Python dependencies
-RUN pip install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
+RUN pip install --no-binary=lgpio --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
 
 # Install pyzmq Python dependency separately
 ENV ZMQ_PREFIX /opt/libzmq

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ tornado
 
 # RPi's GPIO packages:
 # use shim to keep current RPi.GPIO behavior also under Bookworm - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
-rpi-lgpio; platform_machine == "armv7l" or platform_machine == "aarch64"
+rpi-lgpio; platform_machine == "armv6l" or platform_machine == "armv7l" or platform_machine == "aarch64"
 gpiozero
 
 # PyZMQ is a special case:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ tornado
 
 # RPi's GPIO packages:
 # use shim to keep current RPi.GPIO behavior also under Bookworm - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
-rpi-lgpio
+rpi-lgpio; platform_machine == "armv7l" or platform_machine == "aarch64"
 gpiozero
 
 # PyZMQ is a special case:


### PR DESCRIPTION
This update restricts the installation of `rpi-lgpio` to Raspberry Pi architectures only (`armv7l` or `aarch64`) using environment markers in `requirements.txt`.

Previously, the dependency caused installation errors on x86 or other non-ARM hosts, which resulted in failed Docker builds. With this change applied, the following command should no longer fail:

```bash
docker compose -f docker/docker-compose.yml -f docker/docker-compose.linux.yml up
