### PR TITLE
Python action correct dependencies and avoid silent fails - V2 legacy

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,7 +25,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        set -e
+        #  avoid silent errors
+        set -euo pipefail
+        # Ensure build tools are available
+        sudo apt-get update
+        sudo apt-get install -y build-essential unzip
+        # build lg from source for lgpio
         CUR_DIR="$(pwd)"
         mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install
         cd "${CUR_DIR}" && sudo rm -rf tmp > /dev/null

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,7 +29,7 @@ jobs:
         set -euo pipefail
         # Ensure build tools are available
         sudo apt-get update
-        sudo apt-get install -y build-essential unzip
+        sudo apt-get install -y build-essential
         # build lg from source for lgpio
         CUR_DIR="$(pwd)"
         mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,6 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        set -e
         CUR_DIR="$(pwd)"
         mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install
         cd "${CUR_DIR}" && sudo rm -rf tmp > /dev/null


### PR DESCRIPTION
Sometimes manually building lgpio fails.

For improved error detection making sure that the Action fails, if make install has an error.