### PR TITLE
Add support for "trixie"

### DIFF
--- a/.github/workflows/test_docker_debian_v3.yml
+++ b/.github/workflows/test_docker_debian_v3.yml
@@ -37,6 +37,21 @@ concurrency:
 
 jobs:
 
+  run_trixie_armv7:
+    name: 'trixie armv7'
+    uses: ./.github/workflows/test_docker_debian_codename_sub_v3.yml
+    with:
+      debian_codename: 'trixie'
+      platform: linux/arm/v7
+
+  # # can be activate on test branches
+  # run_trixie_armv6:
+  #   name: 'trixie armv6'
+  #   uses: ./.github/workflows/test_docker_debian_codename_sub_v3.yml
+  #   with:
+  #     debian_codename: 'trixie'
+  #     platform: linux/arm/v6
+
   # Build container and run tests. Duplication of job intended for better visualization.
   run_bookworm_armv7:
     name: 'bookworm armv7'

--- a/docker/Dockerfile.jukebox
+++ b/docker/Dockerfile.jukebox
@@ -1,5 +1,5 @@
 FROM libzmq:local AS libzmq
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # These are only dependencies that are required to get as close to the
 # Raspberry Pi environment as possible.

--- a/docker/Dockerfile.libzmq
+++ b/docker/Dockerfile.libzmq
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # Install necessary build dependencies
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile.mpd
+++ b/docker/Dockerfile.mpd
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN set -eux ; \
     apt-get update && apt-get install -y \

--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -238,54 +238,33 @@ verify_dirs_exists() {
     log "  CHECK"
 }
 
-# Check if the file(s) has/have the expected owner and modifications
-verify_files_chmod_chown() {
-    local mod_expected=$1
-    local user_expected=$2
-    local group_expected=$3
-    local files="${@:4}"
-    log "  Verify '${mod_expected}' '${user_expected}:${group_expected}' is set for '${files}'"
+# Check if the dir(s) / file(s) has/have the expected owner, group and access rights for the user
+verify_owner_group_and_access() {
+    local user_expected=$1
+    local group_expected=$2
+    local mod_expected=$3
+    local dirs_files="${@:4}"
+    log "  Verify '${user_expected}:${group_expected}' with '${mod_expected}' is set for '${dirs_files}'"
 
-    if [[ -z "${mod_expected}" || -z "${user_expected}" || -z "${group_expected}" || -z "${files}" ]]; then
+    if [[ -z "${user_expected}" || -z "${group_expected}" || -z "${mod_expected}" || -z "${dirs_files}" ]]; then
         exit_on_error "ERROR: at least one parameter value is missing!"
     fi
 
-    for file in $files
+    for dir_file in $dirs_files
     do
-        test ! -f ${file} && exit_on_error "ERROR: '${file}' does not exists or is not a file!"
+        test ! -e ${dir_file} && exit_on_error "ERROR: '${dir_file}' does not exists!"
 
-        mod_actual=$(stat --format '%a' "${file}")
-        user_actual=$(stat -c '%U' "${file}")
-        group_actual=$(stat -c '%G' "${file}")
-        test ! "${mod_expected}" -eq "${mod_actual}" && exit_on_error "ERROR: '${file}' actual mod '${mod_actual}' differs from expected '${mod_expected}'!"
-        test ! "${user_expected}" == "${user_actual}" && exit_on_error "ERROR: '${file}' actual owner '${user_actual}' differs from expected '${user_expected}'!"
-        test ! "${group_expected}" == "${group_actual}" && exit_on_error "ERROR: '${file}' actual group '${group_actual}' differs from expected '${group_expected}'!"
-    done
-    log "  CHECK"
-}
+        user_actual=$(stat -c '%U' "${dir_file}")
+        group_actual=$(stat -c '%G' "${dir_file}")
+        test ! "${user_expected}" == "${user_actual}" && exit_on_error "ERROR: '${dir_file}' actual owner '${user_actual}' differs from expected '${user_expected}'!"
+        test ! "${group_expected}" == "${group_actual}" && exit_on_error "ERROR: '${dir_file}' actual group '${group_actual}' differs from expected '${group_expected}'!"
 
-# Check if the dir(s) has/have the expected owner and modifications
-verify_dirs_chmod_chown() {
-    local mod_expected=$1
-    local user_expected=$2
-    local group_expected=$3
-    local dirs="${@:4}"
-    log "  Verify '${mod_expected}' '${user_expected}:${group_expected}' is set for '${dirs}'"
-
-    if [[ -z "${mod_expected}" || -z "${user_expected}" || -z "${group_expected}" || -z "${dirs}" ]]; then
-        exit_on_error "ERROR: at least one parameter value is missing!"
-    fi
-
-    for dir in $dirs
-    do
-        test ! -d ${dir} && exit_on_error "ERROR: '${dir}' does not exists or is not a dir!"
-
-        mod_actual=$(stat --format '%a' "${dir}")
-        user_actual=$(stat -c '%U' "${dir}")
-        group_actual=$(stat -c '%G' "${dir}")
-        test ! "${mod_expected}" -eq "${mod_actual}" && exit_on_error "ERROR: '${dir}' actual mod '${mod_actual}' differs from expected '${mod_expected}'!"
-        test ! "${user_expected}" == "${user_actual}" && exit_on_error "ERROR: '${dir}' actual owner '${user_actual}' differs from expected '${user_expected}'!"
-        test ! "${group_expected}" == "${group_actual}" && exit_on_error "ERROR: '${dir}' actual group '${group_actual}' differs from expected '${group_expected}'!"
+        local mod_actual=""
+        for (( i=0; i<${#mod_expected}; i++ )); do
+            local current_mod="${mod_expected:$i:1}"
+            sudo -u ${user_expected} test "-${current_mod}" "${dir_file}" && mod_actual="${mod_actual}${current_mod}"
+        done
+        test ! "${mod_expected}" == "${mod_actual}" && exit_on_error "ERROR: '${dir_file}' actual access rights '${mod_actual}' differs from expected '${mod_expected}'!"
     done
     log "  CHECK"
 }

--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -383,7 +383,7 @@ verify_optional_service_enablement() {
     fi
 
     local actual_enablement=$(_get_service_enablement $service $option)
-    if [[ -z "${actual_enablement}" ]]; then
+    if [[ -z "${actual_enablement}" || "${actual_enablement}" == "not-found" ]]; then
         log "  INFO: optional service ${option}${service} is not installed."
     elif [[ "${actual_enablement}" == "static" ]]; then
         log "  INFO: optional service ${option}${service} is set static."

--- a/installation/routines/setup_git.sh
+++ b/installation/routines/setup_git.sh
@@ -143,7 +143,7 @@ _git_repo_check() {
     print_verify_installation
 
     verify_apt_packages git
-    verify_dirs_chmod_chown 755 "${CURRENT_USER}" "${CURRENT_USER_GROUP}" "${INSTALLATION_PATH}/.git"
+    verify_owner_group_and_access "${CURRENT_USER}" "${CURRENT_USER_GROUP}" rwx "${INSTALLATION_PATH}/.git"
 }
 
 _run_init_git_repo_from_tardir() {

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -157,12 +157,9 @@ _jukebox_core_check() {
     fi
     log "  CHECK"
 
-    verify_files_chmod_chown 644 "${CURRENT_USER}" "${CURRENT_USER_GROUP}" "${JUKEBOX_PULSE_CONFIG}"
+    verify_owner_group_and_access "${CURRENT_USER}" "${CURRENT_USER_GROUP}" rw "${JUKEBOX_PULSE_CONFIG}" "${SETTINGS_PATH}/jukebox.yaml" "${SETTINGS_PATH}/logger.yaml"
 
-    verify_files_chmod_chown 644 "${CURRENT_USER}" "${CURRENT_USER_GROUP}" "${SETTINGS_PATH}/jukebox.yaml"
-    verify_files_chmod_chown 644 "${CURRENT_USER}" "${CURRENT_USER_GROUP}" "${SETTINGS_PATH}/logger.yaml"
-
-    verify_files_chmod_chown 644 root root "${SYSTEMD_USR_PATH}/jukebox-daemon.service"
+    verify_owner_group_and_access root root rw "${SYSTEMD_USR_PATH}/jukebox-daemon.service"
 
     verify_file_contains_string "${INSTALLATION_PATH}" "${JUKEBOX_SERVICE_NAME}"
 

--- a/installation/routines/setup_kiosk_mode.sh
+++ b/installation/routines/setup_kiosk_mode.sh
@@ -11,11 +11,13 @@ _kiosk_mode_install_os_dependencies() {
   # Resource:
   # https://blog.r0b.io/post/minimal-rpi-kiosk/
   sudo apt-get -qq -y install --no-install-recommends \
-    xserver-xorg \
+    xserver-xorg-core \
+    xserver-xorg-input-all \
+    xserver-xorg-video-all \
     x11-xserver-utils \
     xinit \
     openbox \
-    chromium-browser
+    chromium
 }
 
 _kiosk_mode_set_autostart() {
@@ -65,11 +67,13 @@ EOF
 _kiosk_mode_check() {
     print_verify_installation
 
-    verify_apt_packages xserver-xorg \
+    verify_apt_packages     xserver-xorg-core \
+        xserver-xorg-input-all \
+        xserver-xorg-video-all \
         x11-xserver-utils \
         xinit \
         openbox \
-        chromium-browser
+        chromium
 
     verify_files_exists "${KIOSK_MODE_BASHRC}"
     verify_file_contains_string "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_BASHRC}"

--- a/installation/routines/setup_mpd.sh
+++ b/installation/routines/setup_mpd.sh
@@ -45,7 +45,7 @@ _mpd_check() {
 
     verify_apt_packages mpd mpc
 
-    verify_files_chmod_chown 755 "${CURRENT_USER}" "${CURRENT_USER_GROUP}" "${MPD_CONF_PATH}"
+    verify_owner_group_and_access "${CURRENT_USER}" "${CURRENT_USER_GROUP}" rwx "${MPD_CONF_PATH}"
 
     verify_file_contains_string "${AUDIOFOLDERS_PATH}" "${MPD_CONF_PATH}"
     verify_file_contains_string "${PLAYLISTS_PATH}" "${MPD_CONF_PATH}"

--- a/installation/routines/setup_samba.sh
+++ b/installation/routines/setup_samba.sh
@@ -50,7 +50,7 @@ _samba_check() {
 
     verify_apt_packages samba samba-common-bin
 
-    verify_files_chmod_chown 644 root root "${SMB_CONF}"
+    verify_owner_group_and_access root root rw "${SMB_CONF}"
 
     verify_file_contains_string "${SMB_CONF_HEADER}" "${SMB_CONF}"
     verify_file_contains_string "${SHARED_PATH}" "${SMB_CONF}"


### PR DESCRIPTION
Add support for raspberry pi os "trixie"

Done:
- add service state "not-found" for optional Services
- Update changed/depracated kiosk mode packages 
- Refactor access rights check due to for changed umask (from 0022 to 0002)

Todo:
- Update swap file handling for node memory usage on webapp build (dphys-swapfile is not available, trixie uses as deafult zram+file instead of a full swapfile)
-- options? 
--- update swap for bullseye / bookworm to the state of trixie (change swapfile to zram)
--- keep bullseye / bookworm logic and add parallel case for trixie