### PR TITLE
perf(installer): initialize shallow Git checkout

### DIFF
--- a/documentation/builders/installation.md
+++ b/documentation/builders/installation.md
@@ -73,6 +73,15 @@ You can also install a specific branch and/or a fork repository. Update the vari
 cd; GIT_USER='MiczFlor' GIT_BRANCH='future3/develop' bash <(wget -qO- https://raw.githubusercontent.com/MiczFlor/RPi-Jukebox-RFID/future3/develop/installation/install-jukebox.sh)
 ```
 
+The installer uses HTTPS and fetches only the selected branch with shallow history. Set `GIT_USE_SSH=true` to opt in to SSH access. The installed checkout remains a normal tracking branch, so `git pull` works as usual.
+
+Developers who later need all branches, history and tags can fetch them explicitly:
+
+```bash
+git fetch --unshallow origin
+git fetch origin --tags
+```
+
 > [!NOTE]
 > The Installation of the official repository's release branches ([Stable Release](#stable-release) and [Pre-Release](#pre-release)) will deploy a pre-build bundle of the Web App.
 > If you install another branch or from a fork repository, the Web App needs to be built locally. This is part of the installation process. See the the developers [Web App](../developers/webapp.md) documentation for further details.

--- a/installation/includes/01_default_config.sh
+++ b/installation/includes/01_default_config.sh
@@ -20,8 +20,9 @@ ENABLE_SAMBA=true
 ENABLE_WEBAPP=true
 ENABLE_KIOSK_MODE=false
 DISABLE_ONBOARD_AUDIO=false
-# Always try to use GIT with SSH first, and on failure drop down to HTTPS
-GIT_USE_SSH=${GIT_USE_SSH:-"true"}
+# HTTPS works without repository credentials. Developers can explicitly opt in
+# to SSH; a failed SSH fetch still falls back to HTTPS.
+GIT_USE_SSH=${GIT_USE_SSH:-"false"}
 
 # A pre-build binary for the Web App is only available for release builds
 # For non-production builds, the Wep App must be build locally

--- a/installation/routines/setup_git.sh
+++ b/installation/routines/setup_git.sh
@@ -1,30 +1,62 @@
 GIT_ABORT_MSG="Aborting dir to git repo conversion.
 Your directory content is untouched, you simply cannot use git for updating / developing"
 
+_git_fetch_origin() {
+  if [[ "$GIT_USE_SSH" == true ]]; then
+    # Avoid an interactive host-key prompt during installation.
+    git -c core.sshCommand='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' fetch "$@"
+  else
+    git fetch "$@"
+  fi
+}
+
+_git_add_upstream_remote() {
+  if [[ "$GIT_USER" == "$GIT_UPSTREAM_USER" ]]; then
+    return
+  fi
+
+  if [[ "$GIT_USE_SSH" == true ]]; then
+    git remote add upstream "git@github.com:${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}.git"
+  else
+    git remote add upstream "https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}.git"
+  fi
+}
+
+_git_fetch_requested_branch() {
+  local branch_refspec="refs/heads/${GIT_BRANCH}:refs/remotes/origin/${GIT_BRANCH}"
+
+  if ! _git_fetch_origin --depth=1 --no-tags origin "$branch_refspec"; then
+    return 1
+  fi
+
+  if ! git cat-file -e "${GIT_HASH}^{commit}" 2>/dev/null; then
+    log "*** Downloaded commit is not the current branch tip; deepening by 50 commits"
+    _git_fetch_origin --deepen=50 --no-tags origin "$branch_refspec" || return 1
+  fi
+
+  if ! git cat-file -e "${GIT_HASH}^{commit}" 2>/dev/null; then
+    log "*** Downloaded commit is still unresolved; fetching full branch history"
+    _git_fetch_origin --unshallow --no-tags origin "$branch_refspec" || return 1
+  fi
+
+  if ! git cat-file -e "${GIT_HASH}^{commit}" 2>/dev/null; then
+    log "Error: downloaded commit ${GIT_HASH} is not in ${GIT_BRANCH}"
+    return 1
+  fi
+}
+
 _git_convert_tardir_git_repo() {
   log "****************************************************
 *** Converting tar-ball download into git repository
 ****************************************************"
 
-  # Just in case, the git version is not new enough, we split up git init -b "${GIT_BRANCH}" into:
   git -c init.defaultBranch=main init
-  git checkout -q -b "${GIT_BRANCH}"
   git config pull.rebase false
 
-  # We always add origin as the selected (possible) user repository
-  # and, if relevant, MiczFlor's repository as upstream
-  # This means for developers everything is fully set up.
-  # For users there is no difference there is only origin = MiczFlor
-  # We need to get the branch with larger depth, as we do not know
-  # how many commits happened between download and git repo init
-  # We simply get everything from the beginning of future 3 development but excluding Version 2.X
   if [[ $GIT_USE_SSH == true ]]; then
     git remote add origin "git@github.com:${GIT_USER}/${GIT_REPO_NAME}.git"
     log "\n*** Git fetch (SSH) *******************************"
-    # Prevent: The authenticity of host 'github.com (140.82.121.4)' can't be established.
-    # Do only for this one command, so we do not disable the checks forever
-    if ! git -c core.sshCommand='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' fetch origin "${GIT_BRANCH}" --set-upstream --shallow-since=2021-04-21 --tags;
-    then
+    if ! _git_fetch_requested_branch; then
       log "\n*** NOTICE *****************************************
 * Error in getting Git Repository using SSH! USING FALLBACK HTTPS.
 * Note: This is only relevant for developers!
@@ -35,72 +67,34 @@ _git_convert_tardir_git_repo() {
 
       git remote remove origin
       GIT_USE_SSH=false
-    else
-      # Only add upstream with SSH when fetch over SSH succeeded
-      if [[ "$GIT_USER" != "$GIT_UPSTREAM_USER" ]]; then
-        git remote add upstream "git@github.com:${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}.git"
-      fi
     fi
   fi
 
   if [[ $GIT_USE_SSH == false ]]; then
     git remote add origin "https://github.com/${GIT_USER}/${GIT_REPO_NAME}.git"
-    if [[ "$GIT_USER" != "$GIT_UPSTREAM_USER" ]]; then
-      git remote add upstream "https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}.git"
-    fi
     log "\n*** Git fetch (HTTPS) *****************************"
-    if ! git fetch origin --set-upstream --shallow-since=2021-04-21 --tags "${GIT_BRANCH}"; then
+    if ! _git_fetch_requested_branch; then
       log "Error: Could not fetch repository!"
       log "$GIT_ABORT_MSG"
-      return
+      return 1
     fi
   fi
-  HASH_BRANCH=$(git rev-parse FETCH_HEAD) || { echo -e "$GIT_ABORT_MSG"; return; }
 
+  _git_add_upstream_remote
+
+  HASH_BRANCH=$(git rev-parse "refs/remotes/origin/${GIT_BRANCH}") || { echo -e "$GIT_ABORT_MSG"; return 1; }
   log "\n*** FETCH_HEAD ($GIT_BRANCH) = $HASH_BRANCH"
 
   git add .
-  # Checkout the exact hash that we have downloaded as tarball
+  GIT_HASH=$(git rev-parse "${GIT_HASH}^{commit}") || { echo -e "$GIT_ABORT_MSG"; return 1; }
   log "*** Git checkout commit"
-  git -c advice.detachedHead=false checkout "$GIT_HASH" || { echo -e "$GIT_ABORT_MSG"; return; }
-  HASH_HEAD=$(git rev-parse HEAD) || { echo -e "$GIT_ABORT_MSG"; return; }
+  git -c advice.detachedHead=false checkout "$GIT_HASH" || { echo -e "$GIT_ABORT_MSG"; return 1; }
+  HASH_HEAD=$(git rev-parse HEAD) || { echo -e "$GIT_ABORT_MSG"; return 1; }
   log "*** REQUESTED COMMIT = $HASH_HEAD"
 
-  # Let's move onto the relevant branch, WITHOUT touching the current checked-out commit
-  # Since we have fetched with --set-upstream above this initializes the tracking branch
   log "*** Git initialize branch"
   git checkout -b "$GIT_BRANCH"
-
-  if [[ "$GIT_USER" != "$GIT_UPSTREAM_USER" ]]; then
-    log "*** Get upstream release tags"
-    # Always get the upstream release branch to get all release tags
-    # in case they have not been copied to user repository
-    git fetch upstream --shallow-since=2021-04-21 --tags "${GIT_BRANCH_RELEASE}"
-  fi
-
-  # Done! Directory is all set up as git repository now!
-
-  # In case we get a non-develop or non-main branch, we speculatively
-  # try to get these branches, so they can be checkout out with
-  # git checkout ${GIT_BRANCH_DEVELOP}
-  # without the need to set up the remote tracking information
-  # However, in a user repository, these may not be present, so we suppress output in these cases
-  if [[ $GIT_BRANCH != "${GIT_BRANCH_RELEASE}" ]]; then
-    OUTPUT=$(git fetch origin --shallow-since=2021-04-21 --tags "${GIT_BRANCH_RELEASE}" 2>&1)
-    if [[ $? -ne 128 ]]; then
-      log "*** Preparing ${GIT_BRANCH_RELEASE} in background"
-      echo -e "$OUTPUT"
-    fi
-    unset OUTPUT
-  fi
-  if [[ $GIT_BRANCH != "${GIT_BRANCH_DEVELOP}" ]]; then
-    OUTPUT=$(git fetch origin --shallow-since=2021-04-21 --tags "${GIT_BRANCH_DEVELOP}" 2>&1)
-    if [[ $? -ne 128 ]]; then
-      log "*** Preparing ${GIT_BRANCH_DEVELOP} in background"
-      echo -e "$OUTPUT"
-    fi
-    unset OUTPUT
-  fi
+  git branch --set-upstream-to="origin/$GIT_BRANCH" "$GIT_BRANCH"
 
   # Provide some status outputs to the user
   if [[ "${HASH_BRANCH}" != "${HASH_HEAD}" ]]; then
@@ -118,9 +112,9 @@ _git_convert_tardir_git_repo() {
   log "*** Git status *************************************"
   git status -sb
   log "*** Git log ****************************************"
-  git log --oneline "HEAD^..origin/$GIT_BRANCH"
+  git log --oneline --decorate -n 5 HEAD "origin/$GIT_BRANCH"
   log "*** Git describe ***********************************"
-  git describe --tag --dirty='-dirty'
+  git describe --always --dirty
   log "****************************************************"
 
   cp -f .githooks/* .git/hooks
@@ -138,7 +132,7 @@ _git_repo_check() {
 
 _run_init_git_repo_from_tardir() {
     cd "${INSTALLATION_PATH}" || exit_on_error
-    _git_convert_tardir_git_repo
+    _git_convert_tardir_git_repo || exit_on_error "$GIT_ABORT_MSG"
     _git_repo_check
 }
 

--- a/src/jukebox/jukebox/utils.py
+++ b/src/jukebox/jukebox/utils.py
@@ -292,7 +292,7 @@ def get_git_state():
 
     describe = "No git describe info"
     try:
-        sub = subprocess.run("git describe --tag --dirty='-dirty'",
+        sub = subprocess.run("git describe --always --dirty",
                              shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                              check=True)
         if sub.returncode == 0:


### PR DESCRIPTION
## Summary

- default Git transport to HTTPS with explicit SSH opt-in and fallback
- fetch only the requested branch at depth 1 without tags
- deepen by 50 when the tarball commit moved, then unshallow as correctness fallback
- check out the exact downloaded commit and configure its tracking branch
- register fork upstream remotes without fetching extra history
- use `git describe --always --dirty` and document later full-history/tag fetches

## Stack

#2674 is merged. This PR is restacked onto the updated `future3/develop` and now contains only the shallow-Git commit.

## Testing

- unchanged-tip, moved-tip, deepen, and unshallow scenarios passed against local bare remotes
- HTTPS, SSH fallback, tracking branch, normal pull configuration, and unfetched fork upstream remote verified
- all Trixie ARMv7/ARM64 installer scenarios passed on the unchanged commit tree; fresh checks are running for the restacked SHA