### PR TITLE
Make sure lgpio is recognized

### DIFF
--- a/scripts/installscripts/install-jukebox.sh
+++ b/scripts/installscripts/install-jukebox.sh
@@ -986,6 +986,8 @@ install_main() {
     echo "Installing lgpio build dependecies..."
     mkdir -p tmp && cd tmp && wget -q http://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install
     cd "${HOME_DIR}" && sudo rm -rf tmp > /dev/null
+    # make sure the just built lgpio is recognized in the next step
+    sudo ldconfig
 
     # Install more required packages
     echo "Installing additional Python packages..."


### PR DESCRIPTION
sometimes the installation of Python packages fails, because lgpio seems not be available (yet).

Ensure lgpio is recognized after installation.

Related to #2661 