### PR TITLE
v2 - fix lgpio build for armv6 and python 3.13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,6 +25,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        CUR_DIR="$(pwd)"
+        mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install
+        cd "${CUR_DIR}" && sudo rm -rf tmp > /dev/null
         python -m pip install --upgrade pip
         pip install wheel
         pip install spidev

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/packages.txt
+++ b/packages.txt
@@ -27,4 +27,7 @@ python3-setuptools
 python3-wheel
 python3-mutagen
 python3-spidev
+swig
+tar
+unzip
 wget

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ git+https://github.com/lthiery/SPI-Py.git#egg=spi-py
 yt-dlp
 pyserial
 # use shim to keep current RPi.GPIO behavior also under Bookworm - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
-rpi-lgpio
+rpi-lgpio --no-binary=lgpio
 
 # Type checking for python
 # typing

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -983,7 +983,7 @@ install_main() {
     fi
 
     # always build lgpio as the pypi binaries are incomplete (armv6) or broken (bullseye)
-    mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make > /dev/null && sudo make install > /dev/null
+    mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install
     cd "${HOME_DIR}" && sudo rm -rf tmp > /dev/null
     local pip_install_options="--no-binary=lgpio"
 

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -982,13 +982,15 @@ install_main() {
         sudo chmod 440 "${sudoers_mopidy}"
     fi
 
-    # always build lgpio as the pypi binaries are incomplete (armv6) or broken (bullseye)
+    # always build lgpio as the pypi binaries are incomplete (armv6, python3.13) or broken (bullseye)
+    echo "Installing lgpio build dependecies..."
     mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install
     cd "${HOME_DIR}" && sudo rm -rf tmp > /dev/null
 
     # Install more required packages
     echo "Installing additional Python packages..."
     ${pip_install} -r "${jukebox_dir}"/requirements.txt
+
 
     samba_config
 

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -985,11 +985,10 @@ install_main() {
     # always build lgpio as the pypi binaries are incomplete (armv6) or broken (bullseye)
     mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install
     cd "${HOME_DIR}" && sudo rm -rf tmp > /dev/null
-    local pip_install_options="--no-binary=lgpio"
 
     # Install more required packages
     echo "Installing additional Python packages..."
-    ${pip_install} -r "${jukebox_dir}"/requirements.txt ${pip_install_options}
+    ${pip_install} -r "${jukebox_dir}"/requirements.txt
 
     samba_config
 

--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -982,14 +982,10 @@ install_main() {
         sudo chmod 440 "${sudoers_mopidy}"
     fi
 
-    # prepare lgpio build for bullseye as the binaries are broken
-    local pip_install_options=""
-    if [ "${OS_VERSION_ID}" -le "11" ]; then
-        ${apt_get} install swig unzip
-        mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make > /dev/null && sudo make install > /dev/null
-        cd "${HOME_DIR}" && sudo rm -rf tmp > /dev/null
-        pip_install_options="--no-binary=lgpio"
-    fi
+    # always build lgpio as the pypi binaries are incomplete (armv6) or broken (bullseye)
+    mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make > /dev/null && sudo make install > /dev/null
+    cd "${HOME_DIR}" && sudo rm -rf tmp > /dev/null
+    local pip_install_options="--no-binary=lgpio"
 
     # Install more required packages
     echo "Installing additional Python packages..."

--- a/scripts/installscripts/tests/test_installation.sh
+++ b/scripts/installscripts/tests/test_installation.sh
@@ -331,7 +331,7 @@ call_with_args_from_file() {
     local package_file="$1"
     shift
 
-    sed 's/.*#egg=//g' ${package_file} | sed -E 's/(#|=|>|<|;).*//g' | xargs "$@"
+    sed 's/.*#egg=//g' ${package_file} | sed -E 's/(#|=|>|<|;|--).*//g' | xargs "$@"
 }
 
 verify_apt_packages() {


### PR DESCRIPTION
The installation of rpi-lgpio currently does not work for armv6 models and with a python 3.13 environment.
The wheels binaries for lgpio are not reliable and only present for a fixed set of platforms.

The workaround that has been added to support bullseye (also broken binaries for lgpio) ist now the default case. The lgpio package is always build and no binaries are used.

This leads to a support of all platforms.