### PR TITLE
Fix: Install ca-certificates in the mpd image for HTTPS streams

### DIFF
--- a/docker/Dockerfile.mpd
+++ b/docker/Dockerfile.mpd
@@ -5,6 +5,7 @@ RUN set -eux ; \
     pulseaudio \
     pulseaudio-utils \
     mpd mpc \
+    ca-certificates \
     --no-install-recommends \
 	; \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hello, here is a tiny fix on the Dockerfile build for dev.

I encounter this error while I wanted to listen `https://icecast.radiofrance.fr/monpetitfranceinter-midfi.mp3` / `https://icecast.radiofrance.fr/montoutpetitfranceinter-midfi.mp3`

MPD's curl input plugin needs a CA bundle to verify TLS. Without it, playing an https:// livestream fails with 'CURL failed: server certificate verification failed. CAfile: none'. Many public radio streams (and the WDR example in the docs) are HTTPS, so ship ca-certificates in the image.

**Logs**

```logs
mpd      | exception: Failed to decode https://icecast.radiofrance.fr/montoutpetitfranceinter-midfi.mp3; CURL failed: server certificate verification failed. CAfile: none CRLfile: none
mpd      | player: played "https://icecast.radiofrance.fr/montoutpetitfranceinter-midfi.mp3"
```

**Before**

https://github.com/user-attachments/assets/024db301-363b-4cea-b165-79331d06a48e

**After**

https://github.com/user-attachments/assets/995431b2-39fc-4338-afa4-b45dc90e0cdf

(Names of current play are not the good ones on the video, but the sound is correct, this is another issue)