### PR TITLE
fix(sync): protect SSH rsync paths without literal quotes

### DIFF
--- a/src/jukebox/components/synchronisation/rfidcards/__init__.py
+++ b/src/jukebox/components/synchronisation/rfidcards/__init__.py
@@ -259,7 +259,11 @@ class SyncRfidcards:
             _host = self._sync_remote_server
             _port = self._sync_remote_port
 
-            _mode_params = ['--compress', '-e', f"ssh -p {_port}", f"{_user}@{_host}:'{src_path}'", dst_path]
+            _mode_params = [
+                '--compress', '--protect-args',
+                '-e', f"ssh -p {_port}",
+                f"{_user}@{_host}:{src_path}", dst_path,
+            ]
 
         else:
             _mode_params = [src_path, dst_path]

--- a/test/synchronisation/test_rfidcards.py
+++ b/test/synchronisation/test_rfidcards.py
@@ -55,3 +55,41 @@ def test_sync_paths_builds_mount_mode_rsync_command(rfidcards, monkeypatch):
         capture_output=True,
         text=True,
     )
+
+
+@pytest.mark.parametrize('source_path', [
+    '/srv/audiofolders/album',
+    '/srv/audiofolders/favorite album',
+])
+def test_sync_paths_protects_ssh_source_path(
+        rfidcards, monkeypatch, source_path):
+    run = MagicMock(return_value=SimpleNamespace(
+        returncode=0,
+        stdout='',
+        stderr='',
+    ))
+    monkeypatch.setattr(rfidcards.subprocess, 'run', run)
+    controller = rfidcards.SyncRfidcards.__new__(rfidcards.SyncRfidcards)
+    controller._sync_is_mode_ssh = True
+    controller._sync_remote_ssh_user = 'jukebox'
+    controller._sync_remote_server = 'music.example.com'
+    controller._sync_remote_port = 2222
+
+    assert controller._sync_paths(source_path, '/media/destination') is False
+
+    run.assert_called_once_with(
+        [
+            'rsync',
+            '--recursive', '--itemize-changes',
+            '--safe-links', '--times', '--omit-dir-times',
+            '--delete', '--prune-empty-dirs',
+            '--exclude=folder.conf',
+            '--exclude=.*', '--exclude=.*/', '--exclude=@*/', '--cvs-exclude',
+            '--compress', '--protect-args', '-e', 'ssh -p 2222',
+            f'jukebox@music.example.com:{source_path}', '/media/destination',
+        ],
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+    )

--- a/test/synchronisation/test_rfidcards.py
+++ b/test/synchronisation/test_rfidcards.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import jukebox.plugs as plugin
+
+
+def _passthrough_decorator(obj=None, **ignored_kwargs):
+    if obj is None:
+        return lambda decorated: decorated
+    return obj
+
+
+@pytest.fixture
+def rfidcards(monkeypatch):
+    monkeypatch.setattr(plugin, 'register', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'initialize', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'finalize', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'atexit', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'tag', _passthrough_decorator)
+
+    sys.modules.pop('components.synchronisation.rfidcards', None)
+    module = importlib.import_module('components.synchronisation.rfidcards')
+    yield module
+    sys.modules.pop('components.synchronisation.rfidcards', None)
+
+
+def test_sync_paths_builds_mount_mode_rsync_command(rfidcards, monkeypatch):
+    run = MagicMock(return_value=SimpleNamespace(
+        returncode=0,
+        stdout='',
+        stderr='',
+    ))
+    monkeypatch.setattr(rfidcards.subprocess, 'run', run)
+    controller = rfidcards.SyncRfidcards.__new__(rfidcards.SyncRfidcards)
+    controller._sync_is_mode_ssh = False
+
+    assert controller._sync_paths('/media/source', '/media/destination') is False
+
+    run.assert_called_once_with(
+        [
+            'rsync',
+            '--recursive', '--itemize-changes',
+            '--safe-links', '--times', '--omit-dir-times',
+            '--delete', '--prune-empty-dirs',
+            '--exclude=folder.conf',
+            '--exclude=.*', '--exclude=.*/', '--exclude=@*/', '--cvs-exclude',
+            '/media/source', '/media/destination',
+        ],
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary

- construct SSH rsync sources as `user@host:path` without embedded apostrophes
- add `--protect-args` in SSH mode so remote paths containing spaces work with rsync 3.2.3 and 3.2.7
- cover mount mode and ordinary/space-containing SSH paths with mocked command-construction tests

## Root cause

The synchronization command uses `subprocess.run(..., shell=False)`, so apostrophes embedded in the source argument are passed literally to rsync instead of being consumed as shell quoting. This can make the remote path include quote characters and fail synchronization. `--protect-args` preserves path arguments across the rsync protocol without relying on shell quoting.

## Verification

- `./run_pytest.sh test/synchronisation/test_rfidcards.py` (3 passed)
- `./run_pytest.sh` (105 passed, 1 skipped)
- `./run_flake8.sh` (0 issues)

Fixes #2532