### PR TITLE
Handle unavailable CPU temperature sensors gracefully

### DIFF
--- a/docker/config/jukebox.overrides.yaml
+++ b/docker/config/jukebox.overrides.yaml
@@ -2,3 +2,7 @@ playermpd:
   host: mpd
 api:
   bind_address: 0.0.0.0
+host:
+  publish_temperature:
+    # Docker does not expose the Raspberry Pi thermal sensor sysfs.
+    enabled: false

--- a/documentation/developers/docker.md
+++ b/documentation/developers/docker.md
@@ -285,12 +285,16 @@ mpd | exception: Failed to read mixer for 'My ALSA Device': snd_mixer_handle_eve
 
 Many features of the Phoniebox are based on the Raspberry Pi hardware.
 This hardware can\'t be mocked in a virtual Docker environment. As a
-result, a few plugins like RFID, GPIO or CPU temperature will throw
-errors because they can\'t start successfully. Unless you want to
-develop such plugins, you will be able to ignore these errors. The
-plugin system is built in a way that the Jukebox daemon will come up. If
-you want to develop plugins that require hardware support, you will have
-to work on the hardware directly.
+result, a few plugins like RFID or GPIO will throw errors because they
+can\'t start successfully. Docker does not expose the Raspberry Pi
+thermal sensor sysfs, so CPU temperature monitoring is disabled in the
+[Docker configuration override](../../docker/config/jukebox.overrides.yaml).
+Existing Docker configurations that still enable temperature monitoring
+will detect the missing sensor at runtime and leave the timer disabled.
+Unless you want to develop hardware plugins, you will be able to ignore
+the remaining errors. The plugin system is built in a way that the
+Jukebox daemon will come up. If you want to develop plugins that require
+hardware support, you will have to work on the hardware directly.
 
 Typical errors and following exceptions to be ignored in the Docker
 `jukebox` container are:
@@ -299,9 +303,6 @@ Typical errors and following exceptions to be ignored in the Docker
 jukebox    | 634:plugs.py           - jb.plugin            - MainThread      - ERROR    - Ignoring failed package load finalizer: 'rfid.finalize()'
 jukebox    | 635:plugs.py           - jb.plugin            - MainThread      - ERROR    - Reason: FileNotFoundError: [Errno 2] No such file or directory: '/home/pi/RPi-Jukebox-RFID/shared/settings/rfid.yaml'
 ...
-jukebox    | 171:__init__.py        - jb.host.lnx          - MainThread      - ERROR    - Error reading temperature. Canceling temperature publisher. FileNotFoundError: [Errno 2] No such file or directory: '/sys/class/thermal/thermal_zone0/temp'
-...
-jukebox    | 319:server.py          - jb.pub.server        - host.timer.cputemp - ERROR    - Publish command from different thread 'host.timer.cputemp' than publisher was created from 'MainThread'!
 ```
 
 #### Pulseaudio and Volume issues

--- a/src/jukebox/components/hostif/linux/__init__.py
+++ b/src/jukebox/components/hostif/linux/__init__.py
@@ -13,8 +13,6 @@ from jukebox.multitimer import GenericEndlessTimerClass
 
 logger = logging.getLogger('jb.host.lnx')
 cfg = jukebox.cfghandler.get_handler('jukebox')
-# Get the main Thread Publisher
-publisher = jukebox.publishing.get_publisher()
 
 # In debug mode, shutdown and reboot command are not actually executed
 IS_DEBUG = False
@@ -150,19 +148,26 @@ def get_cpu_temperature():
 
 @plugin.register
 def publish_cpu_temperature():
+    _publish_cpu_temperature()
+
+
+def _publish_cpu_temperature():
     global timer_temperature
     try:
         temperature = get_cpu_temperature()
     except Exception as e:
-        logger.error(f"Error reading temperature. Canceling temperature publisher. {e.__class__.__name__}: {e}")
+        logger.warning(f"CPU temperature sensor unavailable. Disabling temperature publisher. "
+                       f"{e.__class__.__name__}: {e}")
         # If there was an error reading the temperature, the is no sense in keeping the timer alive and running
         # into the same problem again
         timer_temperature.cancel()
         # Revoke Temperature from publisher
-        publisher.revoke('host.temperature.cpu')
+        jukebox.publishing.get_publisher().revoke('host.temperature.cpu')
+        return False
     else:
         # May be called from different threads: get thread-correct publisher instance
         jukebox.publishing.get_publisher().send('host.temperature.cpu', str(temperature))
+        return True
 
 
 # ---------------------------------------------------------------------------
@@ -387,8 +392,7 @@ def finalize():
     # Note: Since timer_temperature is an instance of a class from a different module,
     # auto-registration would register it with that module. Manually set package to this plugin module
     plugin.register(timer_temperature, name='timer_temperature', package=plugin.loaded_as(__name__))
-    if enabled:
-        publish_cpu_temperature()
+    if enabled and _publish_cpu_temperature():
         timer_temperature.start()
 
 

--- a/src/jukebox/jukebox/publishing/server.py
+++ b/src/jukebox/jukebox/publishing/server.py
@@ -166,7 +166,7 @@ class LastValueCache:
 
     def update(self, topic, payload):
         if payload == b'':
-            del self.cache[topic]
+            self.cache.pop(topic, None)
         else:
             self.cache[topic] = payload
 

--- a/test/hostif/test_linux_temperature.py
+++ b/test/hostif/test_linux_temperature.py
@@ -1,0 +1,127 @@
+import importlib
+import logging
+import sys
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+import jukebox.plugs as plugin
+
+
+def _passthrough_decorator(obj=None, **ignored_kwargs):
+    if obj is None:
+        return lambda decorated: decorated
+    return obj
+
+
+@pytest.fixture
+def hostif_linux(monkeypatch):
+    monkeypatch.setattr(plugin, 'register', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'initialize', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'finalize', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'atexit', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'loaded_as', lambda ignored_name: 'host')
+    publishing_module = sys.modules.get('jukebox.publishing')
+    if publishing_module is None:
+        publishing_module = importlib.import_module('jukebox.publishing')
+    monkeypatch.setattr(
+        sys.modules['jukebox'],
+        'publishing',
+        publishing_module,
+        raising=False,
+    )
+
+    sys.modules.pop('components.hostif.linux', None)
+    module = importlib.import_module('components.hostif.linux')
+    yield module
+    sys.modules.pop('components.hostif.linux', None)
+
+
+def _temperature_config(*keys, value):
+    return {
+        'enabled': True,
+        'timer_interval_sec': 10,
+    }.get(keys[-1], value)
+
+
+def _patch_get_publisher(hostif_linux, monkeypatch, get_publisher):
+    monkeypatch.setattr(
+        hostif_linux.jukebox.publishing,
+        'get_publisher',
+        get_publisher,
+    )
+    timer_module = sys.modules[hostif_linux.GenericEndlessTimerClass.__module__]
+    monkeypatch.setattr(timer_module.publishing, 'get_publisher', get_publisher)
+
+
+def test_unavailable_sensor_leaves_temperature_timer_disabled(
+        hostif_linux, monkeypatch, caplog):
+    publisher = MagicMock()
+    monkeypatch.setattr(hostif_linux.cfg, 'setndefault', _temperature_config)
+    _patch_get_publisher(
+        hostif_linux,
+        monkeypatch,
+        MagicMock(return_value=publisher),
+    )
+    monkeypatch.setattr(hostif_linux, 'get_cpu_temperature',
+                        MagicMock(side_effect=FileNotFoundError('thermal sensor missing')))
+
+    with caplog.at_level(logging.WARNING, logger='jb.host.lnx'):
+        hostif_linux.finalize()
+
+    assert hostif_linux.timer_temperature.timer_thread is None
+    publisher.send.assert_called_once()
+    timer_topic, timer_state = publisher.send.call_args.args
+    assert timer_topic == 'host.timer.cputemp'
+    assert timer_state['enabled'] is False
+    publisher.revoke.assert_called_once_with('host.temperature.cpu')
+    assert [record.levelno for record in caplog.records] == [logging.WARNING]
+    assert 'CPU temperature sensor unavailable' in caplog.text
+
+
+def test_initial_temperature_read_publishes_and_starts_timer(
+        hostif_linux, monkeypatch):
+    publisher = MagicMock()
+    start = MagicMock()
+    monkeypatch.setattr(hostif_linux.cfg, 'setndefault', _temperature_config)
+    _patch_get_publisher(
+        hostif_linux,
+        monkeypatch,
+        MagicMock(return_value=publisher),
+    )
+    monkeypatch.setattr(hostif_linux, 'get_cpu_temperature',
+                        MagicMock(return_value=47.2))
+    monkeypatch.setattr(hostif_linux.GenericEndlessTimerClass, 'start', start)
+
+    hostif_linux.finalize()
+
+    publisher.send.assert_any_call('host.temperature.cpu', '47.2')
+    start.assert_called_once_with()
+
+
+def test_later_read_failure_cancels_and_revokes_from_timer_thread(
+        hostif_linux, monkeypatch):
+    timer = MagicMock()
+    publisher = MagicMock()
+    publisher_threads = []
+
+    def get_publisher():
+        publisher_threads.append(threading.current_thread())
+        return publisher
+
+    monkeypatch.setattr(hostif_linux, 'timer_temperature', timer, raising=False)
+    monkeypatch.setattr(hostif_linux, 'get_cpu_temperature',
+                        MagicMock(side_effect=OSError('sensor read failed')))
+    _patch_get_publisher(hostif_linux, monkeypatch, get_publisher)
+
+    worker = threading.Thread(
+        target=hostif_linux.publish_cpu_temperature,
+        name='host.timer.cputemp',
+    )
+    worker.start()
+    worker.join()
+
+    timer.cancel.assert_called_once_with()
+    publisher.revoke.assert_called_once_with('host.temperature.cpu')
+    assert publisher_threads == [worker]

--- a/test/publishing/test_server.py
+++ b/test/publishing/test_server.py
@@ -1,0 +1,30 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SERVER_PATH = (
+    Path(__file__).parents[2]
+    / 'src'
+    / 'jukebox'
+    / 'jukebox'
+    / 'publishing'
+    / 'server.py'
+)
+SPEC = importlib.util.spec_from_file_location('publishing_server_under_test', SERVER_PATH)
+server_module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(server_module)
+LastValueCache = server_module.LastValueCache
+
+
+@pytest.mark.parametrize('initial_payload', [None, b'47.2'])
+def test_cache_revocation_is_idempotent(initial_payload):
+    cache = LastValueCache(frontend=None, backend=None)
+    topic = b'host.temperature.cpu'
+    if initial_payload is not None:
+        cache.update(topic, initial_payload)
+
+    cache.update(topic, b'')
+    cache.update(topic, b'')
+
+    assert topic not in cache.cache


### PR DESCRIPTION
## Summary
- disable CPU temperature publishing in the Docker override because containers do not expose Raspberry Pi thermal sysfs
- keep the temperature timer disabled when the initial sensor read fails and use thread-local publishers for publishing and revocation
- make last-value cache revocation idempotent and cover the startup, timer failure, and cache paths with regression tests

## Testing
- `./run_pytest.sh` (`102 passed, 1 skipped`)
- `.venv/bin/flake8 src/jukebox/components/hostif/linux/__init__.py src/jukebox/jukebox/publishing/server.py test/hostif/test_linux_temperature.py test/publishing/test_server.py`
- `docker compose -f docker/docker-compose.yml -f docker/docker-compose.mac.yml config --quiet`
- macOS Compose Jukebox smoke test: timer remained disabled with no cross-thread publisher warning, `host.temperature.cpu` traceback, or cache `KeyError`