### PR TITLE
Optimize pull request CI coverage

### DIFF
--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_build_webapp_v3.yml
+++ b/.github/workflows/test_build_webapp_v3.yml
@@ -31,3 +31,7 @@ jobs:
 
       - name: Build Web App
         uses: ./.github/actions/build-webapp
+
+      - name: Test Web App
+        working-directory: ./src/webapp
+        run: CI=true npm test -- --runInBand

--- a/.github/workflows/test_docker_debian_codename_sub_v3.yml
+++ b/.github/workflows/test_docker_debian_codename_sub_v3.yml
@@ -9,6 +9,10 @@ on:
         platform:
           required: true
           type: string
+        test_scripts_json:
+          required: false
+          type: string
+          default: '["run_install_common.sh", "run_install_faststartup.sh", "run_install_webapp_local.sh", "run_install_webapp_download.sh"]'
         docker_image_name:
           required: false
           type: string
@@ -149,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_script: ['run_install_common.sh', 'run_install_faststartup.sh', 'run_install_webapp_local.sh', 'run_install_webapp_download.sh']
+        test_script: ${{ fromJSON(inputs.test_scripts_json) }}
 
     steps:
     - name: Set up QEMU

--- a/.github/workflows/test_docker_debian_v3.yml
+++ b/.github/workflows/test_docker_debian_v3.yml
@@ -57,6 +57,10 @@ jobs:
     with:
       debian_codename: 'trixie'
       platform: linux/amd64
+      test_scripts_json: >-
+        ${{ github.event_name == 'schedule'
+            && '["run_install_common.sh", "run_install_faststartup.sh", "run_install_webapp_local.sh", "run_install_webapp_download.sh"]'
+            || '["run_install_common.sh", "run_install_faststartup.sh", "run_install_webapp_local.sh"]' }}
 
   run_trixie_armv7:
     name: 'trixie armv7'
@@ -64,6 +68,10 @@ jobs:
     with:
       debian_codename: 'trixie'
       platform: linux/arm/v7
+      test_scripts_json: >-
+        ${{ github.event_name == 'schedule'
+            && '["run_install_common.sh", "run_install_faststartup.sh", "run_install_webapp_local.sh", "run_install_webapp_download.sh"]'
+            || '["run_install_webapp_download.sh"]' }}
 
   run_trixie_arm64:
     name: 'trixie arm64'
@@ -71,3 +79,7 @@ jobs:
     with:
       debian_codename: 'trixie'
       platform: linux/arm64
+      test_scripts_json: >-
+        ${{ github.event_name == 'schedule'
+            && '["run_install_common.sh", "run_install_faststartup.sh", "run_install_webapp_local.sh", "run_install_webapp_download.sh"]'
+            || '["run_install_webapp_download.sh"]' }}


### PR DESCRIPTION
## Summary

- run the existing Jest suite after the web app build, reusing installed dependencies
- test Python 3.11 and 3.13, matching the deployed Bookworm and Trixie runtimes
- select installer scripts per architecture for pull requests and pushes while preserving the full scheduled matrix

## CI impact

- installer pull request/push runs: 19 -> 12 jobs (7 fewer, 37% reduction)
- installer test matrix: 12 -> 5 jobs (7 fewer, 58% reduction in test-job runner work)
- scheduled installer runs: unchanged at 19 jobs with all four scripts on amd64, ARMv7, and ARM64
- Python matrix workers: 5 -> 2 (60% reduction); including Coveralls finalization, 6 -> 3 jobs
- web app workflow: remains one job and now runs all 6 Jest tests after building

Wall-clock savings depend on runner scheduling and cache state. The routine workflows avoid seven installer test workloads, including six emulated ARM workloads, and three complete Python setup/test workloads per matching run.

## Verification

- parsed all modified YAML workflows
- passed `actionlint` syntax validation for all modified workflows
- passed `CI=true npm test -- --runInBand` (6 tests)
- passed `npm run build` (existing ESLint warnings only)
- audited expansion to 12 change-driven installer jobs and 19 scheduled jobs
- confirmed the shared web build action, release workflow, architecture builds, cleanup, artifacts, ARMv6 smoke test, and Coveralls finalization remain unchanged