### PR TITLE
perf(installer): centralize APT dependencies

### DIFF
--- a/docker/Dockerfile.jukebox
+++ b/docker/Dockerfile.jukebox
@@ -41,11 +41,8 @@ RUN apt-get update && apt-get install -qq -y \
     python3 python3-venv python3-dev python3-setuptools python3-mutagen \
     swig unzip
 
-# Build and install the lg C library from source.
-# rpi-lgpio pulls in lgpio, which `requirements.txt` forces to build from source
-# (`--no-binary=lgpio`) because the PyPI lgpio wheels are incomplete (armv6,
-# python3.13). Mirrors
-# `installation/routines/setup_jukebox_core.sh::_jukebox_core_build_and_install_lg`.
+# Generic Debian does not configure Raspberry Pi's repository, so build the lg
+# C library here instead of installing the Pi installer's `liblgpio-dev`.
 ARG LG_COMMIT=b959a17d723360e85648316757b02dbea9902feb
 ARG LG_ARCHIVE_SHA256=3554cd7e60d338b659d38579e6226c46690237d2abe69e8bd77ee7e3b6e615fe
 RUN mkdir -p /tmp/lg && cd /tmp/lg \

--- a/documentation/developers/webapp.md
+++ b/documentation/developers/webapp.md
@@ -4,16 +4,14 @@ The Web App sources are located in `src/webapp`. A pre-build bundle of the Web A
 
 ## Install node manually
 
-If you installed from an official release branch, Node might not be installed. To install Node for local development, follow the [official setup](https://deb.nodesource.com/).
+If you installed from an official release branch, Node might not be installed. Raspberry Pi OS Trixie provides Node.js 20 and npm directly:
 
 ``` bash
-NODE_MAJOR=20
-sudo apt-get -y update && sudo apt-get -y install ca-certificates curl gnupg
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-sudo apt-get -y update && sudo apt-get -y install nodejs
+sudo apt-get update
+sudo apt-get install nodejs npm
 ```
+
+ARMv6 devices use the unofficial Node.js build installed by the Phoniebox installer.
 
 ## Develop the Web App
 

--- a/installation/routines/install.sh
+++ b/installation/routines/install.sh
@@ -3,8 +3,8 @@ install() {
   customize_options
   clear_c
   show_slow_hardware_message
+  prepare_dependencies
   set_raspi_config
-  update_raspi_os
   init_git_repo_from_tardir
   setup_jukebox_core
   setup_mpd

--- a/installation/routines/prepare_dependencies.sh
+++ b/installation/routines/prepare_dependencies.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+APT_PACKAGES=()
+
+_add_apt_packages() {
+    local package
+    local existing
+    local found
+
+    for package in "$@"; do
+        found=false
+        for existing in "${APT_PACKAGES[@]}"; do
+            if [[ "$existing" == "$package" ]]; then
+                found=true
+                break
+            fi
+        done
+        if [[ "$found" == false ]]; then
+            APT_PACKAGES+=("$package")
+        fi
+    done
+}
+
+_collect_apt_packages() {
+    APT_PACKAGES=()
+
+    local core_packages
+    core_packages=($(get_args_from_file "${INSTALLATION_PATH}/packages-core.txt"))
+    _add_apt_packages git "${core_packages[@]}"
+
+    if [[ "$SETUP_MPD" == true && "$ENABLE_MPD_OVERWRITE_INSTALL" == true ]]; then
+        _add_apt_packages mpd mpc
+    fi
+
+    if [[ "$ENABLE_SAMBA" == true ]]; then
+        _add_apt_packages samba samba-common-bin
+    fi
+
+    if [[ "$ENABLE_WEBAPP" == true ]]; then
+        # A trailing '-' asks APT to remove Apache in the same transaction.
+        _add_apt_packages nginx apache2-
+
+        if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false && "$(get_architecture)" != "armv6" ]]; then
+            _add_apt_packages nodejs npm
+        fi
+    fi
+
+    if [[ "$ENABLE_KIOSK_MODE" == true ]]; then
+        _add_apt_packages xserver-xorg x11-xserver-utils xinit openbox chromium-browser
+    fi
+
+    if [[ "$ENABLE_AUTOHOTSPOT" == true ]]; then
+        _add_apt_packages iw
+        if [[ "$(is_dhcpcd_enabled)" == true || "$CI_RUNNING" == true ]]; then
+            _add_apt_packages hostapd dnsmasq
+        fi
+    fi
+}
+
+_run_prepare_dependencies() {
+    _collect_apt_packages
+
+    if [[ "$ENABLE_SAMBA" == true ]]; then
+        # Skip the interactive Samba WINS configuration dialog.
+        echo "samba-common samba-common/dhcp boolean false" | sudo debconf-set-selections
+    fi
+
+    log "  Refresh package indexes"
+    sudo apt-get -qq -y update || exit_on_error "Failed to refresh package indexes"
+
+    update_raspi_os
+
+    if [[ "$SETUP_MPD" == true && "$ENABLE_MPD_OVERWRITE_INSTALL" == true ]]; then
+        log "Note: Installing MPD might cause a message: 'Job failed. See journalctl -xe for details'
+It can be ignored! It's an artefact of the MPD installation - nothing we can do about it."
+    fi
+
+    log "  Install OS dependencies: ${APT_PACKAGES[*]}"
+    sudo apt-get -y install \
+        --no-install-recommends \
+        --allow-downgrades \
+        --allow-remove-essential \
+        --allow-change-held-packages \
+        "${APT_PACKAGES[@]}" || exit_on_error "Failed to install OS dependencies"
+}
+
+prepare_dependencies() {
+    run_with_log_frame _run_prepare_dependencies "Prepare OS dependencies"
+}

--- a/installation/routines/setup_autohotspot_NetworkManager.sh
+++ b/installation/routines/setup_autohotspot_NetworkManager.sh
@@ -3,10 +3,6 @@
 AUTOHOTSPOT_NETWORKMANAGER_RESOURCES_PATH="${INSTALLATION_PATH}/resources/autohotspot/NetworkManager"
 AUTOHOTSPOT_NETWORKMANAGER_CONNECTIONS_PATH="/etc/NetworkManager/system-connections"
 
-_install_packages_NetworkManager() {
-    sudo apt-get -y install iw
-}
-
 _install_autohotspot_NetworkManager() {
     # configure interface conf
     config_file_backup "${AUTOHOTSPOT_INTERFACES_CONF_FILE}"
@@ -90,7 +86,6 @@ _autohotspot_check_NetworkManager() {
 
 _run_setup_autohotspot_NetworkManager() {
     log "Install AutoHotspot NetworkManager"
-    _install_packages_NetworkManager
     _get_interface
     _uninstall_autohotspot_NetworkManager
     _install_autohotspot_NetworkManager

--- a/installation/routines/setup_autohotspot_dhcpcd.sh
+++ b/installation/routines/setup_autohotspot_dhcpcd.sh
@@ -14,9 +14,7 @@ AUTOHOTSPOT_SERVICE_DAEMON_PATH="${SYSTEMD_PATH}/${AUTOHOTSPOT_SERVICE_DAEMON}"
 
 AUTOHOTSPOT_DHCPCD_RESOURCES_PATH="${INSTALLATION_PATH}/resources/autohotspot/dhcpcd"
 
-_install_packages_dhcpcd() {
-    sudo apt-get -y install hostapd dnsmasq iw
-
+_prepare_services_dhcpcd() {
     # disable services. We want to start them manually
     sudo systemctl unmask hostapd
     sudo systemctl disable hostapd
@@ -177,7 +175,7 @@ _autohotspot_check_dhcpcd() {
 
 _run_setup_autohotspot_dhcpcd() {
     log "Install AutoHotspot dhcpcd"
-    _install_packages_dhcpcd
+    _prepare_services_dhcpcd
     _get_interface
     _uninstall_autohotspot_dhcpcd
     _install_autohotspot_dhcpcd

--- a/installation/routines/setup_git.sh
+++ b/installation/routines/setup_git.sh
@@ -1,16 +1,6 @@
 GIT_ABORT_MSG="Aborting dir to git repo conversion.
 Your directory content is untouched, you simply cannot use git for updating / developing"
 
-_git_install_os_dependencies() {
-  log "  Install Git dependencies"
-  sudo apt-get -y update; sudo apt-get -y install \
-    git \
-    --no-install-recommends \
-    --allow-downgrades \
-    --allow-remove-essential \
-    --allow-change-held-packages
-}
-
 _git_convert_tardir_git_repo() {
   log "****************************************************
 *** Converting tar-ball download into git repository
@@ -148,7 +138,6 @@ _git_repo_check() {
 
 _run_init_git_repo_from_tardir() {
     cd "${INSTALLATION_PATH}" || exit_on_error
-    _git_install_os_dependencies
     _git_convert_tardir_git_repo
     _git_repo_check
 }

--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -4,41 +4,8 @@
 JUKEBOX_ZMQ_TMP_DIR="${HOME_PATH}/libzmq"
 JUKEBOX_ZMQ_PREFIX="/usr/local"
 JUKEBOX_ZMQ_VERSION="4.3.5"
-JUKEBOX_LG_COMMIT="b959a17d723360e85648316757b02dbea9902feb"
-JUKEBOX_LG_ARCHIVE_SHA256="3554cd7e60d338b659d38579e6226c46690237d2abe69e8bd77ee7e3b6e615fe"
 
 JUKEBOX_SERVICE_NAME="${SYSTEMD_USR_PATH}/jukebox-daemon.service"
-
-# Functions
-_jukebox_core_install_os_dependencies() {
-  print_lc "  Install Jukebox OS dependencies"
-
-  local apt_packages=$(get_args_from_file "${INSTALLATION_PATH}/packages-core.txt")
-  sudo apt-get -y update && sudo apt-get -y install \
-    $apt_packages \
-    --no-install-recommends \
-    --allow-downgrades \
-    --allow-remove-essential \
-    --allow-change-held-packages
-}
-
-_jukebox_core_build_and_install_lg() {
-    local tmp_path="${HOME_PATH}/tmp"
-    local lg_source_dir="lg-${JUKEBOX_LG_COMMIT}"
-    local lg_zip_filename="${lg_source_dir}.zip"
-    local lg_download_url="https://github.com/joan2937/lg/archive/${JUKEBOX_LG_COMMIT}.zip"
-
-    # Always build lg and lgpio from source: PyPI lgpio wheels are incomplete
-    # (no armv6, no Python 3.13). Requires apt packages "swig python3-dev".
-    mkdir -p "${tmp_path}" && cd "${tmp_path}" || exit_on_error
-    download_from_url "${lg_download_url}" "${lg_zip_filename}"
-    echo "${JUKEBOX_LG_ARCHIVE_SHA256}  ${lg_zip_filename}" | sha256sum --check --status \
-        || exit_on_error "lg source checksum verification failed"
-    unzip -q "${lg_zip_filename}" || exit_on_error
-    cd "${lg_source_dir}" || exit_on_error
-    make && sudo make install
-    cd "${INSTALLATION_PATH}" && sudo rm -rf "${tmp_path}"
-}
 
 _jukebox_core_install_python_requirements() {
   print_lc "  Install Python requirements"
@@ -53,8 +20,6 @@ _jukebox_core_install_python_requirements() {
   pip install --upgrade pip setuptools wheel
   # Remove excluded libs, if installed - see https://github.com/MiczFlor/RPi-Jukebox-RFID/pull/2470
   pip uninstall -y -r "${INSTALLATION_PATH}"/requirements-excluded.txt
-
-  _jukebox_core_build_and_install_lg
 
   pip install --no-cache-dir -r "${INSTALLATION_PATH}/requirements.txt"
 }
@@ -168,7 +133,6 @@ _jukebox_core_check() {
 }
 
 _run_setup_jukebox_core() {
-    _jukebox_core_install_os_dependencies
     _jukebox_core_install_python_requirements
     _jukebox_core_build_and_install_pyzmq
     _jukebox_core_install_settings

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -3,66 +3,43 @@
 # Constants
 WEBAPP_NGINX_SITE_DEFAULT_CONF="/etc/nginx/sites-available/default"
 
-# Node major version used.
-# If changed also update in .github\actions\build-webapp\action.yml
-NODE_MAJOR=20
 # Node version for ARMv6 (unofficial builds)
 NODE_ARMv6_VERSION=v20.10.0
 
 OPTIONAL_WEBAPP_BUILD_FAILED=false
 
-_jukebox_webapp_install_node() {
-    print_lc "  Install NodeJS"
-
+_jukebox_webapp_install_node_armv6() {
     local node_version_installed=$(node -v 2>/dev/null)
     local arch=$(uname -m)
-    if [[ "$arch" == "armv6l" ]]; then
-        if [ "$node_version_installed" == "$NODE_ARMv6_VERSION" ]; then
-            print_lc "    Skipping. NodeJS already installed"
-        else
-            # For ARMv6 unofficial build
-            # https://github.com/nodejs/unofficial-builds/
-            local node_tmp_dir="${HOME_PATH}/node"
-            local node_install_dir=/usr/local/lib/nodejs
-            local node_filename="node-${NODE_ARMv6_VERSION}-linux-${arch}"
-            local node_tar_filename="${node_filename}.tar.gz"
-            node_download_url="https://unofficial-builds.nodejs.org/download/release/${NODE_ARMv6_VERSION}/${node_tar_filename}"
-
-            mkdir -p "${node_tmp_dir}" && cd "${node_tmp_dir}" || exit_on_error
-            download_from_url ${node_download_url} ${node_tar_filename}
-            tar -xzf ${node_tar_filename}
-            rm -rf ${node_tar_filename}
-
-            # see https://github.com/nodejs/help/wiki/Installation
-            # Remove existing symlinks
-            sudo unlink /usr/bin/node 2>/dev/null
-            sudo unlink /usr/bin/npm 2>/dev/null
-            sudo unlink /usr/bin/npx 2>/dev/null
-
-            # Clear existing nodejs and copy new files
-            sudo rm -rf "${node_install_dir}"
-            sudo mv "${node_filename}" "${node_install_dir}"
-
-            sudo ln -s "${node_install_dir}/bin/node" /usr/bin/node
-            sudo ln -s "${node_install_dir}/bin/npm" /usr/bin/npm
-            sudo ln -s "${node_install_dir}/bin/npx" /usr/bin/npx
-
-            cd "${HOME_PATH}" || exit_on_error
-            rm -rf "${node_tmp_dir}"
-        fi
+    if [ "$node_version_installed" == "$NODE_ARMv6_VERSION" ]; then
+        print_lc "    Skipping. NodeJS already installed"
     else
-        if [[ "$node_version_installed" == "v${NODE_MAJOR}."* ]]; then
-            print_lc "    Skipping. NodeJS already installed"
-        else
-            sudo apt-get -y remove nodejs
-            # install NodeJS as recommended in
-            # https://deb.nodesource.com/
-            sudo apt-get -y update && sudo apt-get -y install ca-certificates curl gnupg
-            sudo mkdir -p /etc/apt/keyrings
-            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-            sudo apt-get -y update && sudo apt-get -y install nodejs
-        fi
+        # Node.js does not publish official ARMv6 binaries.
+        # https://github.com/nodejs/unofficial-builds/
+        local node_tmp_dir="${HOME_PATH}/node"
+        local node_install_dir=/usr/local/lib/nodejs
+        local node_filename="node-${NODE_ARMv6_VERSION}-linux-${arch}"
+        local node_tar_filename="${node_filename}.tar.gz"
+        local node_download_url="https://unofficial-builds.nodejs.org/download/release/${NODE_ARMv6_VERSION}/${node_tar_filename}"
+
+        mkdir -p "${node_tmp_dir}" && cd "${node_tmp_dir}" || exit_on_error
+        download_from_url "${node_download_url}" "${node_tar_filename}"
+        tar -xzf "${node_tar_filename}"
+        rm -f "${node_tar_filename}"
+
+        sudo unlink /usr/bin/node 2>/dev/null
+        sudo unlink /usr/bin/npm 2>/dev/null
+        sudo unlink /usr/bin/npx 2>/dev/null
+
+        sudo rm -rf "${node_install_dir}"
+        sudo mv "${node_filename}" "${node_install_dir}"
+
+        sudo ln -s "${node_install_dir}/bin/node" /usr/bin/node
+        sudo ln -s "${node_install_dir}/bin/npm" /usr/bin/npm
+        sudo ln -s "${node_install_dir}/bin/npx" /usr/bin/npx
+
+        cd "${HOME_PATH}" || exit_on_error
+        rm -rf "${node_tmp_dir}"
     fi
 }
 
@@ -108,10 +85,7 @@ _jukebox_webapp_download() {
 }
 
 _jukebox_webapp_register_as_system_service_with_nginx() {
-  print_lc "  Install and configure nginx"
-  sudo apt-get -y update
-  sudo apt-get -y purge apache2
-  sudo apt-get -y install nginx
+  print_lc "  Configure nginx"
 
   sudo mv -f "${WEBAPP_NGINX_SITE_DEFAULT_CONF}" "${WEBAPP_NGINX_SITE_DEFAULT_CONF}.orig"
   sudo cp -f "${INSTALLATION_PATH}/resources/default-settings/nginx.default" "${WEBAPP_NGINX_SITE_DEFAULT_CONF}"
@@ -162,7 +136,9 @@ _run_setup_jukebox_webapp() {
     if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == true || "$ENABLE_WEBAPP_PROD_DOWNLOAD" == "release-only" ]] ; then
         _jukebox_webapp_download
     else
-        _jukebox_webapp_install_node
+        if [[ "$(get_architecture)" == "armv6" ]]; then
+            _jukebox_webapp_install_node_armv6
+        fi
         _jukebox_webapp_build
     fi
     _jukebox_webapp_register_as_system_service_with_nginx

--- a/installation/routines/setup_kiosk_mode.sh
+++ b/installation/routines/setup_kiosk_mode.sh
@@ -6,18 +6,6 @@ KIOSK_MODE_BASHRC="${HOME_PATH}/.bashrc"
 KIOSK_MODE_CHROMIUM_CUSTOM_DISABLE_UPDATE_CHECK='/etc/chromium-browser/customizations/01-disable-update-check'
 KIOSK_MODE_CHROMIUM_FLAG_UPDATE_INTERVAL='--check-for-update-interval=31536000'
 
-_kiosk_mode_install_os_dependencies() {
-  print_lc "  Install Kiosk Mode dependencies"
-  # Resource:
-  # https://blog.r0b.io/post/minimal-rpi-kiosk/
-  sudo apt-get -qq -y install --no-install-recommends \
-    xserver-xorg \
-    x11-xserver-utils \
-    xinit \
-    openbox \
-    chromium-browser
-}
-
 _kiosk_mode_set_autostart() {
   print_lc "  Configure Kiosk Mode"
   local _DISPLAY='$DISPLAY'
@@ -82,7 +70,6 @@ _kiosk_mode_check() {
 }
 
 _run_setup_kiosk_mode() {
-    _kiosk_mode_install_os_dependencies
     _kiosk_mode_set_autostart
     _kiosk_mode_update_settings
     _kiosk_mode_check

--- a/installation/routines/setup_mpd.sh
+++ b/installation/routines/setup_mpd.sh
@@ -3,20 +3,6 @@
 AUDIOFOLDERS_PATH="${SHARED_PATH}/audiofolders"
 PLAYLISTS_PATH="${SHARED_PATH}/playlists"
 
-_mpd_install_os_dependencies() {
-  log "  Install MPD OS dependencies"
-  sudo apt-get -y update
-
-  log "Note: Installing MPD might cause a message: 'Job failed. See journalctl -xe for details'
-It can be ignored! It's an artefact of the MPD installation - nothing we can do about it."
-  sudo apt-get -y install \
-    mpd mpc \
-    --no-install-recommends \
-    --allow-downgrades \
-    --allow-remove-essential \
-    --allow-change-held-packages
-}
-
 _mpd_configure() {
   print_lc "  Configure MPD as user local service"
 
@@ -58,7 +44,6 @@ _mpd_check() {
 }
 
 _run_setup_mpd() {
-    _mpd_install_os_dependencies
     _mpd_configure
     _mpd_check
 }

--- a/installation/routines/setup_samba.sh
+++ b/installation/routines/setup_samba.sh
@@ -3,16 +3,6 @@
 SMB_CONF="/etc/samba/smb.conf"
 SMB_CONF_HEADER="## Jukebox Samba Config"
 
-_samba_install_os_dependencies() {
-  log "  Install Samba Core dependencies"
-  sudo apt-get -qq -y update; sudo apt-get -qq -y install \
-    samba samba-common-bin \
-    --no-install-recommends \
-    --allow-downgrades \
-    --allow-remove-essential \
-    --allow-change-held-packages
-}
-
 _samba_set_user() {
   print_lc "  Configure Samba"
   local SMB_PASSWD="raspberry"
@@ -61,9 +51,6 @@ _samba_check() {
 }
 
 _run_setup_samba() {
-    # Skip interactive Samba WINS config dialog
-    echo "samba-common samba-common/dhcp boolean false" | sudo debconf-set-selections
-    _samba_install_os_dependencies
     _samba_set_user
     _samba_check
 }

--- a/installation/routines/update_raspi_os.sh
+++ b/installation/routines/update_raspi_os.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 _run_update_raspi_os() {
-    sudo apt-get -qq -y update && sudo apt-get -qq -y full-upgrade || exit_on_error "Failed to Update Raspberry Pi OS"
+    sudo apt-get -qq -y full-upgrade || exit_on_error "Failed to update Raspberry Pi OS"
     if [ "$CI_RUNNING" != "true" ]; then
-        sudo apt-get -qq -y autoremove
+        sudo apt-get -qq -y autoremove || exit_on_error "Failed to remove obsolete OS packages"
     fi
 }
 

--- a/packages-core.txt
+++ b/packages-core.txt
@@ -6,6 +6,7 @@ alsa-utils
 espeak
 ffmpeg
 libasound2-dev
+liblgpio-dev
 mpg123
 pipewire
 pipewire-pulse


### PR DESCRIPTION
## Summary

- collect and deduplicate selected OS dependencies in one preparation phase
- run one package-index refresh and one main dependency installation
- retain the optional full upgrade and dynamic RFID dependencies
- install Trixie `liblgpio-dev` instead of downloading/building lg on Raspberry Pi
- use Trixie `nodejs`/`npm` for ARMv7 and ARM64 while preserving ARMv6 unofficial builds
- remove NodeSource setup and component-level APT installs

## Stack

#2673 is merged. This PR is restacked onto the updated `future3/develop` and now contains only the APT-centralization commit.

## Testing

- all five installer scenarios previously passed on Trixie ARMv7 and ARM64
- covered Web App download/local build and local libzmq build
- mocked checks cover both OS-upgrade settings, package deduplication, ARMv6 exclusion, one refresh, and one install transaction
- Raspberry Pi Trixie provides `liblgpio-dev` 0.2.2 for ARMv7 and ARM64
- Trixie APT simulation confirms Node.js 20, npm, nginx, and same-transaction Apache removal