### PR TITLE
(future3) fix(kiosk-mode): fixed kioskmode on bookworm

### DIFF
--- a/installation/routines/optimize_boot_time.sh
+++ b/installation/routines/optimize_boot_time.sh
@@ -8,6 +8,18 @@ OPTIMIZE_BOOT_CMDLINE_OPTIONS_IPV6="ipv6.disable=1"
 OPTIMIZE_DHCP_CONF_HEADER="## Jukebox DHCP Config"
 OPTIMIZE_BOOT_CONF_HEADER="## Jukebox Boot Config"
 
+_optimize_get_boot_cmdline_options() {
+    local options="${OPTIMIZE_BOOT_CMDLINE_OPTIONS}"
+
+    if [ "$ENABLE_KIOSK_MODE" = true ] && [ "$(is_debian_version_at_least 12)" = true ] ; then
+        options="${options/consoleblank=1 /}"
+        options="${options/ consoleblank=1/}"
+        options="${options/consoleblank=1/}"
+    fi
+
+    echo "$options"
+}
+
 _optimize_disable_irrelevant_services() {
   log "  Disable keyboard-setup.service"
   sudo systemctl disable keyboard-setup.service
@@ -115,7 +127,7 @@ _optimize_handle_boot_logs() {
   if [ "$DISABLE_BOOT_LOGS_PRINT" = true ] ; then
     log "  Disable boot logs"
 
-    _add_options_to_cmdline "${OPTIMIZE_BOOT_CMDLINE_OPTIONS}"
+    _add_options_to_cmdline "$(_optimize_get_boot_cmdline_options)"
   fi
 }
 
@@ -187,7 +199,7 @@ _optimize_check() {
     fi
 
     if [ "$DISABLE_BOOT_LOGS_PRINT" = true ] ; then
-        for option in $OPTIMIZE_BOOT_CMDLINE_OPTIONS
+        for option in $(_optimize_get_boot_cmdline_options)
         do
             verify_file_contains_string_once $option "${cmdlineFile}"
         done

--- a/installation/routines/setup_kiosk_mode.sh
+++ b/installation/routines/setup_kiosk_mode.sh
@@ -3,23 +3,43 @@
 KIOSK_MODE_CONF_HEADER="## Jukebox Kiosk Mode"
 KIOSK_MODE_XINITRC='/etc/xdg/openbox/autostart'
 KIOSK_MODE_BASHRC="${HOME_PATH}/.bashrc"
+KIOSK_MODE_BASH_PROFILE="${HOME_PATH}/.bash_profile"
+KIOSK_MODE_LABWC_DIR="${HOME_PATH}/.config/labwc"
+KIOSK_MODE_LABWC_AUTOSTART="${KIOSK_MODE_LABWC_DIR}/autostart"
 KIOSK_MODE_CHROMIUM_CUSTOM_DISABLE_UPDATE_CHECK='/etc/chromium-browser/customizations/01-disable-update-check'
 KIOSK_MODE_CHROMIUM_FLAG_UPDATE_INTERVAL='--check-for-update-interval=31536000'
+KIOSK_MODE_BOOKWORM_DISPLAY_SCALE='1.35'
+
+_kiosk_mode_use_bookworm_variant() {
+  if [ "$(is_debian_version_at_least 12)" = true ] ; then
+    echo true
+  else
+    echo false
+  fi
+}
 
 _kiosk_mode_install_os_dependencies() {
   print_lc "  Install Kiosk Mode dependencies"
-  # Resource:
-  # https://blog.r0b.io/post/minimal-rpi-kiosk/
-  sudo apt-get -qq -y install --no-install-recommends \
-    xserver-xorg \
-    x11-xserver-utils \
-    xinit \
-    openbox \
-    chromium-browser
+  if [ "$(_kiosk_mode_use_bookworm_variant)" = true ] ; then
+    sudo apt-get -qq -y install --no-install-recommends \
+      labwc \
+      wlr-randr \
+      fonts-noto-color-emoji \
+      chromium-browser
+  else
+    # Resource:
+    # https://blog.r0b.io/post/minimal-rpi-kiosk/
+    sudo apt-get -qq -y install --no-install-recommends \
+      xserver-xorg \
+      x11-xserver-utils \
+      xinit \
+      openbox \
+      fonts-noto-color-emoji \
+      chromium-browser
+  fi
 }
 
-_kiosk_mode_set_autostart() {
-  print_lc "  Configure Kiosk Mode"
+_kiosk_mode_set_legacy_autostart() {
   local _DISPLAY='$DISPLAY'
   local _XDG_VTNR='$XDG_VTNR'
 
@@ -52,6 +72,74 @@ chromium-browser http://localhost \
 EOF
 }
 
+_kiosk_mode_set_bookworm_autostart() {
+  print_lc "  Configure Kiosk Mode for Bookworm"
+
+  mkdir -p "${KIOSK_MODE_LABWC_DIR}"
+
+  if [ ! -f "${KIOSK_MODE_BASH_PROFILE}" ] ; then
+    tee "${KIOSK_MODE_BASH_PROFILE}" <<-EOF
+if [ -f "\$HOME/.profile" ]; then
+  . "\$HOME/.profile"
+fi
+
+EOF
+  fi
+
+  if ! grep -Fq "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_BASH_PROFILE}" 2>/dev/null ; then
+    tee -a "${KIOSK_MODE_BASH_PROFILE}" <<-EOF
+
+${KIOSK_MODE_CONF_HEADER}
+if [ -z "\$DISPLAY" ] && [ -z "\$WAYLAND_DISPLAY" ] && [ "\${XDG_VTNR:-0}" -eq 1 ] && command -v labwc >/dev/null 2>&1; then
+  export XDG_SESSION_TYPE=wayland
+  export MOZ_ENABLE_WAYLAND=1
+  export WLR_NO_HARDWARE_CURSORS=1
+  export WLR_RENDERER=pixman
+  mkdir -p "\$HOME/.cache"
+  echo "\$(date -Is) starting Bookworm kiosk" >> "\$HOME/.cache/phoniebox-kiosk-session.log"
+  exec labwc >> "\$HOME/.cache/phoniebox-kiosk-session.log" 2>&1
+fi
+
+EOF
+  fi
+
+  tee "${KIOSK_MODE_LABWC_AUTOSTART}" <<-EOF
+#!/usr/bin/env bash
+
+${KIOSK_MODE_CONF_HEADER}
+wlr-randr --output DSI-1 --on >/dev/null 2>&1 || true
+(
+  while ! wget -q --spider http://localhost; do
+    sleep 1
+  done
+
+  chromium-browser http://localhost \\
+    --enable-features=UseOzonePlatform \\
+    --ozone-platform=wayland \\
+    --disable-gpu \\
+    --force-device-scale-factor=${KIOSK_MODE_BOOKWORM_DISPLAY_SCALE} \\
+    --disable-infobars \\
+    --disable-pinch \\
+    --disable-translate \\
+    --kiosk \\
+    --noerrdialogs \\
+    --no-first-run \\
+    >> "\$HOME/.cache/phoniebox-kiosk-browser.log" 2>&1
+) &
+EOF
+
+  chmod 755 "${KIOSK_MODE_LABWC_AUTOSTART}"
+}
+
+_kiosk_mode_set_autostart() {
+  print_lc "  Configure Kiosk Mode"
+  if [ "$(_kiosk_mode_use_bookworm_variant)" = true ] ; then
+    _kiosk_mode_set_bookworm_autostart
+  else
+    _kiosk_mode_set_legacy_autostart
+  fi
+}
+
 _kiosk_mode_update_settings() {
   # Resource: https://github.com/Thyraz/Sonos-Kids-Controller/blob/d1f061f4662c54ae9b8dc8b545f9c3ba39f670eb/README.md#kiosk-mode-installation
   sudo mkdir -p $(dirname "${KIOSK_MODE_CHROMIUM_CUSTOM_DISABLE_UPDATE_CHECK}")
@@ -65,17 +153,34 @@ EOF
 _kiosk_mode_check() {
     print_verify_installation
 
-    verify_apt_packages xserver-xorg \
-        x11-xserver-utils \
-        xinit \
-        openbox \
-        chromium-browser
+    if [ "$(_kiosk_mode_use_bookworm_variant)" = true ] ; then
+        verify_apt_packages labwc \
+            wlr-randr \
+            fonts-noto-color-emoji \
+            chromium-browser
 
-    verify_files_exists "${KIOSK_MODE_BASHRC}"
-    verify_file_contains_string "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_BASHRC}"
+        verify_files_exists "${KIOSK_MODE_BASH_PROFILE}"
+        verify_file_contains_string "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_BASH_PROFILE}"
+        verify_file_contains_string "labwc" "${KIOSK_MODE_BASH_PROFILE}"
 
-    verify_files_exists "${KIOSK_MODE_XINITRC}"
-    verify_file_contains_string "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_XINITRC}"
+        verify_files_exists "${KIOSK_MODE_LABWC_AUTOSTART}"
+        verify_file_contains_string "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_LABWC_AUTOSTART}"
+        verify_file_contains_string "ozone-platform=wayland" "${KIOSK_MODE_LABWC_AUTOSTART}"
+        verify_file_contains_string "force-device-scale-factor=${KIOSK_MODE_BOOKWORM_DISPLAY_SCALE}" "${KIOSK_MODE_LABWC_AUTOSTART}"
+    else
+        verify_apt_packages xserver-xorg \
+            x11-xserver-utils \
+            xinit \
+            openbox \
+            fonts-noto-color-emoji \
+            chromium-browser
+
+        verify_files_exists "${KIOSK_MODE_BASHRC}"
+        verify_file_contains_string "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_BASHRC}"
+
+        verify_files_exists "${KIOSK_MODE_XINITRC}"
+        verify_file_contains_string "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_XINITRC}"
+    fi
 
     verify_files_exists "${KIOSK_MODE_CHROMIUM_CUSTOM_DISABLE_UPDATE_CHECK}"
     verify_file_contains_string "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_CHROMIUM_CUSTOM_DISABLE_UPDATE_CHECK}"

--- a/installation/routines/setup_kiosk_mode.sh
+++ b/installation/routines/setup_kiosk_mode.sh
@@ -9,6 +9,7 @@ KIOSK_MODE_LABWC_AUTOSTART="${KIOSK_MODE_LABWC_DIR}/autostart"
 KIOSK_MODE_CHROMIUM_CUSTOM_DISABLE_UPDATE_CHECK='/etc/chromium-browser/customizations/01-disable-update-check'
 KIOSK_MODE_CHROMIUM_FLAG_UPDATE_INTERVAL='--check-for-update-interval=31536000'
 KIOSK_MODE_BOOKWORM_DISPLAY_SCALE='1.35'
+KIOSK_MODE_BOOKWORM_IDLE_TIMEOUT_SECONDS='600'
 
 _kiosk_mode_use_bookworm_variant() {
   if [ "$(is_debian_version_at_least 12)" = true ] ; then
@@ -24,6 +25,8 @@ _kiosk_mode_install_os_dependencies() {
     sudo apt-get -qq -y install --no-install-recommends \
       labwc \
       wlr-randr \
+      wlopm \
+      swayidle \
       fonts-noto-color-emoji \
       chromium-browser
   else
@@ -108,6 +111,9 @@ EOF
 
 ${KIOSK_MODE_CONF_HEADER}
 wlr-randr --output DSI-1 --on >/dev/null 2>&1 || true
+swayidle -w \
+  timeout ${KIOSK_MODE_BOOKWORM_IDLE_TIMEOUT_SECONDS} "wlopm --off '*'" \
+  resume "wlopm --on '*'" >/dev/null 2>&1 &
 (
   while ! wget -q --spider http://localhost; do
     sleep 1
@@ -156,6 +162,8 @@ _kiosk_mode_check() {
     if [ "$(_kiosk_mode_use_bookworm_variant)" = true ] ; then
         verify_apt_packages labwc \
             wlr-randr \
+            wlopm \
+            swayidle \
             fonts-noto-color-emoji \
             chromium-browser
 
@@ -165,6 +173,9 @@ _kiosk_mode_check() {
 
         verify_files_exists "${KIOSK_MODE_LABWC_AUTOSTART}"
         verify_file_contains_string "${KIOSK_MODE_CONF_HEADER}" "${KIOSK_MODE_LABWC_AUTOSTART}"
+        verify_file_contains_string "swayidle" "${KIOSK_MODE_LABWC_AUTOSTART}"
+        verify_file_contains_string "timeout ${KIOSK_MODE_BOOKWORM_IDLE_TIMEOUT_SECONDS}" "${KIOSK_MODE_LABWC_AUTOSTART}"
+        verify_file_contains_string "wlopm --off" "${KIOSK_MODE_LABWC_AUTOSTART}"
         verify_file_contains_string "ozone-platform=wayland" "${KIOSK_MODE_LABWC_AUTOSTART}"
         verify_file_contains_string "force-device-scale-factor=${KIOSK_MODE_BOOKWORM_DISPLAY_SCALE}" "${KIOSK_MODE_LABWC_AUTOSTART}"
     else


### PR DESCRIPTION
I had issues with the kiosk mode not working on a raspberry Pi 3 + _Raspberry Pi Touch Display 2 5"_ running the future 3 release on bookworm lite. 

This PR is a fix that works for this setup since it is the only one I can test it on. I tried to preserve the old flow as well for older raspbian distros. 
This new kioskmode is only used on bookworm. 

What it includes:
* Uses wayland instead of X11
* includes `swayidle` and a default timeout of 10 minutes ➡️ the display get dark after 10 minutes but can be woken up by touching it
* Configures a scaling factor that (for my taste fits for the 5" Raspberry Pi Display

I appreciate any comment or suggestions for improvement.