### PR TITLE
fix flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,9 @@ ignore =
     # continuation line under-indented for visual indent
     E128,
     # line break before binary operator
-    W503
+    W503,
+    # global name / nonlocal name is unused: name is never assigned in scope
+    F824
 per-file-ignores =
     # Only in __init__files ignore imported but unused
     # Not necessary, if __all__ is declared in __init__ file

--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -5,11 +5,21 @@ on:
     branches:
         - 'future3/**'
     paths:
+        - '.github/workflows/pythonpackage_future3.yml'
+        - '.flake8'
+        - 'run_flake8.sh'
+        - '.coveragerc'
+        - 'run_pytest.sh'
         - '**.py'
   pull_request:
     branches:
         - 'future3/**'
     paths:
+        - '.github/workflows/pythonpackage_future3.yml'
+        - '.flake8'
+        - 'run_flake8.sh'
+        - '.coveragerc'
+        - 'run_pytest.sh'
         - '**.py'
 
 jobs:

--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -10,6 +10,7 @@ on:
         - 'run_flake8.sh'
         - '.coveragerc'
         - 'run_pytest.sh'
+        - '**requirements*.txt'
         - '**.py'
   pull_request:
     branches:
@@ -20,6 +21,7 @@ on:
         - 'run_flake8.sh'
         - '.coveragerc'
         - 'run_pytest.sh'
+        - '**requirements*.txt'
         - '**.py'
 
 jobs:


### PR DESCRIPTION
The flake8 version 7.2.0 has added the Error "F824 global name / nonlocal name is unused: name is never assigned in scope". This causes the ci to fail.

The errors can be fixed, but with code changes.
To prepare the new release, this error is only ignored.

The correct solution should be done afterwards, with more time to test.

also added some path for the workflow run change detection