### PR TITLE
Fix: mqtt cmd subscription

### DIFF
--- a/src/jukebox/components/mqtt/__init__.py
+++ b/src/jukebox/components/mqtt/__init__.py
@@ -56,7 +56,7 @@ class MQTT(threading.Thread):
     def _subscribe(self):
         logger.debug("Subscribing to MQTT topics.")
         self._mqtt_client.message_callback_add(f'{base_topic}/cmd/#', self._on_cmd)
-        self._mqtt_client.subscribe(f'{base_topic}/cmd/#',0)
+        self._mqtt_client.subscribe(f'{base_topic}/cmd/#', 0)
 
     def _on_cmd(self, client, userdata, msg):
         cmd = split_topic(topic=msg.topic)

--- a/src/jukebox/components/mqtt/__init__.py
+++ b/src/jukebox/components/mqtt/__init__.py
@@ -56,6 +56,7 @@ class MQTT(threading.Thread):
     def _subscribe(self):
         logger.debug("Subscribing to MQTT topics.")
         self._mqtt_client.message_callback_add(f'{base_topic}/cmd/#', self._on_cmd)
+        self._mqtt_client.subscribe(f'{base_topic}/cmd/#',0)
 
     def _on_cmd(self, client, userdata, msg):
         cmd = split_topic(topic=msg.topic)


### PR DESCRIPTION
Quick fix to what @gandy92 mentioned over a year ago in pull request #2412, which I was able to verify on my phoniebox setup: subscribing to the command topic "{base_topic}/cmd/#" only works with an added subscribe line.