### PR TITLE
v3 - fix lgpio build for armv6 and python 3.13

### DIFF
--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -5,11 +5,13 @@ on:
     branches:
         - 'future3/**'
     paths:
+        - '.github/workflows/pythonpackage_future3.yml'
         - '**.py'
   pull_request:
     branches:
         - 'future3/**'
     paths:
+        - '.github/workflows/pythonpackage_future3.yml'
         - '**.py'
 
 jobs:

--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -33,6 +33,11 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libasound2-dev pulseaudio
+
+        CUR_DIR="$(pwd)"
+        mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install
+        cd "${CUR_DIR}" && sudo rm -rf tmp > /dev/null
+
         python3 -m venv .venv
         source ".venv/bin/activate"
 

--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -399,7 +399,7 @@ verify_optional_service_enablement() {
 #   1    : textfile to read
 get_args_from_file() {
     local package_file="$1"
-    sed 's/.*#egg=//g' ${package_file} | sed -E 's/(#|=|>|<|;).*//g' | xargs echo
+    sed 's/.*#egg=//g' ${package_file} | sed -E 's/(#|=|>|<|;|--).*//g' | xargs echo
 }
 
 # Check if all passed packages are installed. Fail on first missing.

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -26,7 +26,8 @@ _jukebox_core_build_and_install_lgpio() {
     local lg_filename="lg"
     local lg_zip_filename="${lg_filename}.zip"
 
-    sudo apt-get -y install swig unzip python3-dev python3-setuptools
+    # always build lg from source as pypi wheels are incomplete (armv6) or broken (bullseye)
+    # build needs apt packages "swig python3-dev"
     mkdir -p "${tmp_path}" && cd "${tmp_path}" || exit_on_error
     download_from_url "http://abyz.me.uk/lg/${lg_zip_filename}" "${lg_zip_filename}"
     unzip ${lg_zip_filename} || exit_on_error
@@ -47,12 +48,8 @@ _jukebox_core_install_python_requirements() {
   # Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
   pip uninstall -y -r "${INSTALLATION_PATH}"/requirements-excluded.txt
 
-  # prepare lgpio build for bullseye as the binaries are broken
-  local pip_install_options=""
-  if [ "$(is_debian_version_at_least 12)" = false ]; then
-    _jukebox_core_build_and_install_lgpio
-    pip_install_options="--no-binary=lgpio"
-  fi
+  _jukebox_core_build_and_install_lgpio
+  local pip_install_options="--no-binary=lgpio"
 
   pip install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt" ${pip_install_options}
 }

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -21,6 +21,21 @@ _jukebox_core_install_os_dependencies() {
     --allow-change-held-packages
 }
 
+_jukebox_core_build_and_install_lg() {
+    local tmp_path="${HOME_PATH}/tmp"
+    local lg_filename="lg"
+    local lg_zip_filename="${lg_filename}.zip"
+
+    # always build lg and lgpio from source as pypi wheels are incomplete (armv6) or broken (bullseye)
+    # build needs apt packages "swig python3-dev"
+    mkdir -p "${tmp_path}" && cd "${tmp_path}" || exit_on_error
+    download_from_url "http://abyz.me.uk/lg/${lg_zip_filename}" "${lg_zip_filename}"
+    unzip ${lg_zip_filename} || exit_on_error
+    cd "${lg_filename}" || exit_on_error
+    make && sudo make install
+    cd "${INSTALLATION_PATH}" && sudo rm -rf "${tmp_path}"
+}
+
 _jukebox_core_install_python_requirements() {
   print_lc "  Install Python requirements"
 
@@ -32,6 +47,8 @@ _jukebox_core_install_python_requirements() {
   pip install --upgrade pip
   # Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
   pip uninstall -y -r "${INSTALLATION_PATH}"/requirements-excluded.txt
+
+  _jukebox_core_build_and_install_lg
 
   pip install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt"
 }

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -26,7 +26,7 @@ _jukebox_core_build_and_install_lg() {
     local lg_filename="lg"
     local lg_zip_filename="${lg_filename}.zip"
 
-    # always build lg and lgpio from source as pypi wheels are incomplete (armv6) or broken (bullseye)
+    # always build lg and lgpio from source as pypi wheels are incomplete (armv6, python3.13) or broken (bullseye)
     # build needs apt packages "swig python3-dev"
     mkdir -p "${tmp_path}" && cd "${tmp_path}" || exit_on_error
     download_from_url "http://abyz.me.uk/lg/${lg_zip_filename}" "${lg_zip_filename}"

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -21,21 +21,6 @@ _jukebox_core_install_os_dependencies() {
     --allow-change-held-packages
 }
 
-_jukebox_core_build_and_install_lgpio() {
-    local tmp_path="${HOME_PATH}/tmp"
-    local lg_filename="lg"
-    local lg_zip_filename="${lg_filename}.zip"
-
-    # always build lg from source as pypi wheels are incomplete (armv6) or broken (bullseye)
-    # build needs apt packages "swig python3-dev"
-    mkdir -p "${tmp_path}" && cd "${tmp_path}" || exit_on_error
-    download_from_url "http://abyz.me.uk/lg/${lg_zip_filename}" "${lg_zip_filename}"
-    unzip ${lg_zip_filename} || exit_on_error
-    cd "${lg_filename}" || exit_on_error
-    make && sudo make install
-    cd "${INSTALLATION_PATH}" && sudo rm -rf "${tmp_path}"
-}
-
 _jukebox_core_install_python_requirements() {
   print_lc "  Install Python requirements"
 
@@ -48,10 +33,7 @@ _jukebox_core_install_python_requirements() {
   # Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
   pip uninstall -y -r "${INSTALLATION_PATH}"/requirements-excluded.txt
 
-  _jukebox_core_build_and_install_lgpio
-  local pip_install_options="--no-binary=lgpio"
-
-  pip install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt" ${pip_install_options}
+  pip install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt"
 }
 
 _jukebox_core_configure_pulseaudio() {

--- a/packages-core.txt
+++ b/packages-core.txt
@@ -14,7 +14,9 @@ pulseaudio-utils
 python3
 python3-venv
 python3-dev
+python3-setuptools
 rsync
+swig # needed for lg build
 tar
 unzip
 wget

--- a/packages-core.txt
+++ b/packages-core.txt
@@ -14,6 +14,7 @@ pulseaudio-utils
 python3
 python3-venv
 python3-dev
+python3-setuptools
 rsync
 swig #needed for lgpio build
 tar

--- a/packages-core.txt
+++ b/packages-core.txt
@@ -15,4 +15,7 @@ python3
 python3-venv
 python3-dev
 rsync
+swig #needed for lgpio build
+tar
+unzip
 wget

--- a/packages-core.txt
+++ b/packages-core.txt
@@ -14,9 +14,7 @@ pulseaudio-utils
 python3
 python3-venv
 python3-dev
-python3-setuptools
 rsync
-swig #needed for lgpio build
 tar
 unzip
 wget

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ tornado
 
 # RPi's GPIO packages:
 # use shim to keep current RPi.GPIO behavior also under Bookworm - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
+swig # needed to build lgpio
+lgpio --no-binary=lgpio
 rpi-lgpio
 gpiozero
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,7 @@ tornado
 
 # RPi's GPIO packages:
 # use shim to keep current RPi.GPIO behavior also under Bookworm - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
-lgpio --no-binary=lgpio
-rpi-lgpio
+rpi-lgpio --no-binary=lgpio
 gpiozero
 
 # PyZMQ is a special case:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ tornado
 
 # RPi's GPIO packages:
 # use shim to keep current RPi.GPIO behavior also under Bookworm - see https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/2313
-swig # needed to build lgpio
 lgpio --no-binary=lgpio
 rpi-lgpio
 gpiozero


### PR DESCRIPTION
The installation of rpi-lgpio currently does not work for armv6 models and with a python 3.13 environment.
The wheels binaries for lgpio are not reliable and only present for a fixed set of platforms.

The workaround that has been added to support bullseye (also broken binaries for lgpio) ist now the default case. The lgpio package is always build and no binaries are used.

This leads to a support of all platforms.

See PR for v2 #2567

Needs the changes of #2566 for the ci build