### PR TITLE
fix: prevent PHP Object Injection via unserialize from GET parameter

### DIFF
--- a/htdocs/rss-mp3.php
+++ b/htdocs/rss-mp3.php
@@ -32,7 +32,12 @@ $replace = array("ae","oe","ue","Ae","Oe","Ue","ss", "");
 /*****************************************************************************************/
 
 if(isset($_GET['rss'])) {
-    $filesMp3 = unserialize($_GET['rss']);
+    // Use json_decode instead of unserialize to prevent PHP Object Injection (CWE-502)
+    $filesMp3 = json_decode($_GET['rss'], true);
+    if (!is_array($filesMp3)) {
+        // Fallback: try unserialize with allowed_classes=false for backwards compatibility
+        $filesMp3 = unserialize($_GET['rss'], ['allowed_classes' => false]);
+    }
     $title = urldecode($_GET['title']);
     phoniepodcastxml($filesMp3, $title);
 } else {


### PR DESCRIPTION
## Summary

Prevent PHP Object Injection vulnerability by replacing unsafe `unserialize($_GET['rss'])` with safe alternatives.

## Problem

Line 35 of `htdocs/rss-mp3.php` deserializes user-supplied GET data without restriction:

```php
$filesMp3 = unserialize($_GET['rss']);
```

PHP's `unserialize()` on user input is a **critical security vulnerability** (CWE-502). An attacker can craft a serialized PHP object that triggers arbitrary code execution through magic methods (`__destruct`, `__wakeup`, `__toString`). This is known as **PHP Object Injection**.

### Exploitation

An attacker visits:
```
/htdocs/rss-mp3.php?rss=O:8:"SplStack":0:{}&title=test
```

If any class with exploitable magic methods is autoloaded (common in PHP applications), the attacker achieves **Remote Code Execution**.

## Fix

1. **Primary**: Use `json_decode()` instead of `unserialize()` — JSON cannot instantiate PHP objects
2. **Fallback**: If JSON parsing fails, use `unserialize()` with `['allowed_classes' => false]` — this converts objects to `__PHP_Incomplete_Class`, preventing magic method execution

## Impact

- **Type**: Insecure Deserialization / PHP Object Injection (CWE-502)
- **OWASP**: A08:2021 — Software and Data Integrity Failures
- **Affected endpoint**: `htdocs/rss-mp3.php?rss=`
- **Risk**: Remote Code Execution via crafted serialized objects