### PR TITLE
build: separate requirements and stabilize lg builds

### DIFF
--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -51,8 +51,8 @@ jobs:
         python3 -m venv .venv
         source ".venv/bin/activate"
 
-        python3 -m pip install --upgrade pip
-        pip3 install -r requirements.txt
+        python3 -m pip install --upgrade pip setuptools wheel
+        pip3 install -r requirements-dev.txt
         # For operation of the Jukebox, ZMQ must be compiled from sources due to Websocket support
         # Also install all optional dependencies
         pip3 install -r src/jukebox/components/rfid/hardware/fake_reader_gui/requirements.txt

--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -44,9 +44,16 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libasound2-dev pulseaudio
 
-        CUR_DIR="$(pwd)"
-        mkdir -p tmp && cd tmp && wget -q https://abyz.me.uk/lg/lg.zip && unzip lg.zip > /dev/null && cd lg && make && sudo make install
-        cd "${CUR_DIR}" && sudo rm -rf tmp > /dev/null
+        LG_COMMIT=b959a17d723360e85648316757b02dbea9902feb
+        LG_ARCHIVE_SHA256=3554cd7e60d338b659d38579e6226c46690237d2abe69e8bd77ee7e3b6e615fe
+        mkdir -p tmp
+        wget --quiet --timeout=30 --tries=3 \
+          "https://github.com/joan2937/lg/archive/${LG_COMMIT}.zip" -O tmp/lg.zip
+        echo "${LG_ARCHIVE_SHA256}  tmp/lg.zip" | sha256sum --check --status
+        unzip -q tmp/lg.zip -d tmp
+        make -C "tmp/lg-${LG_COMMIT}"
+        sudo make -C "tmp/lg-${LG_COMMIT}" install
+        sudo rm -rf tmp
 
         python3 -m venv .venv
         source ".venv/bin/activate"

--- a/docker/Dockerfile.jukebox
+++ b/docker/Dockerfile.jukebox
@@ -46,10 +46,14 @@ RUN apt-get update && apt-get install -qq -y \
 # (`--no-binary=lgpio`) because the PyPI lgpio wheels are incomplete (armv6,
 # python3.13). Mirrors
 # `installation/routines/setup_jukebox_core.sh::_jukebox_core_build_and_install_lg`.
+ARG LG_COMMIT=b959a17d723360e85648316757b02dbea9902feb
+ARG LG_ARCHIVE_SHA256=3554cd7e60d338b659d38579e6226c46690237d2abe69e8bd77ee7e3b6e615fe
 RUN mkdir -p /tmp/lg && cd /tmp/lg \
-    && wget --quiet https://abyz.me.uk/lg/lg.zip \
+    && wget --quiet --timeout=30 --tries=3 \
+        "https://github.com/joan2937/lg/archive/${LG_COMMIT}.zip" -O lg.zip \
+    && echo "${LG_ARCHIVE_SHA256}  lg.zip" | sha256sum --check --status \
     && unzip -q lg.zip \
-    && cd lg \
+    && cd "lg-${LG_COMMIT}" \
     && make && make install \
     && cd / && rm -rf /tmp/lg
 

--- a/docker/Dockerfile.jukebox
+++ b/docker/Dockerfile.jukebox
@@ -65,8 +65,9 @@ ENV VIRTUAL_ENV=${INSTALLATION_PATH}/.venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Install all Python dependencies
-RUN pip install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
+# Install build tooling and runtime Python dependencies
+RUN pip install --no-cache-dir --upgrade setuptools wheel \
+    && pip install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
 
 # Install pyzmq Python dependency separately
 ENV ZMQ_PREFIX=/opt/libzmq

--- a/docker/armv7/jukebox.Dockerfile
+++ b/docker/armv7/jukebox.Dockerfile
@@ -64,7 +64,8 @@ USER ${USER}
 WORKDIR ${HOME}
 COPY --chown=${USER}:${USER} . ${INSTALLATION_PATH}/
 
-RUN pip install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
+RUN pip install --no-cache-dir --upgrade setuptools wheel \
+    && pip install --no-cache-dir -r ${INSTALLATION_PATH}/requirements.txt
 RUN pip install --no-cache-dir --no-binary pyzmq pyzmq
 
 EXPOSE 5555 5556

--- a/documentation/developers/development-environment.md
+++ b/documentation/developers/development-environment.md
@@ -29,7 +29,14 @@ We recommend to use at least a Pi 3 or Pi Zero 2 for development. While this har
 
 The jukebox also runs on any Linux machine. The Raspberry Pi specific stuff will not work of course. That is no issue depending our your development area. USB RFID Readers, however, will work. You will have to install and configure [MPD (Music Player Daemon)](https://www.musicpd.org/).
 
-In addition to the `requirements.txt`, you will this dependency. On the Raspberry PI, the latest stable release of ZMQ does not support WebSockets. We need to compile the latest version from Github, which is taken care of by the installation script. For regular machines, the normal package can be installed:
+Install the runtime and development dependencies from `requirements-dev.txt`:
+
+``` bash
+pip install --upgrade setuptools wheel
+pip install -r requirements-dev.txt
+```
+
+In addition to these requirements, you need the following dependency. On the Raspberry PI, the latest stable release of ZMQ does not support WebSockets. We need to compile the latest version from Github, which is taken care of by the installation script. For regular machines, the normal package can be installed:
 
 ``` bash
 pip install pyzmq

--- a/installation/includes/02_helpers.sh
+++ b/installation/includes/02_helpers.sh
@@ -127,7 +127,7 @@ validate_url() {
 download_from_url() {
     local url=$1
     local output_filename=$2
-    wget ${url} -O ${output_filename} || exit_on_error "Download failed"
+    wget --timeout=30 --tries=3 "${url}" -O "${output_filename}" || exit_on_error "Download failed"
     return $?
 }
 

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -4,6 +4,8 @@
 JUKEBOX_ZMQ_TMP_DIR="${HOME_PATH}/libzmq"
 JUKEBOX_ZMQ_PREFIX="/usr/local"
 JUKEBOX_ZMQ_VERSION="4.3.5"
+JUKEBOX_LG_COMMIT="b959a17d723360e85648316757b02dbea9902feb"
+JUKEBOX_LG_ARCHIVE_SHA256="3554cd7e60d338b659d38579e6226c46690237d2abe69e8bd77ee7e3b6e615fe"
 
 JUKEBOX_SERVICE_NAME="${SYSTEMD_USR_PATH}/jukebox-daemon.service"
 
@@ -22,15 +24,18 @@ _jukebox_core_install_os_dependencies() {
 
 _jukebox_core_build_and_install_lg() {
     local tmp_path="${HOME_PATH}/tmp"
-    local lg_filename="lg"
-    local lg_zip_filename="${lg_filename}.zip"
+    local lg_source_dir="lg-${JUKEBOX_LG_COMMIT}"
+    local lg_zip_filename="${lg_source_dir}.zip"
+    local lg_download_url="https://github.com/joan2937/lg/archive/${JUKEBOX_LG_COMMIT}.zip"
 
     # Always build lg and lgpio from source: PyPI lgpio wheels are incomplete
     # (no armv6, no Python 3.13). Requires apt packages "swig python3-dev".
     mkdir -p "${tmp_path}" && cd "${tmp_path}" || exit_on_error
-    download_from_url "https://abyz.me.uk/lg/${lg_zip_filename}" "${lg_zip_filename}"
-    unzip ${lg_zip_filename} || exit_on_error
-    cd "${lg_filename}" || exit_on_error
+    download_from_url "${lg_download_url}" "${lg_zip_filename}"
+    echo "${JUKEBOX_LG_ARCHIVE_SHA256}  ${lg_zip_filename}" | sha256sum --check --status \
+        || exit_on_error "lg source checksum verification failed"
+    unzip -q "${lg_zip_filename}" || exit_on_error
+    cd "${lg_source_dir}" || exit_on_error
     make && sudo make install
     cd "${INSTALLATION_PATH}" && sudo rm -rf "${tmp_path}"
 }

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -43,7 +43,9 @@ _jukebox_core_install_python_requirements() {
   python3 -m venv $VIRTUAL_ENV
   source "$VIRTUAL_ENV/bin/activate"
 
-  pip install --upgrade pip
+  # Build tooling is needed for native Python dependencies, but is not part of
+  # the Jukebox runtime requirements.
+  pip install --upgrade pip setuptools wheel
   # Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
   pip uninstall -y -r "${INSTALLATION_PATH}"/requirements-excluded.txt
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+# Runtime dependencies
+-r requirements.txt
+
+# Code quality and tests
+flake8>=4.0.0
+pytest
+coverage
+pytest-cov
+mock
+
+# API docs generation
+pydoc-markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 # Common python packages
 # You need to install these with `python -m pip install --no-cache-dir -r requirements.txt`
 
-setuptools
-wheel
-
 # Note:
 # sudo apt install libasound2-dev required on some machines
 
@@ -30,15 +27,6 @@ gpiozero
 # On the PI, it needs to be compiled with special options to enable Websocket support
 # On regular Linux PCs, Websocket is enabled in the Python package
 # pyzmq
-
-# Code quality
-flake8>=4.0.0
-pytest
-pytest-cov
-mock
-
-# API docs generation
-pydoc-markdown
 
 # MQTT
 paho-mqtt


### PR DESCRIPTION
## Summary

- keep production dependencies in `requirements.txt`
- add `requirements-dev.txt` for tests, coverage, linting, mocks, and documentation
- install `setuptools` and `wheel` explicitly as native build tooling
- update Python CI and developer setup to use development requirements
- replace unreliable `abyz.me.uk` downloads with checksum-verified lg v0.2.2 source pinned to its GitHub commit
- bound installer downloads to three 30-second attempts

## Stack

#2672 is merged. This is the next PR in the installation-optimization sequence.

## Testing

- Python 3.9, 3.10, 3.11, 3.12, and 3.13 CI previously passed on the completed stack
- 50 local tests and flake8 pass
- pinned archive checksum and clean Debian source build pass
- runtime requirements exclude development packages