### PR TITLE
Replace volume fadeout timer state machine

### DIFF
--- a/documentation/developers/docstring/README.md
+++ b/documentation/developers/docstring/README.md
@@ -59,16 +59,12 @@
 * [components.timers](#components.timers)
 * [components.timers.volume\_fadeout\_shutdown\_timer](#components.timers.volume_fadeout_shutdown_timer)
   * [VolumeFadeoutError](#components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutError)
-  * [VolumeFadeoutAction](#components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAction)
-    * [\_\_call\_\_](#components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAction.__call__)
-  * [VolumeFadoutAndShutdown](#components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown)
-    * [MIN\_TOTAL\_DURATION](#components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.MIN_TOTAL_DURATION)
-    * [FADEOUT\_DURATION](#components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.FADEOUT_DURATION)
-    * [start](#components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.start)
-    * [cancel](#components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.cancel)
-    * [is\_alive](#components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.is_alive)
-    * [get\_state](#components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.get_state)
-    * [get\_config](#components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.get_config)
+  * [VolumeFadeoutAndShutdown](#components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown)
+    * [start](#components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.start)
+    * [cancel](#components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.cancel)
+    * [is\_alive](#components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.is_alive)
+    * [get\_state](#components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.get_state)
+    * [get\_config](#components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.get_config)
 * [components.hostif.linux](#components.hostif.linux)
   * [shutdown](#components.hostif.linux.shutdown)
   * [reboot](#components.hostif.linux.reboot)
@@ -423,10 +419,6 @@
   * [GenericEndlessTimerClass](#jukebox.multitimer.GenericEndlessTimerClass)
     * [\_\_init\_\_](#jukebox.multitimer.GenericEndlessTimerClass.__init__)
     * [get\_state](#jukebox.multitimer.GenericEndlessTimerClass.get_state)
-  * [GenericMultiTimerClass](#jukebox.multitimer.GenericMultiTimerClass)
-    * [\_\_init\_\_](#jukebox.multitimer.GenericMultiTimerClass.__init__)
-    * [start](#jukebox.multitimer.GenericMultiTimerClass.start)
-    * [get\_state](#jukebox.multitimer.GenericMultiTimerClass.get_state)
 * [jukebox.api.server](#jukebox.api.server)
   * [EventBroker](#jukebox.api.server.EventBroker)
   * [ApiServer](#jukebox.api.server.ApiServer)
@@ -1138,92 +1130,32 @@ Returns the current state of Idle Shutdown
 class VolumeFadeoutError(Exception)
 ```
 
-Custom exception for volume fadeout errors
+Raised when a fadeout timer request is invalid.
 
 
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAction"></a>
+<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown"></a>
 
-## VolumeFadeoutAction Objects
-
-```python
-class VolumeFadeoutAction()
-```
-
-Handles the actual volume fade out actions
-
-
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAction.__call__"></a>
-
-#### \_\_call\_\_
+## VolumeFadeoutAndShutdown Objects
 
 ```python
-def __call__(iteration, *args, **kwargs)
+class VolumeFadeoutAndShutdown()
 ```
 
-Called for each timer iteration
+Fade volume over the final two minutes, then request shutdown.
 
 
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown"></a>
-
-## VolumeFadoutAndShutdown Objects
-
-```python
-class VolumeFadoutAndShutdown()
-```
-
-Timer system that gracefully fades out volume before shutdown.
-
-This timer manages three coordinated timers for a smooth shutdown sequence:
-1. Main shutdown timer: Runs for the full duration and triggers the final shutdown
-2. Fadeout start timer: Triggers the volume fadeout 2 minutes before shutdown
-3. Volume fadeout timer: Handles the actual volume reduction in the last 2 minutes
-
-Example for a 5-minute (300s) timer:
-- t=0s:   Shutdown timer starts (300s)
-          Fadeout start timer starts (180s)
-- t=180s: Fadeout start timer triggers volume reduction
-          Volume fadeout begins (12 steps over 120s)
-- t=300s: Shutdown timer triggers system shutdown
-
-The fadeout always takes 2 minutes (120s), regardless of the total timer duration.
-The minimum total duration is 2 minutes to accommodate the fadeout period.
-All timers can be cancelled together using the cancel() method.
-
-
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.MIN_TOTAL_DURATION"></a>
-
-#### MIN\_TOTAL\_DURATION
-
-2 minutes minimum
-
-
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.FADEOUT_DURATION"></a>
-
-#### FADEOUT\_DURATION
-
-Last 2 minutes for fadeout
-
-
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.start"></a>
+<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.start"></a>
 
 #### start
 
 ```python
 @plugin.tag
-def start(wait_seconds=None)
+def start(wait_seconds=None, restart: bool = True)
 ```
 
-Start the coordinated timer system
+Start or atomically replace the fadeout timer.
 
-**Arguments**:
-
-- `wait_seconds` (`float`): Total duration until shutdown (optional)
-
-**Raises**:
-
-- `VolumeFadeoutError`: If duration too short
-
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.cancel"></a>
+<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.cancel"></a>
 
 #### cancel
 
@@ -1232,10 +1164,9 @@ Start the coordinated timer system
 def cancel()
 ```
 
-Cancel all active timers
+Cancel all future fade and shutdown actions.
 
-
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.is_alive"></a>
+<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.is_alive"></a>
 
 #### is\_alive
 
@@ -1244,10 +1175,9 @@ Cancel all active timers
 def is_alive()
 ```
 
-Check if any timer is currently active
+Return whether the fadeout controller is active.
 
-
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.get_state"></a>
+<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.get_state"></a>
 
 #### get\_state
 
@@ -1256,10 +1186,9 @@ Check if any timer is currently active
 def get_state()
 ```
 
-Get the current state of the timer system
+Return the RPC-compatible fadeout state.
 
-
-<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadoutAndShutdown.get_config"></a>
+<a id="components.timers.volume_fadeout_shutdown_timer.VolumeFadeoutAndShutdown.get_config"></a>
 
 #### get\_config
 
@@ -1268,7 +1197,7 @@ Get the current state of the timer system
 def get_config()
 ```
 
-Get the current configuration
+Return fadeout timer configuration.
 
 
 <a id="components.hostif.linux"></a>
@@ -6102,27 +6031,7 @@ Parse the folder ``path`` and create a playlist from its content
 
 # jukebox.multitimer
 
-MultiTimer Module
-
-This module provides timer functionality with support for single, multiple, and endless iterations.
-It includes three main timer classes:
-- MultiTimer: The base timer implementation using threading
-- GenericTimerClass: A single-event timer with plugin/RPC support
-- GenericEndlessTimerClass: An endless repeating timer
-- GenericMultiTimerClass: A multi-iteration timer with callback builder support
-
-Example usage:
-    # Single event timer
-    timer = GenericTimerClass("my_timer", 5.0, my_function)
-    timer.start()
-
-    # Endless timer
-    endless_timer = GenericEndlessTimerClass("endless", 1.0, update_function)
-    endless_timer.start()
-
-    # Multi-iteration timer
-    multi_timer = GenericMultiTimerClass("counter", 5, 1.0, CounterCallback)
-    multi_timer.start()
+Threaded one-shot and fixed-delay periodic timers.
 
 
 <a id="jukebox.multitimer.MultiTimer"></a>
@@ -6472,87 +6381,6 @@ Get current timer state.
 `dict`: Timer state including:
 - enabled: Whether timer is running
 - wait_seconds_per_iteration: Interval between calls
-- type: Timer class name
-
-<a id="jukebox.multitimer.GenericMultiTimerClass"></a>
-
-## GenericMultiTimerClass Objects
-
-```python
-class GenericMultiTimerClass(GenericTimerClass)
-```
-
-A multi-iteration timer with callback builder support.
-
-This timer executes a specified number of iterations with a callback
-that's created for each full cycle. It's useful when you need stateful
-callbacks or complex iteration handling.
-
-The callee parameter should be a class or function that:
-1. Takes iterations as a parameter during construction
-2. Returns a callable that accepts an iteration parameter
-
-
-<a id="jukebox.multitimer.GenericMultiTimerClass.__init__"></a>
-
-#### \_\_init\_\_
-
-```python
-def __init__(name: str,
-             iterations: int,
-             wait_seconds_per_iteration: float,
-             callee: Callable,
-             args=None,
-             kwargs=None)
-```
-
-Initialize multi-iteration timer.
-
-**Arguments**:
-
-- `name`: Timer identifier
-- `iterations`: Total number of iterations
-- `wait_seconds_per_iteration`: Interval between calls
-- `callee`: Callback builder class/function
-- `args`: Positional arguments for callee
-- `kwargs`: Keyword arguments for callee
-
-<a id="jukebox.multitimer.GenericMultiTimerClass.start"></a>
-
-#### start
-
-```python
-@plugin.tag
-def start(iterations: Optional[int] = None,
-          wait_seconds_per_iteration: Optional[float] = None)
-```
-
-Start the timer with optional new parameters.
-
-**Arguments**:
-
-- `iterations`: Optional new iteration count
-- `wait_seconds_per_iteration`: Optional new interval
-
-<a id="jukebox.multitimer.GenericMultiTimerClass.get_state"></a>
-
-#### get\_state
-
-```python
-@plugin.tag
-def get_state() -> Dict[str, Any]
-```
-
-Get current timer state.
-
-**Returns**:
-
-`dict`: Timer state including:
-- enabled: Whether timer is running
-- wait_seconds_per_iteration: Interval between calls
-- remaining_seconds_current_iteration: Time until next call
-- remaining_seconds: Total time remaining
-- iterations: Total iteration count
 - type: Timer class name
 
 <a id="jukebox.api.server"></a>

--- a/resources/default-settings/jukebox.default.yaml
+++ b/resources/default-settings/jukebox.default.yaml
@@ -119,9 +119,8 @@ timers:
     default_timeout_sec: 3600
   stop_player:
     default_timeout_sec: 3600
-  volume_fade_out:
-    default_time_per_iteration_sec: 900
-    number_of_steps: 10
+  volume_fadeout:
+    default_timeout_sec: 600
 host:
   # Do not actually execute system shutdown and reboot commands
   debug_mode: false

--- a/src/jukebox/components/timers/__init__.py
+++ b/src/jukebox/components/timers/__init__.py
@@ -6,11 +6,12 @@ import jukebox.cfghandler
 import jukebox.plugs as plugin
 from jukebox.multitimer import GenericTimerClass
 from .idle_shutdown_timer import IdleShutdownTimer
-from .volume_fadeout_shutdown_timer import VolumeFadoutAndShutdown
+from .volume_fadeout_shutdown_timer import VolumeFadeoutAndShutdown
 
 
 logger = logging.getLogger('jb.timers')
 cfg = jukebox.cfghandler.get_handler('jukebox')
+VolumeFadoutAndShutdown = VolumeFadeoutAndShutdown
 
 
 # ---------------------------------------------------------------------------
@@ -31,7 +32,7 @@ def stop_player():
 # ---------------------------------------------------------------------------
 timer_shutdown: GenericTimerClass
 timer_stop_player: GenericTimerClass
-timer_fade_volume: VolumeFadoutAndShutdown
+timer_fade_volume: VolumeFadeoutAndShutdown
 timer_idle_shutdown: IdleShutdownTimer
 
 
@@ -57,7 +58,7 @@ def finalize():
 
     # Volume Fadeout and Shutdown Timer
     global timer_fade_volume
-    timer_fade_volume = VolumeFadoutAndShutdown(
+    timer_fade_volume = VolumeFadeoutAndShutdown(
         name=f"{plugin.loaded_as(__name__)}.timer_fade_volume"
     )
     plugin.register(timer_fade_volume, name='timer_fade_volume', package=plugin.loaded_as(__name__))

--- a/src/jukebox/components/timers/idle_shutdown_timer.py
+++ b/src/jukebox/components/timers/idle_shutdown_timer.py
@@ -158,6 +158,7 @@ class IdleShutdownTimer:
         self._phase = _PHASE_DISABLED
         self._detector_error_logged = False
         self._snapshot_error_logged = False
+        self._controller_generation = 0
         self._monitor = GenericEndlessTimerClass(
             name=None,
             wait_seconds_per_iteration=check_interval,
@@ -180,9 +181,12 @@ class IdleShutdownTimer:
         with self._lock:
             self._wait_seconds = startup_timeout
             if startup_timeout:
-                self._begin_locked(startup_timeout)
+                generation = self._begin_locked(startup_timeout)
             else:
                 self._publish_locked()
+                generation = None
+        if generation is not None:
+            self._start_monitor(generation)
 
     @staticmethod
     def _default_paths():
@@ -236,6 +240,7 @@ class IdleShutdownTimer:
         return snapshot
 
     def _begin_locked(self, wait_seconds):
+        self._controller_generation += 1
         now = self._clock()
         self._wait_seconds = wait_seconds
         self._enabled = True
@@ -249,7 +254,18 @@ class IdleShutdownTimer:
             self._phase = _PHASE_COUNTDOWN
             self._running = True
         self._publish_locked()
+        return self._controller_generation
+
+    def _start_monitor(self, generation):
         self._monitor.start(restart=True)
+        worker = self._monitor.timer_thread
+        with self._lock:
+            stale = (
+                not self._enabled
+                or generation != self._controller_generation
+            )
+        if stale and worker is not None:
+            self._monitor.cancel_generation(worker)
 
     def _remaining_seconds_locked(self):
         if not self._enabled or not self._running or self._deadline is None:
@@ -269,7 +285,8 @@ class IdleShutdownTimer:
                 'timeout_sec',
                 value=timeout,
             )
-            self._begin_locked(timeout)
+            generation = self._begin_locked(timeout)
+        self._start_monitor(generation)
 
     @plugin.tag
     def cancel(self):
@@ -283,13 +300,14 @@ class IdleShutdownTimer:
             )
             transitioned = self._enabled
             self._enabled = False
+            self._controller_generation += 1
             self._running = False
             self._deadline = None
             self._baseline = None
             self._phase = _PHASE_DISABLED
-            self._monitor.cancel()
             if transitioned:
                 self._publish_locked()
+        self._monitor.cancel()
 
     @plugin.tag
     def get_state(self):
@@ -434,11 +452,12 @@ class IdleShutdownTimer:
         with self._lock:
             transitioned = self._enabled
             self._enabled = False
+            self._controller_generation += 1
             self._running = False
             self._deadline = None
             self._baseline = None
             self._phase = _PHASE_DISABLED
-            self._monitor.cancel()
             if transitioned:
                 self._publish_locked()
+        self._monitor.cancel()
         self._monitor.close()

--- a/src/jukebox/components/timers/volume_fadeout_shutdown_timer.py
+++ b/src/jukebox/components/timers/volume_fadeout_shutdown_timer.py
@@ -1,216 +1,364 @@
 import logging
-import time
+import threading
+from time import monotonic
+
 import jukebox.cfghandler
 import jukebox.plugs as plugin
-from jukebox.multitimer import GenericTimerClass, GenericMultiTimerClass
+import jukebox.publishing as publishing
+from jukebox.multitimer import GenericTimerClass
 
 
-logger = logging.getLogger('jb.timers')
+logger = logging.getLogger('jb.timers.volume_fadeout')
 cfg = jukebox.cfghandler.get_handler('jukebox')
+
+_PHASE_DISABLED = 'disabled'
+_PHASE_WAITING = 'waiting'
+_PHASE_FADING = 'fading'
+_PHASE_WAITING_FOR_SHUTDOWN = 'waiting_for_shutdown'
+_PHASE_COMPLETE = 'complete'
 
 
 class VolumeFadeoutError(Exception):
-    """Custom exception for volume fadeout errors"""
-    pass
+    """Raised when a fadeout timer request is invalid."""
 
 
-class VolumeFadeoutAction:
-    """Handles the actual volume fade out actions"""
-    def __init__(self, start_volume):
-        self.start_volume = start_volume
-        # Use 12 steps for 2 minutes = 10 seconds per step
-        self.iterations = 12
-        self.volume_step = start_volume / (self.iterations - 1)
-        logger.debug(f"Initialized fadeout from volume {start_volume}")
+class VolumeFadeoutAndShutdown:
+    """Fade volume over the final two minutes, then request shutdown."""
 
-    def __call__(self, iteration, *args, **kwargs):
-        """Called for each timer iteration"""
-        # Calculate target volume for this step
-        target_volume = max(0, int(self.start_volume - (self.iterations - iteration - 1) * self.volume_step))
-        logger.debug(f"Fading volume to {target_volume} (Step {self.iterations - iteration}/{self.iterations})")
-        plugin.call_ignore_errors('volume', 'ctrl', 'set_volume', args=[target_volume])
+    MIN_TOTAL_DURATION = 120
+    FADEOUT_DURATION = 120
+    FADE_STEPS = 12
+    STEP_SECONDS = 10
 
-
-class VolumeFadoutAndShutdown:
-    """Timer system that gracefully fades out volume before shutdown.
-
-    This timer manages three coordinated timers for a smooth shutdown sequence:
-    1. Main shutdown timer: Runs for the full duration and triggers the final shutdown
-    2. Fadeout start timer: Triggers the volume fadeout 2 minutes before shutdown
-    3. Volume fadeout timer: Handles the actual volume reduction in the last 2 minutes
-
-    Example for a 5-minute (300s) timer:
-    - t=0s:   Shutdown timer starts (300s)
-              Fadeout start timer starts (180s)
-    - t=180s: Fadeout start timer triggers volume reduction
-              Volume fadeout begins (12 steps over 120s)
-    - t=300s: Shutdown timer triggers system shutdown
-
-    The fadeout always takes 2 minutes (120s), regardless of the total timer duration.
-    The minimum total duration is 2 minutes to accommodate the fadeout period.
-    All timers can be cancelled together using the cancel() method.
-    """
-
-    MIN_TOTAL_DURATION = 120  # 2 minutes minimum
-    FADEOUT_DURATION = 120    # Last 2 minutes for fadeout
-
-    def __init__(self, name):
+    def __init__(
+            self,
+            name,
+            *,
+            clock=monotonic,
+            get_volume=None,
+            set_volume=None,
+            shutdown_action=None):
         self.name = name
-        self.default_timeout = cfg.setndefault('timers', 'volume_fadeout', 'default_timeout_sec', value=600)
-
-        self.shutdown_timer = None
-        self.fadeout_start_timer = None
-        self.fadeout_timer = None
-
-        self._reset_state()
-
-    def _reset_state(self):
-        """Reset internal state variables"""
+        self.default_timeout = cfg.setndefault(
+            'timers',
+            'volume_fadeout',
+            'default_timeout_sec',
+            value=600,
+        )
+        self._clock = clock
+        self._get_volume = (
+            get_volume
+            if get_volume is not None
+            else lambda: plugin.call('volume', 'ctrl', 'get_volume')
+        )
+        self._set_volume = (
+            set_volume
+            if set_volume is not None
+            else lambda volume: plugin.call(
+                'volume',
+                'ctrl',
+                'set_volume',
+                args=[volume],
+            )
+        )
+        self._shutdown_action = (
+            shutdown_action
+            if shutdown_action is not None
+            else lambda: plugin.call_ignore_errors('host', 'shutdown')
+        )
+        self._lock = threading.RLock()
+        self._timer = GenericTimerClass(None, self.default_timeout, self._on_timer)
+        self._generation = 0
+        self._worker_generations = {}
+        self._enabled = False
+        self._shutdown_latched = False
+        self._phase = _PHASE_DISABLED
         self.start_time = None
         self.total_duration = None
         self.current_volume = None
         self.fadeout_started = False
+        self._final_deadline = None
+        self._fade_deadline = None
+        self._next_step = 0
+        self._error = None
+        self._publish_locked()
 
-    def _start_fadeout(self):
-        """Callback for fadeout_start_timer - initiates the volume fadeout"""
-        logger.info("Starting volume fadeout sequence")
-        self.fadeout_started = True
+    @property
+    def timer_thread(self):
+        """Return the current one-shot worker for shutdown integration."""
+        return self._timer.timer_thread
 
-        # Get current volume at start of fadeout
-        self.current_volume = plugin.call('volume', 'ctrl', 'get_volume')
-        if self.current_volume <= 0:
-            logger.warning("Volume already at 0, waiting for shutdown")
-            return
+    @staticmethod
+    def _validate_duration(wait_seconds):
+        if isinstance(wait_seconds, bool):
+            raise VolumeFadeoutError('Duration must be a number of seconds')
+        try:
+            duration = float(wait_seconds)
+        except (TypeError, ValueError) as error:
+            raise VolumeFadeoutError(
+                'Duration must be a number of seconds',
+            ) from error
+        if duration < VolumeFadeoutAndShutdown.MIN_TOTAL_DURATION:
+            raise VolumeFadeoutError(
+                'Duration must be at least '
+                f'{VolumeFadeoutAndShutdown.MIN_TOTAL_DURATION} seconds',
+            )
+        if duration.is_integer():
+            return int(duration)
+        return duration
 
-        # Start the fadeout timer
-        self.fadeout_timer = GenericMultiTimerClass(
-            name=f"{self.name}_fadeout",
-            iterations=12,  # 12 steps over 2 minutes = 10 seconds per step
-            wait_seconds_per_iteration=10,
-            callee=lambda iterations: VolumeFadeoutAction(self.current_volume)
+    def _is_current_locked(self, generation):
+        return (
+            self._enabled
+            and not self._shutdown_latched
+            and generation == self._generation
         )
-        self.fadeout_timer.start()
 
-    def _shutdown(self):
-        """Callback for shutdown_timer - performs the actual shutdown"""
-        logger.info("Timer complete, initiating shutdown")
-        plugin.call_ignore_errors('host', 'shutdown')
+    def _schedule(self, deadline, generation):
+        delay = max(0, deadline - self._clock())
+        self._timer.start(delay, restart=True)
+        worker = self._timer.timer_thread
+        with self._lock:
+            current = self._is_current_locked(generation)
+            if current:
+                self._worker_generations[worker] = generation
+        if not current:
+            self._timer.cancel_generation(worker)
+
+    def _remaining_seconds_locked(self):
+        if not self._enabled or self._final_deadline is None:
+            return 0
+        return max(0, self._final_deadline - self._clock())
+
+    def _active_state_locked(self):
+        elapsed = max(0, self._clock() - self.start_time)
+        progress = min(
+            100,
+            elapsed / self.total_duration * 100,
+        )
+        return {
+            'enabled': True,
+            'type': 'VolumeFadoutAndShutdown',
+            'total_duration': self.total_duration,
+            'remaining_seconds': self._remaining_seconds_locked(),
+            'progress_percent': progress,
+            'fadeout_started': self.fadeout_started,
+            'error': self._error,
+        }
 
     @plugin.tag
-    def start(self, wait_seconds=None):
-        """Start the coordinated timer system
+    def start(self, wait_seconds=None, restart: bool = True):
+        """Start or atomically replace the fadeout timer."""
+        duration = self._validate_duration(
+            self.default_timeout if wait_seconds is None else wait_seconds,
+        )
+        with self._lock:
+            if self._enabled and not restart:
+                return
+            self._generation += 1
+            generation = self._generation
+            self._worker_generations.clear()
+            self._enabled = True
+            self._shutdown_latched = False
+            self._phase = _PHASE_WAITING
+            self.start_time = self._clock()
+            self.total_duration = duration
+            self.current_volume = None
+            self.fadeout_started = False
+            self._final_deadline = self.start_time + duration
+            self._fade_deadline = (
+                self._final_deadline - self.FADEOUT_DURATION
+            )
+            self._next_step = 0
+            self._error = None
+            self._publish_locked()
 
-        Args:
-            wait_seconds (float): Total duration until shutdown (optional)
+        if duration == self.FADEOUT_DURATION:
+            self._begin_fade(generation)
+        else:
+            self._schedule(self._fade_deadline, generation)
 
-        Raises:
-            VolumeFadeoutError: If duration too short
-        """
-        # Cancel any existing timers
-        self.cancel()
+    def _begin_fade(self, generation):
+        volume = None
+        error_message = None
+        try:
+            volume = max(0, float(self._get_volume()))
+        except Exception as error:
+            logger.exception('Unable to read volume; fadeout will be skipped')
+            error_message = (
+                f'{error.__class__.__name__}: {error}'
+            )
 
-        # Use provided duration or default
-        duration = wait_seconds if wait_seconds is not None else self.default_timeout
+        with self._lock:
+            if not self._is_current_locked(generation):
+                return
+            self.fadeout_started = True
+            if error_message is not None:
+                self._phase = _PHASE_WAITING_FOR_SHUTDOWN
+                self._error = error_message
+                deadline = self._final_deadline
+            else:
+                self._phase = _PHASE_FADING
+                self.current_volume = volume
+                self._next_step = 0
+                deadline = (
+                    self._fade_deadline + self.STEP_SECONDS
+                )
+            self._publish_locked()
+        self._schedule(deadline, generation)
 
-        # Validate duration
-        if duration < self.MIN_TOTAL_DURATION:
-            raise VolumeFadeoutError(f"Duration must be at least {self.MIN_TOTAL_DURATION} seconds")
-
-        self.start_time = time.time()
-        self.total_duration = duration
-
-        # Start the main shutdown timer
-        self.shutdown_timer = GenericTimerClass(
-            name=f"{self.name}_shutdown",
-            wait_seconds=duration,
-            function=self._shutdown
+    def _target_volume_locked(self):
+        remaining_steps = self.FADE_STEPS - self._next_step - 1
+        return max(
+            0,
+            int(self.current_volume * remaining_steps / (self.FADE_STEPS - 1)),
         )
 
-        # Start the fadeout start timer
-        fadeout_start_time = duration - self.FADEOUT_DURATION
-        self.fadeout_start_timer = GenericTimerClass(
-            name=f"{self.name}_fadeout_start",
-            wait_seconds=fadeout_start_time,
-            function=self._start_fadeout
-        )
+    def _fade_step(self, generation):
+        with self._lock:
+            if not self._is_current_locked(generation):
+                return
+            target_volume = self._target_volume_locked()
 
-        logger.info(
-            f"Starting timer system: {fadeout_start_time}s until fadeout starts, "
-            f"total duration {duration}s"
-        )
+        error_message = None
+        try:
+            self._set_volume(target_volume)
+        except Exception as error:
+            logger.exception(
+                'Unable to set fadeout volume to %s; continuing',
+                target_volume,
+            )
+            error_message = f'{error.__class__.__name__}: {error}'
 
-        self.shutdown_timer.start()
-        self.fadeout_start_timer.start()
+        request_shutdown = False
+        next_deadline = None
+        with self._lock:
+            if not self._is_current_locked(generation):
+                return
+            if error_message is not None:
+                self._error = error_message
+            self._next_step += 1
+            self._publish_locked()
+            if self._next_step == self.FADE_STEPS:
+                request_shutdown = self._complete_locked()
+            else:
+                next_deadline = (
+                    self._fade_deadline
+                    + (self._next_step + 1) * self.STEP_SECONDS
+                )
+
+        if next_deadline is not None:
+            self._schedule(next_deadline, generation)
+        if request_shutdown:
+            self._request_shutdown()
+
+    def _complete_locked(self):
+        if self._shutdown_latched:
+            return False
+        self._shutdown_latched = True
+        self._enabled = False
+        self._phase = _PHASE_COMPLETE
+        self._generation += 1
+        self._publish_locked()
+        return True
+
+    def _request_shutdown(self):
+        logger.info('Fadeout complete; initiating shutdown')
+        self._shutdown_action()
+
+    def _on_timer(self):
+        worker = threading.current_thread()
+        with self._lock:
+            generation = self._worker_generations.pop(worker, None)
+            if (
+                    generation is None
+                    or not self._is_current_locked(generation)):
+                return
+            phase = self._phase
+
+        if phase == _PHASE_WAITING:
+            self._begin_fade(generation)
+        elif phase == _PHASE_FADING:
+            self._fade_step(generation)
+        elif phase == _PHASE_WAITING_FOR_SHUTDOWN:
+            with self._lock:
+                if not self._is_current_locked(generation):
+                    return
+                request_shutdown = self._complete_locked()
+            if request_shutdown:
+                self._request_shutdown()
+
+    def _reset_locked(self):
+        self._enabled = False
+        self._shutdown_latched = False
+        self._phase = _PHASE_DISABLED
+        self.start_time = None
+        self.total_duration = None
+        self.current_volume = None
+        self.fadeout_started = False
+        self._final_deadline = None
+        self._fade_deadline = None
+        self._next_step = 0
+        self._error = None
+        self._worker_generations.clear()
 
     @plugin.tag
     def cancel(self):
-        """Cancel all active timers"""
-        if self.shutdown_timer and self.shutdown_timer.is_alive():
-            logger.info("Cancelling shutdown timer")
-            self.shutdown_timer.cancel()
-
-        if self.fadeout_start_timer and self.fadeout_start_timer.is_alive():
-            logger.info("Cancelling fadeout start timer")
-            self.fadeout_start_timer.cancel()
-
-        if self.fadeout_timer and self.fadeout_timer.is_alive():
-            logger.info("Cancelling volume fadeout")
-            self.fadeout_timer.cancel()
-
-        self._reset_state()
-
-    def close(self):
-        """Stop all timer workers without invoking public cancellation."""
-        for timer in (
-                self.shutdown_timer,
-                self.fadeout_start_timer,
-                self.fadeout_timer):
-            if timer is not None:
-                timer.close()
-        self._reset_state()
+        """Cancel all future fade and shutdown actions."""
+        with self._lock:
+            if not self._enabled:
+                return
+            self._generation += 1
+            self._reset_locked()
+            self._publish_locked()
+        self._timer.cancel()
 
     @plugin.tag
     def is_alive(self):
-        """Check if any timer is currently active"""
-        return (
-            (self.shutdown_timer and self.shutdown_timer.is_alive())
-            or (self.fadeout_start_timer and self.fadeout_start_timer.is_alive())
-            or (self.fadeout_timer and self.fadeout_timer.is_alive())
-        )
+        """Return whether the fadeout controller is active."""
+        with self._lock:
+            return self._enabled
 
     @plugin.tag
     def get_state(self):
-        """Get the current state of the timer system"""
-        if not self.is_alive() or not self.start_time:
+        """Return the RPC-compatible fadeout state."""
+        with self._lock:
+            if self._enabled:
+                return self._active_state_locked()
             return {
                 'enabled': False,
                 'type': 'VolumeFadoutAndShutdown',
                 'total_duration': None,
                 'remaining_seconds': 0,
                 'progress_percent': 0,
-                'error': None
+                'error': None,
             }
 
-        # Use the main shutdown timer for overall progress
-        elapsed = time.time() - self.start_time
-        remaining = max(0, self.total_duration - elapsed)
-        progress = min(100, (elapsed / self.total_duration) * 100 if self.total_duration else 0)
-
-        return {
-            'enabled': True,
-            'type': 'VolumeFadoutAndShutdown',
-            'total_duration': self.total_duration,
-            'remaining_seconds': remaining,
-            'progress_percent': progress,
-            'fadeout_started': self.fadeout_started,
-            'error': None
-        }
+    def _publish_locked(self):
+        state = self.get_state()
+        logger.debug('%s: State = %s', self.name, state)
+        publishing.get_publisher().send(self.name, state)
 
     @plugin.tag
     def get_config(self):
-        """Get the current configuration"""
+        """Return fadeout timer configuration."""
         return {
             'default_timeout': self.default_timeout,
             'min_duration': self.MIN_TOTAL_DURATION,
-            'fadeout_duration': self.FADEOUT_DURATION
+            'fadeout_duration': self.FADEOUT_DURATION,
         }
+
+    def close(self):
+        """Stop timer workers without requesting shutdown."""
+        with self._lock:
+            transitioned = self._enabled
+            self._generation += 1
+            self._reset_locked()
+            if transitioned:
+                self._publish_locked()
+        self._timer.cancel()
+        self._timer.close()
+
+
+# Compatibility for callers and the public state type predating the typo fix.
+VolumeFadoutAndShutdown = VolumeFadeoutAndShutdown

--- a/src/jukebox/jukebox/multitimer.py
+++ b/src/jukebox/jukebox/multitimer.py
@@ -257,6 +257,14 @@ class GenericTimerClass:
                 worker.cancel()
             self._publish_core(enabled=False)
 
+    def cancel_generation(self, worker):
+        """Cancel one worker without affecting a newer generation."""
+        with self._lock:
+            if self._enabled and self.timer_thread is worker:
+                self.cancel()
+            else:
+                worker.cancel()
+
     @plugin.tag
     def toggle(self):
         """Toggle between active and disabled states."""
@@ -372,68 +380,4 @@ class GenericEndlessTimerClass(GenericTimerClass):
                 'enabled': self._enabled,
                 'wait_seconds_per_iteration': self._wait_seconds,
                 'type': 'GenericEndlessTimerClass',
-            }
-
-
-class GenericMultiTimerClass(GenericTimerClass):
-    """A limited fixed-delay timer with callback-builder support."""
-
-    def __init__(
-            self,
-            name: str,
-            iterations: int,
-            wait_seconds_per_iteration: float,
-            callee: Callable,
-            args=None,
-            kwargs=None):
-        super().__init__(
-            name,
-            wait_seconds_per_iteration,
-            lambda: None,
-            None,
-            None,
-        )
-        self.class_args = args if args is not None else []
-        self.class_kwargs = kwargs if kwargs is not None else {}
-        self._iterations = iterations
-        self._callee = callee
-
-    @plugin.tag
-    def start(
-            self,
-            iterations: Optional[int] = None,
-            wait_seconds_per_iteration: Optional[float] = None,
-            restart: bool = True):
-        """Build one callback instance and start a limited generation."""
-        with self._lock:
-            if self._enabled and not restart:
-                return
-            if iterations is not None:
-                self._iterations = iterations
-            instance = self._callee(
-                *self.class_args,
-                iterations=self._iterations,
-                **self.class_kwargs,
-            )
-            self._function = lambda iteration, *args, **kwargs: instance(
-                *args,
-                iteration=iteration,
-                **kwargs,
-            )
-        super().start(wait_seconds_per_iteration, restart=restart)
-
-    @plugin.tag
-    def get_state(self) -> Dict[str, Any]:
-        """Return the RPC-compatible limited timer state."""
-        with self._lock:
-            remaining_current = self._remaining_seconds_locked()
-            return {
-                'enabled': self._enabled,
-                'wait_seconds_per_iteration': self._wait_seconds,
-                'remaining_seconds_current_iteration': remaining_current,
-                'remaining_seconds': (
-                    self._wait_seconds * self._iterations + remaining_current
-                ),
-                'iterations': self._iterations,
-                'type': 'GenericMultiTimerClass',
             }

--- a/test/timers/test_idle_shutdown_timer.py
+++ b/test/timers/test_idle_shutdown_timer.py
@@ -1,6 +1,7 @@
 import importlib.util
 import logging
 import os
+import threading
 import time
 from pathlib import Path
 
@@ -386,6 +387,35 @@ def test_publication_uses_rpc_compatible_state(controller_factory):
     }
     assert state['enabled'] is True
     assert state['running'] is True
+
+
+def test_restart_at_poll_boundary_has_no_lock_inversion(
+        controller_factory):
+    create, _, _ = controller_factory
+    detector_entered = threading.Event()
+    release_detector = threading.Event()
+    block_detector = {'value': False}
+
+    def playback():
+        if block_detector['value']:
+            detector_entered.set()
+            assert release_detector.wait(1)
+        return False
+
+    timer = create(playback_detector=playback)
+    timer.start(60)
+    block_detector['value'] = True
+    timer._monitor.trigger()
+    assert detector_entered.wait(1)
+
+    restart = threading.Thread(target=timer.start, args=(120,))
+    restart.start()
+    time.sleep(0.02)
+    release_detector.set()
+    restart.join(1)
+
+    assert not restart.is_alive()
+    assert timer.get_state()['wait_seconds'] == 120
 
 
 def test_filesystem_fingerprint_detects_metadata_and_missing_roots(tmp_path):

--- a/test/timers/test_multitimer.py
+++ b/test/timers/test_multitimer.py
@@ -6,7 +6,6 @@ import pytest
 
 from jukebox.multitimer import (
     GenericEndlessTimerClass,
-    GenericMultiTimerClass,
     GenericTimerClass,
 )
 
@@ -194,40 +193,3 @@ def test_close_joins_workers_and_prevents_later_starts(publisher):
     timer.start(0)
     assert timer.timer_thread is worker
     assert not worker.is_alive()
-
-
-def test_multi_timer_builds_one_callback_and_preserves_iteration_order(
-        publisher):
-    constructed = []
-    iterations = []
-    complete = threading.Event()
-
-    class Callback:
-        def __init__(self, prefix, *, iterations):
-            constructed.append((prefix, iterations))
-
-        def __call__(self, suffix, *, iteration):
-            iterations.append((suffix, iteration))
-            if iteration == 0:
-                complete.set()
-
-    timer = GenericMultiTimerClass(
-        'test.multi',
-        3,
-        0.01,
-        Callback,
-        args=['builder'],
-        kwargs={},
-    )
-    timer.args = ['callback']
-    timer.start()
-
-    assert complete.wait(1)
-    wait_until(lambda: not timer.is_alive())
-    assert constructed == [('builder', 3)]
-    assert iterations == [
-        ('callback', 2),
-        ('callback', 1),
-        ('callback', 0),
-    ]
-    timer.close()

--- a/test/timers/test_volume_fadeout_shutdown_timer.py
+++ b/test/timers/test_volume_fadeout_shutdown_timer.py
@@ -1,0 +1,334 @@
+import importlib.util
+import logging
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).parents[2]
+MODULE_PATH = (
+    PROJECT_ROOT
+    / 'src/jukebox/components/timers/volume_fadeout_shutdown_timer.py'
+)
+SPEC = importlib.util.spec_from_file_location(
+    'volume_fadeout_timer_under_test',
+    MODULE_PATH,
+)
+fadeout_module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(fadeout_module)
+
+VolumeFadeoutAndShutdown = fadeout_module.VolumeFadeoutAndShutdown
+VolumeFadeoutError = fadeout_module.VolumeFadeoutError
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class Publisher:
+    def __init__(self):
+        self.messages = []
+        self.lock = threading.Lock()
+
+    def send(self, topic, state):
+        with self.lock:
+            self.messages.append((topic, state.copy()))
+
+
+def wait_until(predicate, timeout=1):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.002)
+    pytest.fail('condition was not met before timeout')
+
+
+def fire_scheduled_timer(timer):
+    worker = timer.timer_thread
+    assert worker is not None
+    timer._timer.trigger()
+    wait_until(
+        lambda: timer.timer_thread is not worker or not worker.is_alive(),
+    )
+
+
+@pytest.fixture
+def fadeout_factory(monkeypatch):
+    timers = []
+    publisher = Publisher()
+    config_calls = []
+    monkeypatch.setattr(
+        fadeout_module.publishing,
+        'get_publisher',
+        lambda: publisher,
+    )
+
+    def set_default(*keys, value):
+        config_calls.append((keys, value))
+        return value
+
+    monkeypatch.setattr(fadeout_module.cfg, 'setndefault', set_default)
+
+    def create(
+            *,
+            clock=None,
+            get_volume=lambda: 110,
+            set_volume=lambda volume: None,
+            shutdown_action=lambda: None):
+        timer = VolumeFadeoutAndShutdown(
+            'timers.timer_fade_volume',
+            clock=clock or FakeClock(),
+            get_volume=get_volume,
+            set_volume=set_volume,
+            shutdown_action=shutdown_action,
+        )
+        timers.append(timer)
+        return timer
+
+    yield create, publisher, config_calls
+
+    for timer in timers:
+        timer.close()
+
+
+def test_minimum_validation_and_exact_duration_starts_fade_immediately(
+        fadeout_factory):
+    create, _, _ = fadeout_factory
+    reads = []
+    timer = create(get_volume=lambda: (reads.append(True), 110)[1])
+
+    with pytest.raises(VolumeFadeoutError):
+        timer.start(119)
+
+    timer.start(120)
+
+    assert reads == [True]
+    assert timer.get_state()['fadeout_started'] is True
+    assert timer.get_state()['remaining_seconds'] == 120
+    assert timer.timer_thread is not None
+
+
+def test_restart_false_and_restart_replace_pending_generation(
+        fadeout_factory):
+    create, _, _ = fadeout_factory
+    clock = FakeClock()
+    reads = []
+    timer = create(
+        clock=clock,
+        get_volume=lambda: (reads.append(True), 110)[1],
+    )
+    timer.start(180)
+    first_worker = timer.timer_thread
+
+    timer.start(240, restart=False)
+    assert timer.timer_thread is first_worker
+    assert timer.get_state()['total_duration'] == 180
+
+    timer.start(240)
+    replacement = timer.timer_thread
+    first_worker.trigger()
+    wait_until(lambda: not first_worker.is_alive())
+
+    assert replacement is not first_worker
+    assert reads == []
+    assert timer.get_state()['total_duration'] == 240
+
+
+def test_cancellation_before_and_during_fade_suppresses_future_steps(
+        fadeout_factory):
+    create, _, _ = fadeout_factory
+    clock = FakeClock()
+    writes = []
+    shutdowns = []
+    before = create(
+        clock=clock,
+        set_volume=writes.append,
+        shutdown_action=lambda: shutdowns.append(True),
+    )
+    before.start(180)
+    worker = before.timer_thread
+    before.cancel()
+    worker.trigger()
+    wait_until(lambda: not worker.is_alive())
+    assert writes == []
+
+    during = create(
+        clock=clock,
+        set_volume=writes.append,
+        shutdown_action=lambda: shutdowns.append(True),
+    )
+    during.start(120)
+    clock.advance(10)
+    fire_scheduled_timer(during)
+    during.cancel()
+    time.sleep(0.02)
+
+    assert writes == [110]
+    assert shutdowns == []
+    assert during.get_state()['enabled'] is False
+
+
+def test_restart_during_fade_suppresses_stale_step(fadeout_factory):
+    create, _, _ = fadeout_factory
+    clock = FakeClock()
+    writes = []
+    timer = create(clock=clock, set_volume=writes.append)
+    timer.start(120)
+    stale_worker = timer.timer_thread
+
+    timer.start(120)
+    replacement = timer.timer_thread
+    stale_worker.trigger()
+    wait_until(lambda: not stale_worker.is_alive())
+
+    assert replacement is not stale_worker
+    assert writes == []
+    clock.advance(10)
+    fire_scheduled_timer(timer)
+    assert writes == [110]
+
+
+def test_twelve_ordered_steps_reach_zero_before_one_shutdown(
+        fadeout_factory):
+    create, _, _ = fadeout_factory
+    clock = FakeClock()
+    events = []
+    timer = create(
+        clock=clock,
+        set_volume=lambda volume: events.append(('volume', volume)),
+        shutdown_action=lambda: events.append(('shutdown', None)),
+    )
+    timer.start(120)
+
+    for _ in range(12):
+        clock.advance(10)
+        fire_scheduled_timer(timer)
+
+    assert events == [
+        ('volume', 110),
+        ('volume', 100),
+        ('volume', 90),
+        ('volume', 80),
+        ('volume', 70),
+        ('volume', 60),
+        ('volume', 50),
+        ('volume', 40),
+        ('volume', 30),
+        ('volume', 20),
+        ('volume', 10),
+        ('volume', 0),
+        ('shutdown', None),
+    ]
+    assert timer.get_state()['enabled'] is False
+
+
+def test_volume_read_failure_skips_fade_but_keeps_shutdown(
+        fadeout_factory,
+        caplog):
+    create, _, _ = fadeout_factory
+    clock = FakeClock()
+    shutdowns = []
+
+    def fail_read():
+        raise OSError('mixer unavailable')
+
+    timer = create(
+        clock=clock,
+        get_volume=fail_read,
+        shutdown_action=lambda: shutdowns.append(True),
+    )
+    with caplog.at_level(
+            logging.ERROR,
+            logger='jb.timers.volume_fadeout'):
+        timer.start(120)
+
+    assert timer.get_state()['error'] == 'OSError: mixer unavailable'
+    clock.advance(120)
+    fire_scheduled_timer(timer)
+    assert shutdowns == [True]
+    assert 'fadeout will be skipped' in caplog.text
+
+
+def test_volume_write_failures_are_published_and_later_steps_continue(
+        fadeout_factory):
+    create, publisher, _ = fadeout_factory
+    clock = FakeClock()
+    attempts = []
+    shutdowns = []
+
+    def write(volume):
+        attempts.append(volume)
+        if volume == 100:
+            raise OSError('write failed')
+
+    timer = create(
+        clock=clock,
+        set_volume=write,
+        shutdown_action=lambda: shutdowns.append(True),
+    )
+    timer.start(120)
+    for _ in range(12):
+        clock.advance(10)
+        fire_scheduled_timer(timer)
+
+    assert attempts[-1] == 0
+    assert len(attempts) == 12
+    assert shutdowns == [True]
+    assert any(
+        state['error'] == 'OSError: write failed'
+        for _, state in publisher.messages
+        if state['enabled']
+    )
+
+
+def test_state_progress_remaining_and_publication(fadeout_factory):
+    create, publisher, config_calls = fadeout_factory
+    clock = FakeClock()
+    timer = create(clock=clock)
+    timer.start(180)
+    clock.advance(45)
+
+    state = timer.get_state()
+    assert state['type'] == 'VolumeFadoutAndShutdown'
+    assert state['remaining_seconds'] == 135
+    assert state['progress_percent'] == 25
+    assert state['error'] is None
+    assert config_calls == [
+        (('timers', 'volume_fadeout', 'default_timeout_sec'), 600),
+    ]
+    assert all(
+        topic == 'timers.timer_fade_volume'
+        for topic, _ in publisher.messages
+    )
+
+
+def test_compatibility_alias_and_obsolete_defaults_are_removed():
+    assert (
+        fadeout_module.VolumeFadoutAndShutdown
+        is fadeout_module.VolumeFadeoutAndShutdown
+    )
+    config = (
+        PROJECT_ROOT / 'resources/default-settings/jukebox.default.yaml'
+    ).read_text()
+    assert 'volume_fade_out:' not in config
+    assert 'timer_fade_volume:' not in config
+    assert 'volume_fadeout:' in config
+
+
+def test_generic_multi_timer_has_no_remaining_consumers():
+    source_root = PROJECT_ROOT / 'src'
+    references = []
+    for path in source_root.rglob('*.py'):
+        if 'GenericMultiTimerClass' in path.read_text():
+            references.append(path)
+    assert references == []


### PR DESCRIPTION
## Summary

- replace three coordinated fade/shutdown timers with one controller and one reschedulable one-shot worker
- schedule 12 absolute-deadline fade steps and complete the zero-volume write before requesting shutdown once
- preserve shutdown through volume read/write failures and suppress cancelled/restarted generations
- publish public fade state on starts, phase changes, steps, errors, cancellation, and completion
- correct the implementation name while retaining the misspelled compatibility alias and state type string
- canonicalize the tracked `volume_fadeout.default_timeout_sec` default and remove the final `GenericMultiTimerClass` consumer, implementation, tests, and docs
- remove controller/worker lock inversion found at idle poll boundaries

Part of #2687.

## Verification

- `./run_pytest.sh` (`136 passed, 1 skipped`)
- `./run_flake8.sh`

A Raspberry Pi debug-mode shutdown smoke check remains hardware-only.
