### PR TITLE
Add mfrc522 i2c rfid reader

### DIFF
--- a/documentation/developers/rfid/README.md
+++ b/documentation/developers/rfid/README.md
@@ -7,6 +7,7 @@
   * [Generic USB Reader](genericusb.md)
   * [RDM6300 Reader](rdm6300.md)
   * [MFRC522 SPI Reader](mfrc522_spi.md)
+  * [MFRC522 I2C Reader](mfrc522_i2c.md)
   * [PN532 I2C Reader](pn532_i2c.md)
   * [Generic Readers without HID (NFCpy)](generic_nfcpy.md)
   * [Mock Reader](mock_reader.md)

--- a/documentation/developers/rfid/mfrc522_i2c.md
+++ b/documentation/developers/rfid/mfrc522_i2c.md
@@ -13,6 +13,19 @@ There are no configurable options for this module.
 
 This reader module has been tested with  [M5Stack RFID 2 Unit WS1850S module](https://docs.m5stack.com/en/unit/rfid2).
 
+### Using an alternate board with a different i2c_address
+
+The default address is `0x28`. To find out the I2C address of your reader, first install the `i2c-tools` package:
+
+`sudo apt install i2c-tools`
+
+Then query all I2C addresses using:
+
+`i2cdetect -y 1`
+
+The address you see in the output will be a hex value (e.g. the hex value `0x28` is the decimal value `40`).
+Convert this to decimal, then add this to your `rfid.yaml` settings file.
+
 ## Board Connections
 
 ### Default wiring

--- a/documentation/developers/rfid/mfrc522_i2c.md
+++ b/documentation/developers/rfid/mfrc522_i2c.md
@@ -1,0 +1,25 @@
+# MFRC522 I2C Reader
+
+The MFRC522-based readers connected via I2C
+
+This reader module is based on the [mfrc522_i2c
+library](https://github.com/cpranzl/mfrc522_i2c) and uses the I2C bus.
+
+## Options
+
+There are no configurable options for this module.
+
+## Hardware
+
+This reader module has been tested with  [M5Stack RFID 2 Unit WS1850S module](https://docs.m5stack.com/en/unit/rfid2).
+
+## Board Connections
+
+### Default wiring
+
+| MFRC522 | RPI GPIO     | RPI Pin |
+|---------|--------------|---------|
+| 5V      | 5V           | > 4     |
+| GND     | GND          | > 6     |
+| SDA     | GPIO 2 (SDA) | > 3     |
+| SCL     | GPIO 3 (SCL) | > 5     |

--- a/src/jukebox/components/rfid/hardware/mfrc522_i2c/README.md
+++ b/src/jukebox/components/rfid/hardware/mfrc522_i2c/README.md
@@ -1,0 +1,2 @@
+
+For documentation see [documentation/developers/rfid/mfrc522_i2c.md](../../../../../../documentation/developers/rfid/mfrc522_i2c.md).

--- a/src/jukebox/components/rfid/hardware/mfrc522_i2c/description.py
+++ b/src/jukebox/components/rfid/hardware/mfrc522_i2c/description.py
@@ -1,0 +1,2 @@
+DESCRIPTION = "MFRC522 Reader using I2C via the mfrc522_i2c library."
+IS_PLACE_CAPABLE = True

--- a/src/jukebox/components/rfid/hardware/mfrc522_i2c/mfrc522_i2c.py
+++ b/src/jukebox/components/rfid/hardware/mfrc522_i2c/mfrc522_i2c.py
@@ -1,0 +1,79 @@
+import logging
+
+import jukebox.cfghandler
+from mfrc522_i2c import MFRC522
+
+from ...readerbase import ReaderBaseClass
+
+from .description import DESCRIPTION
+
+
+cfg = jukebox.cfghandler.get_handler("rfid")
+
+
+def query_customization() -> dict:
+    print(
+        "RFID MFRC522 (I2C) default parameters should work unless you changed the address."
+    )
+    return {"i2c_bus": 1, "i2c_address": 0x28, "log_all_cards": False}
+
+
+class ReaderClass(ReaderBaseClass):
+    def __init__(self, reader_cfg_key):
+        self._logger = logging.getLogger(f"jb.rfid.522i2c({reader_cfg_key})")
+        super().__init__(
+            reader_cfg_key=reader_cfg_key, description=DESCRIPTION, logger=self._logger
+        )
+
+        with cfg:
+            config = cfg.setndefault(
+                "rfid", "readers", reader_cfg_key, "config", value={}
+            )
+            self.i2c_bus = config.setdefault("i2c_bus", 1)
+            self.i2c_address = config.setdefault("i2c_address", 0x28)
+            self.log_all_cards = config.setdefault("log_all_cards", False)
+
+        self._keep_running = True
+        self._identified_card = False
+
+        # Create instance of MFRC522 (I2C)
+        self.device = MFRC522(self.i2c_bus, self.i2c_address)
+
+        # Print version for debug
+        self._logger.info(f"MFRC522(I2C) version: {self.device.getReaderVersion()}")
+
+    def cleanup(self):
+        del self.device
+
+    def stop(self):
+        self._keep_running = False
+
+    def _uid_to_string(self, uid):
+        uid_str = ""
+        for uid_section in uid:
+            uid_str += f"{uid_section:02x}"
+        return uid_str
+
+    def read_card(self) -> str:
+        if not self._keep_running:
+            return ""
+
+        # Only try to detect a card if we previously failed to identify one.
+        if not self._identified_card:
+            status, _, _ = self.device.scan()
+            if status != self.device.MIFARE_OK:
+                return ""
+
+        # Identify the card (will fail if no card is present)
+        status, uid, _ = self.device.identify()
+        if status == self.device.MIFARE_OK:
+            uid_str = self._uid_to_string(uid)
+
+            if self.log_all_cards:
+                self._logger.debug(f"Card detected with ID = {uid_str}")
+
+            self._identified_card = True
+            return uid_str
+        else:
+            self._identified_card = False
+            return ""

--- a/src/jukebox/components/rfid/hardware/mfrc522_i2c/requirements.txt
+++ b/src/jukebox/components/rfid/hardware/mfrc522_i2c/requirements.txt
@@ -1,0 +1,4 @@
+# MFRC522 I2C related requirements
+# You need to install these with `python -m pip install --upgrade --force-reinstall -q -r requirements.txt`
+
+mfrc522_i2c

--- a/src/jukebox/components/rfid/hardware/mfrc522_i2c/setup.inc.sh
+++ b/src/jukebox/components/rfid/hardware/mfrc522_i2c/setup.inc.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "Entering setup.inc.sh"
+
+printf "Activating I2C interface...\n"
+sudo raspi-config nonint do_i2c 0
+
+echo -e "\nREBOOT for changes to take effect!\n"
+


### PR DESCRIPTION
As title, I got a WS1850S rfid module (https://docs.m5stack.com/en/unit/rfid2) for my phoniebox. Since there was no driver for it I wrote this one, so far it seems to be working