### PR TITLE
future3: Speed up sync from local folders and network mounts

### DIFF
--- a/src/jukebox/components/synchronisation/rfidcards/__init__.py
+++ b/src/jukebox/components/synchronisation/rfidcards/__init__.py
@@ -259,21 +259,20 @@ class SyncRfidcards:
             _host = self._sync_remote_server
             _port = self._sync_remote_port
 
-            _paths = ['-e', f"ssh -p {_port}", f"{_user}@{_host}:'{src_path}'", dst_path]
+            _mode_params = ['--compress', '-e', f"ssh -p {_port}", f"{_user}@{_host}:'{src_path}'", dst_path]
 
         else:
-            _paths = [src_path, dst_path]
+            _mode_params = [src_path, dst_path]
 
         _run_params = (['rsync',
-                        '--compress', '--recursive', '--itemize-changes',
+                        '--recursive', '--itemize-changes',
                         '--safe-links', '--times', '--omit-dir-times',
                         '--delete', '--prune-empty-dirs',
                         '--exclude=folder.conf',  # exclude if existing from v2.x
                         '--exclude=.*', '--exclude=.*/', '--exclude=@*/', '--cvs-exclude'
-                        ] + _paths)
+                        ] + _mode_params)
 
         _runresult = subprocess.run(_run_params, shell=False, check=False, capture_output=True, text=True)
-
         if _runresult.returncode == 0 and _runresult.stdout != '':
             logger.debug(f"Synced:\n{_runresult.stdout}")
             _files_synced = True


### PR DESCRIPTION
Syncing from my home server felt a bit slow. Wifi is the bottleneck, but an improvement of ~25% could still be attained with this patch.

I ran some tests using (the awesome!) [hyperfine](https://github.com/sharkdp/hyperfine), copying a 127MB mp3 from a cifs-mounted samba share to a local folder.

| Command (abbreviated) | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `rsync --compress` | 28.745 ± 1.040 | 27.546 | 30.406 | 1.44 ± 0.06 |
| `rsync ` | 23.255 ± 0.298 | 22.908 | 23.556 | 1.16 ± 0.02 |
| `cp` | 19.986 ± 0.322 | 19.657 | 20.450 | 1.00 |

`cp` is handsdown fastest. For `rsync`,  `--compress` incurs the ~25% penalty I mentioned above.

I assume `--compress` does speed up SSH-transfers, so I left it in for those.