### PR TITLE
Publish prebuilt Web App bundles for development branches

### DIFF
--- a/.github/actions/bundle-webapp/action.yml
+++ b/.github/actions/bundle-webapp/action.yml
@@ -1,0 +1,38 @@
+name: Bundle Web App
+description: 'Package a built Web App for installation'
+inputs:
+  webapp-root-path:
+    description: 'Root path of the built Web App'
+    required: false
+    default: './src/webapp'
+outputs:
+  commit-sha:
+    description: 'Commit containing the Web App sources'
+    value: ${{ steps.vars.outputs.commit-sha }}
+  bundle-name:
+    description: 'Filename of the Web App bundle'
+    value: ${{ steps.vars.outputs.bundle-name }}
+  bundle-path:
+    description: 'Path of the Web App bundle'
+    value: ${{ steps.vars.outputs.bundle-path }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set bundle variables
+      id: vars
+      working-directory: ${{ inputs.webapp-root-path }}
+      shell: bash
+      run: |
+        commit_sha=$(git rev-parse HEAD)
+        bundle_name="webapp-build-${commit_sha:0:10}.tar.gz"
+        echo "commit-sha=${commit_sha}" >> "$GITHUB_OUTPUT"
+        echo "bundle-name=${bundle_name}" >> "$GITHUB_OUTPUT"
+        echo "bundle-path=${PWD}/${bundle_name}" >> "$GITHUB_OUTPUT"
+
+    - name: Create bundle
+      working-directory: ${{ inputs.webapp-root-path }}
+      shell: bash
+      env:
+        BUNDLE_NAME: ${{ steps.vars.outputs.bundle-name }}
+      run: tar -czf "${BUNDLE_NAME}" build

--- a/.github/workflows/bundle_webapp_and_release_v3.yml
+++ b/.github/workflows/bundle_webapp_and_release_v3.yml
@@ -75,8 +75,8 @@ jobs:
     outputs:
       tag_name: ${{ needs.check.outputs.tag_name }}
       release_type: ${{ needs.check.outputs.release_type }}
-      commit_sha: ${{ steps.vars.outputs.commit_sha }}
-      webapp_bundle_name: ${{ steps.vars.outputs.webapp_bundle_name }}
+      commit_sha: ${{ steps.bundle-webapp.outputs.commit-sha }}
+      webapp_bundle_name: ${{ steps.bundle-webapp.outputs.bundle-name }}
       webapp_bundle_name_latest: ${{ steps.vars.outputs.webapp_bundle_name_latest }}
 
     steps:
@@ -84,27 +84,25 @@ jobs:
 
       - name: Set Output vars
         id: vars
-        env:
-          COMMIT_SHA: ${{ github.sha }}
         run: |
-          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
-          echo "webapp_bundle_name=webapp-build-${COMMIT_SHA:0:10}.tar.gz" >> $GITHUB_OUTPUT
           echo "webapp_bundle_name_latest=webapp-build-latest.tar.gz" >> $GITHUB_OUTPUT
 
       - name: Build Web App
         id: build-webapp
         uses: ./.github/actions/build-webapp
 
-      - name: Create Bundle
-        working-directory: ${{ steps.build-webapp.outputs.webapp-root-path }}
-        run: |
-          tar -czvf ${{ steps.vars.outputs.webapp_bundle_name }} build
+      - name: Bundle Web App
+        id: bundle-webapp
+        uses: ./.github/actions/bundle-webapp
+        with:
+          webapp-root-path: ${{ steps.build-webapp.outputs.webapp-root-path }}
 
       - name: Artifact Upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.vars.outputs.webapp_bundle_name }}
-          path: ${{ steps.build-webapp.outputs.webapp-root-path }}/${{ steps.vars.outputs.webapp_bundle_name }}
+          name: ${{ steps.bundle-webapp.outputs.bundle-name }}
+          path: ${{ steps.bundle-webapp.outputs.bundle-path }}
+          if-no-files-found: error
           retention-days: 5
 
   release:

--- a/.github/workflows/test_build_webapp_v3.yml
+++ b/.github/workflows/test_build_webapp_v3.yml
@@ -10,6 +10,7 @@ on:
     paths:
         - '.github/workflows/test_build_webapp_v3.yml'
         - '.github/actions/build-webapp/**'
+        - '.github/actions/bundle-webapp/**'
         - 'src/webapp/**'
   pull_request:
     # The branches below must be a subset of the branches above
@@ -19,12 +20,17 @@ on:
     paths:
         - '.github/workflows/test_build_webapp_v3.yml'
         - '.github/actions/build-webapp/**'
+        - '.github/actions/bundle-webapp/**'
         - 'src/webapp/**'
 
 jobs:
 
   build:
     runs-on: ubuntu-latest
+
+    outputs:
+      commit_sha: ${{ steps.bundle-webapp.outputs.commit-sha }}
+      webapp_bundle_name: ${{ steps.bundle-webapp.outputs.bundle-name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -35,3 +41,28 @@ jobs:
       - name: Test Web App
         working-directory: ./src/webapp
         run: CI=true npm test -- --runInBand
+
+      - name: Bundle Web App
+        id: bundle-webapp
+        uses: ./.github/actions/bundle-webapp
+
+      - name: Upload Web App artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.bundle-webapp.outputs.bundle-name }}
+          path: ${{ steps.bundle-webapp.outputs.bundle-path }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Add bundle to workflow summary
+        env:
+          BUNDLE_NAME: ${{ steps.bundle-webapp.outputs.bundle-name }}
+          COMMIT_SHA: ${{ steps.bundle-webapp.outputs.commit-sha }}
+        run: |
+          {
+            echo "### Web App bundle"
+            echo
+            echo "- Artifact: \`${BUNDLE_NAME}\`"
+            echo "- Source commit: \`${COMMIT_SHA}\`"
+            echo "- Retention: 14 days"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test_build_webapp_v3.yml
+++ b/.github/workflows/test_build_webapp_v3.yml
@@ -7,11 +7,6 @@ on:
   push:
     branches:
         - 'future3/**'
-    paths:
-        - '.github/workflows/test_build_webapp_v3.yml'
-        - '.github/actions/build-webapp/**'
-        - '.github/actions/bundle-webapp/**'
-        - 'src/webapp/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
@@ -22,6 +17,9 @@ on:
         - '.github/actions/build-webapp/**'
         - '.github/actions/bundle-webapp/**'
         - 'src/webapp/**'
+
+permissions:
+  contents: read
 
 jobs:
 
@@ -65,4 +63,76 @@ jobs:
             echo "- Artifact: \`${BUNDLE_NAME}\`"
             echo "- Source commit: \`${COMMIT_SHA}\`"
             echo "- Retention: 14 days"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    if: ${{ github.event_name == 'push' }}
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    env:
+      GH_REPO: ${{ github.repository }}
+      RELEASE_TAG: webapp-development
+
+    concurrency:
+      group: development-webapp-release-${{ github.repository }}
+      cancel-in-progress: false
+
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - name: Download Web App artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.webapp_bundle_name }}
+
+      - name: Create development release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.build.outputs.commit_sha }}
+        run: |
+          if ! gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            gh release create "${RELEASE_TAG}" \
+              --target "${SOURCE_SHA}" \
+              --title "Development Web App builds" \
+              --notes "Commit-addressed Web App bundles for development installations. The newest 20 bundles are retained." \
+              --prerelease
+          fi
+
+      - name: Publish exact-commit bundle
+        env:
+          BUNDLE_NAME: ${{ needs.build.outputs.webapp_bundle_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${RELEASE_TAG}" "${BUNDLE_NAME}" --clobber
+
+      - name: Prune old development bundles
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEEP_ASSETS: 20
+        run: |
+          release_id=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+            --jq '.id')
+          mapfile -t stale_asset_ids < <(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
+              --jq "sort_by(.created_at) | reverse | .[${KEEP_ASSETS}:][] | .id"
+          )
+          for asset_id in "${stale_asset_ids[@]}"; do
+            gh api \
+              --method DELETE \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+          done
+
+      - name: Add release asset to workflow summary
+        env:
+          BUNDLE_NAME: ${{ needs.build.outputs.webapp_bundle_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          {
+            echo "### Public development bundle"
+            echo
+            echo "https://github.com/${REPOSITORY}/releases/download/${RELEASE_TAG}/${BUNDLE_NAME}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test_docker_debian_v3.yml
+++ b/.github/workflows/test_docker_debian_v3.yml
@@ -37,6 +37,14 @@ concurrency:
 
 jobs:
 
+  test_webapp_bundle_download:
+    name: 'Web App bundle download selection'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test Web App bundle download selection
+        run: bash ./ci/installation/test_webapp_bundle_download.sh
+
   run_raspbian_armv6_zmq:
     name: 'Raspberry Pi Debian bookworm armv6 ZMQ packages'
     runs-on: ubuntu-latest

--- a/ci/installation/run_install_webapp_download.sh
+++ b/ci/installation/run_install_webapp_download.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(dirname "$SOURCE")"
 LOCAL_INSTALL_SCRIPT_PATH="${INSTALL_SCRIPT_PATH:-${SCRIPT_DIR}/../../installation}"
 LOCAL_INSTALL_SCRIPT_PATH="${LOCAL_INSTALL_SCRIPT_PATH%/}"
 
-
+export ENABLE_WEBAPP_PROD_DOWNLOAD=true
 # Run installation (in interactive mode)
 # y - start setup
 # n - use static ip
@@ -24,7 +24,7 @@ LOCAL_INSTALL_SCRIPT_PATH="${LOCAL_INSTALL_SCRIPT_PATH%/}"
 # n - setup rfid reader
 # n - setup samba
 # y - setup webapp
-# n - build webapp
+# - - exact bundle download (forced, with release fallback)
 # y - setup kiosk mode
 # n - reboot
 
@@ -37,7 +37,6 @@ n
 n
 n
 y
-n
 y
 n
 '

--- a/ci/installation/run_install_webapp_local.sh
+++ b/ci/installation/run_install_webapp_local.sh
@@ -24,7 +24,7 @@ export ENABLE_WEBAPP_PROD_DOWNLOAD=false
 # n - setup rfid reader
 # n - setup samba
 # y - setup webapp
-# y - build webapp
+# - - exact bundle download (skipped due to forced local build)
 # y - setup kiosk mode
 # n - reboot
 
@@ -36,7 +36,6 @@ n
 n
 n
 n
-y
 y
 y
 n

--- a/ci/installation/test_webapp_bundle_download.sh
+++ b/ci/installation/test_webapp_bundle_download.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SOURCE="${BASH_SOURCE[0]}"
+SCRIPT_DIR="$(dirname "$SOURCE")"
+REPOSITORY_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+source "${REPOSITORY_ROOT}/installation/routines/setup_jukebox_webapp.sh"
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+INSTALLATION_PATH="${TEST_ROOT}/RPi-Jukebox-RFID"
+GIT_REPO_NAME="RPi-Jukebox-RFID"
+GIT_UPSTREAM_USER="MiczFlor"
+GIT_USER="contributor"
+TEST_COMMIT="0123456789abcdef0123456789abcdef01234567"
+TEST_VERSION="3.7.0-alpha"
+ATTEMPTED_URLS=()
+AVAILABLE_URL=""
+
+mkdir -p "${INSTALLATION_PATH}/src/webapp"
+mkdir -p "${TEST_ROOT}/payload/build"
+echo "test bundle" > "${TEST_ROOT}/payload/build/index.html"
+tar -czf "${TEST_ROOT}/fixture.tar.gz" -C "${TEST_ROOT}/payload" build
+
+print_lc() {
+    :
+}
+
+print_c() {
+    :
+}
+
+clear_c() {
+    :
+}
+
+log() {
+    :
+}
+
+python() {
+    echo "${TEST_VERSION}"
+}
+
+git() {
+    echo "${TEST_COMMIT}"
+}
+
+validate_url() {
+    ATTEMPTED_URLS+=("$1")
+    [[ "$1" == "${AVAILABLE_URL}" ]]
+}
+
+download_from_url() {
+    cp "${TEST_ROOT}/fixture.tar.gz" "$2"
+}
+
+exit_on_error() {
+    echo "$*" >&2
+    exit 1
+}
+
+reset_download() {
+    ATTEMPTED_URLS=()
+    AVAILABLE_URL="$1"
+    rm -rf "${INSTALLATION_PATH}/src/webapp/build"
+}
+
+assert_attempts() {
+    local expected=("$@")
+    local index
+
+    [[ "${#ATTEMPTED_URLS[@]}" -eq "${#expected[@]}" ]]
+    for index in "${!expected[@]}"; do
+        [[ "${ATTEMPTED_URLS[$index]}" == "${expected[$index]}" ]]
+    done
+}
+
+BUNDLE_NAME="webapp-build-${TEST_COMMIT:0:10}.tar.gz"
+SOURCE_DEVELOPMENT_URL="https://github.com/${GIT_USER}/${GIT_REPO_NAME}/releases/download/${WEBAPP_DEVELOPMENT_RELEASE_TAG}/${BUNDLE_NAME}"
+SOURCE_RELEASE_URL="https://github.com/${GIT_USER}/${GIT_REPO_NAME}/releases/download/v${TEST_VERSION}/${BUNDLE_NAME}"
+UPSTREAM_DEVELOPMENT_URL="https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}/releases/download/${WEBAPP_DEVELOPMENT_RELEASE_TAG}/${BUNDLE_NAME}"
+UPSTREAM_RELEASE_URL="https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}/releases/download/v${TEST_VERSION}/${BUNDLE_NAME}"
+UPSTREAM_LATEST_URL="https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}/releases/download/v${TEST_VERSION}/webapp-build-latest.tar.gz"
+
+ENABLE_WEBAPP_PROD_DOWNLOAD=auto
+reset_download "${SOURCE_DEVELOPMENT_URL}"
+_jukebox_webapp_download
+assert_attempts "${SOURCE_DEVELOPMENT_URL}"
+[[ -f "${INSTALLATION_PATH}/src/webapp/build/index.html" ]]
+
+reset_download "not-available"
+if _jukebox_webapp_download; then
+    echo "Automatic download unexpectedly succeeded" >&2
+    exit 1
+fi
+assert_attempts \
+    "${SOURCE_DEVELOPMENT_URL}" \
+    "${SOURCE_RELEASE_URL}" \
+    "${UPSTREAM_DEVELOPMENT_URL}" \
+    "${UPSTREAM_RELEASE_URL}"
+
+ENABLE_WEBAPP_PROD_DOWNLOAD=true
+reset_download "${UPSTREAM_LATEST_URL}"
+_jukebox_webapp_download
+assert_attempts \
+    "${SOURCE_DEVELOPMENT_URL}" \
+    "${SOURCE_RELEASE_URL}" \
+    "${UPSTREAM_DEVELOPMENT_URL}" \
+    "${UPSTREAM_RELEASE_URL}" \
+    "${UPSTREAM_LATEST_URL}"
+
+GIT_USER="miczflor"
+ENABLE_WEBAPP_PROD_DOWNLOAD=release-only
+SOURCE_RELEASE_URL="https://github.com/${GIT_USER}/${GIT_REPO_NAME}/releases/download/v${TEST_VERSION}/${BUNDLE_NAME}"
+reset_download "${SOURCE_RELEASE_URL}"
+_jukebox_webapp_download
+assert_attempts "${SOURCE_RELEASE_URL}"
+
+source "${REPOSITORY_ROOT}/installation/routines/customize_options.sh"
+
+GIT_BRANCH="future3/test-bundles"
+GIT_BRANCH_RELEASE="future3/main"
+GIT_BRANCH_DEVELOP="future3/develop"
+GIT_USER="contributor"
+GIT_UPSTREAM_USER="MiczFlor"
+CI_RUNNING=false
+
+ENABLE_WEBAPP_PROD_DOWNLOAD=release-only
+_option_webapp_devel_build <<< ''
+[[ "${ENABLE_WEBAPP_PROD_DOWNLOAD}" == auto ]]
+
+ENABLE_WEBAPP_PROD_DOWNLOAD=auto
+_option_webapp_devel_build <<< 'n'
+[[ "${ENABLE_WEBAPP_PROD_DOWNLOAD}" == false ]]
+
+source "${REPOSITORY_ROOT}/installation/routines/prepare_dependencies.sh"
+
+# Bash 3.2 treats an empty array expansion as unset under nounset.
+set +u
+
+get_args_from_file() {
+    echo "tar"
+}
+
+get_architecture() {
+    echo "amd64"
+}
+
+SETUP_MPD=false
+ENABLE_SAMBA=false
+ENABLE_WEBAPP=true
+ENABLE_KIOSK_MODE=false
+ENABLE_AUTOHOTSPOT=false
+ENABLE_WEBAPP_PROD_DOWNLOAD=auto
+_collect_apt_packages
+[[ " ${APT_PACKAGES[*]} " == *" nodejs "* ]]
+[[ " ${APT_PACKAGES[*]} " == *" npm "* ]]
+
+ENABLE_WEBAPP_PROD_DOWNLOAD=true
+_collect_apt_packages
+[[ " ${APT_PACKAGES[*]} " != *" nodejs "* ]]
+[[ " ${APT_PACKAGES[*]} " != *" npm "* ]]
+
+LOCAL_BUILD_CALLED=false
+
+_jukebox_webapp_build() {
+    LOCAL_BUILD_CALLED=true
+}
+
+_jukebox_webapp_register_as_system_service_with_nginx() {
+    :
+}
+
+_jukebox_webapp_check() {
+    :
+}
+
+GIT_USER="contributor"
+AVAILABLE_URL="not-available"
+ENABLE_WEBAPP_PROD_DOWNLOAD=auto
+_run_setup_jukebox_webapp
+[[ "${LOCAL_BUILD_CALLED}" == true ]]
+
+echo "Web App bundle download tests passed"

--- a/ci/installation/test_webapp_bundle_download.sh
+++ b/ci/installation/test_webapp_bundle_download.sh
@@ -86,24 +86,12 @@ UPSTREAM_DEVELOPMENT_URL="https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAM
 UPSTREAM_RELEASE_URL="https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}/releases/download/v${TEST_VERSION}/${BUNDLE_NAME}"
 UPSTREAM_LATEST_URL="https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}/releases/download/v${TEST_VERSION}/webapp-build-latest.tar.gz"
 
-ENABLE_WEBAPP_PROD_DOWNLOAD=auto
+ENABLE_WEBAPP_PROD_DOWNLOAD=true
 reset_download "${SOURCE_DEVELOPMENT_URL}"
 _jukebox_webapp_download
 assert_attempts "${SOURCE_DEVELOPMENT_URL}"
 [[ -f "${INSTALLATION_PATH}/src/webapp/build/index.html" ]]
 
-reset_download "not-available"
-if _jukebox_webapp_download; then
-    echo "Automatic download unexpectedly succeeded" >&2
-    exit 1
-fi
-assert_attempts \
-    "${SOURCE_DEVELOPMENT_URL}" \
-    "${SOURCE_RELEASE_URL}" \
-    "${UPSTREAM_DEVELOPMENT_URL}" \
-    "${UPSTREAM_RELEASE_URL}"
-
-ENABLE_WEBAPP_PROD_DOWNLOAD=true
 reset_download "${UPSTREAM_LATEST_URL}"
 _jukebox_webapp_download
 assert_attempts \
@@ -131,10 +119,10 @@ CI_RUNNING=false
 
 ENABLE_WEBAPP_PROD_DOWNLOAD=release-only
 _option_webapp_devel_build <<< ''
-[[ "${ENABLE_WEBAPP_PROD_DOWNLOAD}" == auto ]]
+[[ "${ENABLE_WEBAPP_PROD_DOWNLOAD}" == true ]]
 
-ENABLE_WEBAPP_PROD_DOWNLOAD=auto
-_option_webapp_devel_build <<< 'n'
+ENABLE_WEBAPP_PROD_DOWNLOAD=release-only
+_option_webapp_devel_build <<< 'y'
 [[ "${ENABLE_WEBAPP_PROD_DOWNLOAD}" == false ]]
 
 source "${REPOSITORY_ROOT}/installation/routines/prepare_dependencies.sh"
@@ -155,7 +143,7 @@ ENABLE_SAMBA=false
 ENABLE_WEBAPP=true
 ENABLE_KIOSK_MODE=false
 ENABLE_AUTOHOTSPOT=false
-ENABLE_WEBAPP_PROD_DOWNLOAD=auto
+ENABLE_WEBAPP_PROD_DOWNLOAD=false
 _collect_apt_packages
 [[ " ${APT_PACKAGES[*]} " == *" nodejs "* ]]
 [[ " ${APT_PACKAGES[*]} " == *" npm "* ]]
@@ -180,8 +168,7 @@ _jukebox_webapp_check() {
 }
 
 GIT_USER="contributor"
-AVAILABLE_URL="not-available"
-ENABLE_WEBAPP_PROD_DOWNLOAD=auto
+ENABLE_WEBAPP_PROD_DOWNLOAD=false
 _run_setup_jukebox_webapp
 [[ "${LOCAL_BUILD_CALLED}" == true ]]
 

--- a/documentation/builders/installation.md
+++ b/documentation/builders/installation.md
@@ -84,7 +84,7 @@ git fetch origin --tags
 
 > [!NOTE]
 > The Installation of the official repository's release branches ([Stable Release](#stable-release) and [Pre-Release](#pre-release)) will deploy a pre-build bundle of the Web App.
-> If you install another branch or from a fork repository, the Web App needs to be built locally. This is part of the installation process. See the the developers [Web App](../developers/webapp.md) documentation for further details.
+> For another branch or a fork repository, the installer first looks for a CI bundle matching the exact commit. If it is unavailable, the Web App is built locally. See the developers [Web App](../developers/webapp.md) documentation for further details.
 
 ### Logs
 

--- a/documentation/builders/installation.md
+++ b/documentation/builders/installation.md
@@ -84,7 +84,7 @@ git fetch origin --tags
 
 > [!NOTE]
 > The Installation of the official repository's release branches ([Stable Release](#stable-release) and [Pre-Release](#pre-release)) will deploy a pre-build bundle of the Web App.
-> For another branch or a fork repository, the installer first looks for a CI bundle matching the exact commit. If it is unavailable, the Web App is built locally. See the developers [Web App](../developers/webapp.md) documentation for further details.
+> For another branch or a fork repository, the installer first looks for a CI bundle matching the exact commit and otherwise downloads the latest applicable pre-built release bundle. A local build is optional and disabled by default. See the developers [Web App](../developers/webapp.md) documentation for further details.
 
 ### Logs
 

--- a/documentation/developers/webapp.md
+++ b/documentation/developers/webapp.md
@@ -1,6 +1,22 @@
 # Web App
 
-The Web App sources are located in `src/webapp`. A pre-build bundle of the Web App is deployed when installing from an official release branch. If you install from a feature branch or a fork repository, the Web App needs to be built locally. This requires Node to be installed and is part of the installation process.
+The Web App sources are located in `src/webapp`. A pre-built bundle of the Web App is deployed when installing from an official release branch.
+
+Pushes to `future3/**` branches also publish a short-lived set of commit-addressed bundles to the `webapp-development` prerelease in the source repository. For feature branches and forks, the installer offers to download the bundle matching the installed commit. If that exact bundle is unavailable, it builds the Web App locally.
+
+Repository Actions must be enabled and the workflow token must have `contents: write` permission for a fork to publish development bundles.
+
+## Download a CI bundle manually
+
+Successful Web App workflow runs retain the exact-commit bundle as a GitHub Actions artifact for 14 days. Signed-in developers can download it with the GitHub CLI:
+
+```bash
+gh run download RUN_ID \
+  --repo OWNER/RPi-Jukebox-RFID \
+  --name webapp-build-0123456789.tar.gz
+```
+
+GitHub Actions artifacts require authentication. The installer uses the public prerelease asset instead.
 
 ## Install node manually
 

--- a/documentation/developers/webapp.md
+++ b/documentation/developers/webapp.md
@@ -2,7 +2,7 @@
 
 The Web App sources are located in `src/webapp`. A pre-built bundle of the Web App is deployed when installing from an official release branch.
 
-Pushes to `future3/**` branches also publish a short-lived set of commit-addressed bundles to the `webapp-development` prerelease in the source repository. For feature branches and forks, the installer offers to download the bundle matching the installed commit. If that exact bundle is unavailable, it builds the Web App locally.
+Pushes to `future3/**` branches also publish a short-lived set of commit-addressed bundles to the `webapp-development` prerelease in the source repository. For feature branches and forks, the installer uses the bundle matching the installed commit when available and otherwise downloads the latest applicable pre-built release bundle. Building locally is an explicit opt-in because it installs Node and can take a long time on Raspberry Pi devices.
 
 Repository Actions must be enabled and the workflow token must have `contents: write` permission for a fork to publish development bundles.
 

--- a/installation/includes/01_default_config.sh
+++ b/installation/includes/01_default_config.sh
@@ -23,10 +23,9 @@ DISABLE_ONBOARD_AUDIO=false
 # to SSH; a failed SSH fetch still falls back to HTTPS.
 GIT_USE_SSH=${GIT_USE_SSH:-"false"}
 
-# A pre-build binary for the Web App is only available for release builds
-# For non-production builds, the Wep App must be build locally
 # Valid values
 # - release-only: download in release branch only
-# - true: force download even in non-release branch
+# - auto: download an exact-commit development bundle or build locally
+# - true: force download, allowing the latest release bundle as a fallback
 # - false: never download
 ENABLE_WEBAPP_PROD_DOWNLOAD=${ENABLE_WEBAPP_PROD_DOWNLOAD:-"release-only"}

--- a/installation/includes/01_default_config.sh
+++ b/installation/includes/01_default_config.sh
@@ -25,7 +25,6 @@ GIT_USE_SSH=${GIT_USE_SSH:-"false"}
 
 # Valid values
 # - release-only: download in release branch only
-# - auto: download an exact-commit development bundle or build locally
 # - true: force download, allowing the latest release bundle as a fallback
 # - false: never download
 ENABLE_WEBAPP_PROD_DOWNLOAD=${ENABLE_WEBAPP_PROD_DOWNLOAD:-"release-only"}

--- a/installation/routines/customize_options.sh
+++ b/installation/routines/customize_options.sh
@@ -343,29 +343,25 @@ Disable Pi's on-chip audio (headphone / jack output)? [y/N]"
 _option_webapp_devel_build() {
   # Let's detect if we are on the official release branch
   if [[ "$GIT_BRANCH" != "${GIT_BRANCH_RELEASE}" && "$GIT_BRANCH" != "${GIT_BRANCH_DEVELOP}" ]] || [[ "$GIT_USER" != "$GIT_UPSTREAM_USER" ]] || [[ "$CI_RUNNING" == "true" ]] ; then
-    # Unless ENABLE_WEBAPP_PROD_DOWNLOAD is forced to true by user override, do not download a potentially stale build
+    # Development branches default to an exact-commit download with a local build fallback.
     if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == "release-only" ]]; then
-      ENABLE_WEBAPP_PROD_DOWNLOAD=false
+      ENABLE_WEBAPP_PROD_DOWNLOAD=auto
     fi
-    if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" != true && "$ENABLE_WEBAPP_PROD_DOWNLOAD" != "release-only" ]]; then
+    if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == auto ]]; then
       clear_c
       print_c "--------------------- WEB APP BUILD ---------------------
 
 You are installing from a non-release branch
 and/or an unofficial repository.
-Therefore a pre-build Web App is not available
-and it needs to be built locally.
-This requires Node to be installed.
+The installer can download a pre-built Web App
+for this exact commit when CI has published one.
+If none is available, it will build locally.
 
-If you decline, the lastest pre-build version
-from the official repository will be installed.
-This can lead to incompatibilities.
-
-Do you want to build the Web App? [Y/n]"
+Try the exact pre-built Web App first? [Y/n]"
       read -r response
       case "$response" in
         [nN][oO]|[nN])
-            ENABLE_WEBAPP_PROD_DOWNLOAD=true
+            ENABLE_WEBAPP_PROD_DOWNLOAD=false
             ;;
         *)
             ;;

--- a/installation/routines/customize_options.sh
+++ b/installation/routines/customize_options.sh
@@ -343,24 +343,25 @@ Disable Pi's on-chip audio (headphone / jack output)? [y/N]"
 _option_webapp_devel_build() {
   # Let's detect if we are on the official release branch
   if [[ "$GIT_BRANCH" != "${GIT_BRANCH_RELEASE}" && "$GIT_BRANCH" != "${GIT_BRANCH_DEVELOP}" ]] || [[ "$GIT_USER" != "$GIT_UPSTREAM_USER" ]] || [[ "$CI_RUNNING" == "true" ]] ; then
-    # Development branches default to an exact-commit download with a local build fallback.
+    # Development branches default to a pre-built bundle without installing Node.
     if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == "release-only" ]]; then
-      ENABLE_WEBAPP_PROD_DOWNLOAD=auto
-    fi
-    if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == auto ]]; then
+      ENABLE_WEBAPP_PROD_DOWNLOAD=true
       clear_c
       print_c "--------------------- WEB APP BUILD ---------------------
 
 You are installing from a non-release branch
 and/or an unofficial repository.
-The installer can download a pre-built Web App
-for this exact commit when CI has published one.
-If none is available, it will build locally.
+A pre-built Web App for this exact commit will
+be downloaded when available. Otherwise, the
+latest applicable pre-built version is used.
 
-Try the exact pre-built Web App first? [Y/n]"
+Building locally installs Node and can take a
+long time on Raspberry Pi devices.
+
+Do you want to build the Web App locally? [y/N]"
       read -r response
       case "$response" in
-        [nN][oO]|[nN])
+        [yY][eE][sS]|[yY])
             ENABLE_WEBAPP_PROD_DOWNLOAD=false
             ;;
         *)

--- a/installation/routines/prepare_dependencies.sh
+++ b/installation/routines/prepare_dependencies.sh
@@ -40,8 +40,7 @@ _collect_apt_packages() {
         # A trailing '-' asks APT to remove Apache in the same transaction.
         _add_apt_packages nginx apache2-
 
-        if [[ ( "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false || "$ENABLE_WEBAPP_PROD_DOWNLOAD" == auto ) \
-            && "$(get_architecture)" != "armv6" ]]; then
+        if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false && "$(get_architecture)" != "armv6" ]]; then
             _add_apt_packages nodejs npm
         fi
     fi

--- a/installation/routines/prepare_dependencies.sh
+++ b/installation/routines/prepare_dependencies.sh
@@ -40,7 +40,8 @@ _collect_apt_packages() {
         # A trailing '-' asks APT to remove Apache in the same transaction.
         _add_apt_packages nginx apache2-
 
-        if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false && "$(get_architecture)" != "armv6" ]]; then
+        if [[ ( "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false || "$ENABLE_WEBAPP_PROD_DOWNLOAD" == auto ) \
+            && "$(get_architecture)" != "armv6" ]]; then
             _add_apt_packages nodejs npm
         fi
     fi

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -181,15 +181,7 @@ _jukebox_webapp_check() {
 }
 
 _run_setup_jukebox_webapp() {
-    if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == auto ]]; then
-        if ! _jukebox_webapp_download; then
-            print_lc "  No exact Web App bundle found; building locally."
-            if [[ "$(get_architecture)" == "armv6" ]]; then
-                _jukebox_webapp_install_node_armv6
-            fi
-            _jukebox_webapp_build
-        fi
-    elif [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == true || "$ENABLE_WEBAPP_PROD_DOWNLOAD" == "release-only" ]] ; then
+    if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == true || "$ENABLE_WEBAPP_PROD_DOWNLOAD" == "release-only" ]] ; then
         _jukebox_webapp_download || exit_on_error "No pre-built Web App bundle found!"
     elif [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false ]]; then
         if [[ "$(get_architecture)" == "armv6" ]]; then

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -2,11 +2,13 @@
 
 # Constants
 WEBAPP_NGINX_SITE_DEFAULT_CONF="/etc/nginx/sites-available/default"
+WEBAPP_DEVELOPMENT_RELEASE_TAG="webapp-development"
 
 # Node version for ARMv6 (unofficial builds)
 NODE_ARMv6_VERSION=v20.10.0
 
 OPTIONAL_WEBAPP_BUILD_FAILED=false
+WEBAPP_BUILT_LOCALLY=false
 
 _jukebox_webapp_install_node_armv6() {
     local node_version_installed=$(node -v 2>/dev/null)
@@ -45,6 +47,7 @@ _jukebox_webapp_install_node_armv6() {
 
 _jukebox_webapp_build() {
     print_lc "  Building Web App"
+    WEBAPP_BUILT_LOCALLY=true
     cd "${INSTALLATION_PATH}/src/webapp" || exit_on_error
     if ! ./run_rebuild.sh -u ; then
         print_lc "    Web App build failed!
@@ -59,28 +62,75 @@ _jukebox_webapp_build() {
     fi
 }
 
+_jukebox_webapp_try_download() {
+  local download_url="$1"
+  local tar_filename="$2"
+
+  print_lc "    Checking ${download_url}"
+  if ! validate_url "${download_url}"; then
+    log "    Web App bundle not found: ${download_url}"
+    return 1
+  fi
+
+  print_lc "    Using Web App bundle: ${download_url}"
+  download_from_url "${download_url}" "${tar_filename}"
+}
+
 _jukebox_webapp_download() {
   print_lc "  Downloading Web App"
-  local jukebox_version=$(python "${INSTALLATION_PATH}/src/jukebox/jukebox/version.py")
-  local git_head_hash=$(git -C "${INSTALLATION_PATH}" rev-parse --verify --quiet HEAD)
-  local git_head_hash_short=${git_head_hash:0:10}
+  local jukebox_version
+  local git_head_hash
+  local git_head_hash_short
+  local git_user_normalized
+  local git_upstream_user_normalized
   local tar_filename="webapp-build.tar.gz"
-  # URL must be set to default repo as installation can be run from different repos as well where releases may not exist
-  local download_url_commit="https://github.com/${GIT_UPSTREAM_USER}/RPi-Jukebox-RFID/releases/download/v${jukebox_version}/webapp-build-${git_head_hash_short}.tar.gz"
-  local download_url_latest="https://github.com/${GIT_UPSTREAM_USER}/RPi-Jukebox-RFID/releases/download/v${jukebox_version}/webapp-build-latest.tar.gz"
+  local bundle_name
+  local source_development_url
+  local source_release_url
+  local upstream_development_url
+  local upstream_release_url
+  local upstream_latest_url
+  local bundle_downloaded=false
+
+  jukebox_version=$(python "${INSTALLATION_PATH}/src/jukebox/jukebox/version.py") \
+    || exit_on_error "Could not determine the Jukebox version"
+  git_head_hash=$(git -C "${INSTALLATION_PATH}" rev-parse --verify --quiet HEAD) \
+    || exit_on_error "Could not determine the installed commit"
+  git_head_hash_short=${git_head_hash:0:10}
+  bundle_name="webapp-build-${git_head_hash_short}.tar.gz"
+  source_development_url="https://github.com/${GIT_USER}/${GIT_REPO_NAME}/releases/download/${WEBAPP_DEVELOPMENT_RELEASE_TAG}/${bundle_name}"
+  source_release_url="https://github.com/${GIT_USER}/${GIT_REPO_NAME}/releases/download/v${jukebox_version}/${bundle_name}"
+  upstream_development_url="https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}/releases/download/${WEBAPP_DEVELOPMENT_RELEASE_TAG}/${bundle_name}"
+  upstream_release_url="https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}/releases/download/v${jukebox_version}/${bundle_name}"
+  upstream_latest_url="https://github.com/${GIT_UPSTREAM_USER}/${GIT_REPO_NAME}/releases/download/v${jukebox_version}/webapp-build-latest.tar.gz"
+  git_user_normalized=$(printf '%s' "${GIT_USER}" | tr '[:upper:]' '[:lower:]')
+  git_upstream_user_normalized=$(printf '%s' "${GIT_UPSTREAM_USER}" | tr '[:upper:]' '[:lower:]')
 
   cd "${INSTALLATION_PATH}/src/webapp" || exit_on_error
-  if validate_url ${download_url_commit} ; then
-    log "    DOWNLOAD_URL ${download_url_commit}"
-    download_from_url ${download_url_commit} ${tar_filename}
-  elif [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == true ]] && validate_url ${download_url_latest} ; then
-    log "    DOWNLOAD_URL ${download_url_latest}"
-    download_from_url ${download_url_latest} ${tar_filename}
-  else
-    exit_on_error "No prebuild Web App bundle found!"
+
+  if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" != "release-only" ]] \
+      && _jukebox_webapp_try_download "${source_development_url}" "${tar_filename}"; then
+    bundle_downloaded=true
+  elif _jukebox_webapp_try_download "${source_release_url}" "${tar_filename}"; then
+    bundle_downloaded=true
+  elif [[ "${git_user_normalized}" != "${git_upstream_user_normalized}" ]] \
+      && _jukebox_webapp_try_download "${upstream_development_url}" "${tar_filename}"; then
+    bundle_downloaded=true
+  elif [[ "${git_user_normalized}" != "${git_upstream_user_normalized}" ]] \
+      && _jukebox_webapp_try_download "${upstream_release_url}" "${tar_filename}"; then
+    bundle_downloaded=true
+  elif [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == true ]] \
+      && _jukebox_webapp_try_download "${upstream_latest_url}" "${tar_filename}"; then
+    bundle_downloaded=true
   fi
-  tar -xzf ${tar_filename}
-  rm -f ${tar_filename}
+
+  if [[ "$bundle_downloaded" != true ]]; then
+    cd "${INSTALLATION_PATH}" || exit_on_error
+    return 1
+  fi
+
+  tar -xzf "${tar_filename}" || exit_on_error "Invalid Web App bundle"
+  rm -f "${tar_filename}"
   cd "${INSTALLATION_PATH}" || exit_on_error
 }
 
@@ -104,9 +154,7 @@ _jukebox_webapp_register_as_system_service_with_nginx() {
 _jukebox_webapp_check() {
     print_verify_installation
 
-    if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == true || "$ENABLE_WEBAPP_PROD_DOWNLOAD" == "release-only" ]] ; then
-        verify_dirs_exists "${INSTALLATION_PATH}/src/webapp/build"
-    else
+    if [[ "$WEBAPP_BUILT_LOCALLY" == true ]]; then
         local arch=$(uname -m)
         if [[ "$arch" == "armv6l" ]]; then
             local node_version_installed=$(node -v 2>/dev/null)
@@ -116,10 +164,10 @@ _jukebox_webapp_check() {
         else
             verify_apt_packages nodejs
         fi
+    fi
 
-        if [[ "$OPTIONAL_WEBAPP_BUILD_FAILED" == false ]]; then
-            verify_dirs_exists "${INSTALLATION_PATH}/src/webapp/build"
-        fi
+    if [[ "$OPTIONAL_WEBAPP_BUILD_FAILED" == false ]]; then
+        verify_dirs_exists "${INSTALLATION_PATH}/src/webapp/build"
     fi
 
     verify_apt_packages nginx
@@ -133,13 +181,23 @@ _jukebox_webapp_check() {
 }
 
 _run_setup_jukebox_webapp() {
-    if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == true || "$ENABLE_WEBAPP_PROD_DOWNLOAD" == "release-only" ]] ; then
-        _jukebox_webapp_download
-    else
+    if [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == auto ]]; then
+        if ! _jukebox_webapp_download; then
+            print_lc "  No exact Web App bundle found; building locally."
+            if [[ "$(get_architecture)" == "armv6" ]]; then
+                _jukebox_webapp_install_node_armv6
+            fi
+            _jukebox_webapp_build
+        fi
+    elif [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == true || "$ENABLE_WEBAPP_PROD_DOWNLOAD" == "release-only" ]] ; then
+        _jukebox_webapp_download || exit_on_error "No pre-built Web App bundle found!"
+    elif [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false ]]; then
         if [[ "$(get_architecture)" == "armv6" ]]; then
             _jukebox_webapp_install_node_armv6
         fi
         _jukebox_webapp_build
+    else
+        exit_on_error "Invalid ENABLE_WEBAPP_PROD_DOWNLOAD value: ${ENABLE_WEBAPP_PROD_DOWNLOAD}"
     fi
     _jukebox_webapp_register_as_system_service_with_nginx
     _jukebox_webapp_check


### PR DESCRIPTION
## Summary

- retain successful Web App builds as commit-addressed GitHub Actions artifacts
- publish exact-commit bundles from branch pushes to a rolling `webapp-development` prerelease in the source repository, retaining the newest 20 assets
- keep pull request workflows read-only and restrict release publishing to push runs
- make development installations download the exact source/upstream bundle first and fall back to the latest applicable prebuilt release bundle
- make local Web App builds an explicit `[y/N]` opt-in so Node/npm are not installed by default
- add focused bundle-selection/dependency tests and update installation documentation

## Testing

- [Web App build, tests, artifact upload, and release publishing](https://github.com/pabera/RPi-Jukebox-RFID/actions/runs/30761076325)
- [Installer tests on amd64, armv7, and arm64](https://github.com/pabera/RPi-Jukebox-RFID/actions/runs/30761076434)
- [Markdown lint](https://github.com/pabera/RPi-Jukebox-RFID/actions/runs/30761076318)

Both armv7 and arm64 installer logs selected the public exact-commit asset `webapp-build-31181813db.tar.gz` without building the Web App locally.

Closes #2679