### PR TITLE
Make timer UI backend-authoritative

### DIFF
--- a/src/webapp/e2e/webapp.spec.js
+++ b/src/webapp/e2e/webapp.spec.js
@@ -69,10 +69,17 @@ const socketEvents = {
 
 async function mockBackend(
   page,
-  { failRpc = false, rpcGate, showCovers = false } = {},
+  {
+    failRpc = false,
+    rpcGate,
+    showCovers = false,
+    timerEvents = {},
+  } = {},
 ) {
+  const eventSockets = new Set();
   const libraryCalls = [];
   const rpcCalls = [];
+  const subscribedTopics = new Set();
 
   await page.addInitScript(() => {
     window.localStorage.setItem('i18nextLng', 'en');
@@ -129,6 +136,7 @@ async function mockBackend(
   }));
 
   await page.routeWebSocket('**/api/v1/events', socket => {
+    eventSockets.add(socket);
     socket.onMessage(message => {
       const payload = JSON.parse(message);
       if (payload.type !== 'subscribe') {
@@ -136,18 +144,35 @@ async function mockBackend(
       }
 
       payload.topics.forEach(topic => {
-        if (topic in socketEvents) {
+        subscribedTopics.add(topic);
+        const events = { ...socketEvents, ...timerEvents };
+        if (topic in events) {
           socket.send(JSON.stringify({
             type: 'event',
             topic,
-            data: socketEvents[topic],
+            data: events[topic],
           }));
         }
       });
     });
   });
 
-  return { libraryCalls, rpcCalls };
+  const publishEvent = (topic, data) => {
+    eventSockets.forEach(socket => {
+      socket.send(JSON.stringify({
+        type: 'event',
+        topic,
+        data,
+      }));
+    });
+  };
+
+  return {
+    libraryCalls,
+    publishEvent,
+    rpcCalls,
+    subscribedTopics,
+  };
 }
 
 async function expectStableLayout(page) {
@@ -362,4 +387,64 @@ test('RPC failures leave navigation and an error state available', async ({ page
   await expect(page.getByText('An error occurred while loading cards list.')).toBeVisible();
   await expect(page.getByRole('link', { name: 'Settings' })).toBeVisible();
   await expectStableLayout(page);
+});
+
+test('timer settings follow authoritative backend state', async ({ page }) => {
+  const timerTopic = 'timers.timer_shutdown';
+  const {
+    publishEvent,
+    rpcCalls,
+    subscribedTopics,
+  } = await mockBackend(page);
+  await page.goto('/#/settings');
+
+  const shutdownTimer = page.getByRole('listitem').filter({
+    has: page.getByText('Shut Down', { exact: true }),
+  });
+  await expect.poll(() => Array.from(subscribedTopics)).toContain(timerTopic);
+  publishEvent(timerTopic, {
+    enabled: true,
+    remaining_seconds: 3600,
+  });
+  await expect(page.getByText('1:00:00')).toBeVisible();
+  await shutdownTimer.getByRole('button', { name: 'Cancel' }).click();
+  await expect(
+    shutdownTimer.getByRole('button', { name: 'Set timer' }),
+  ).toBeVisible();
+  await expect.poll(() => (
+    rpcCalls.filter(call => (
+      call.plugin === 'timer_shutdown' && call.method === 'cancel'
+    )).length
+  )).toBe(1);
+
+  publishEvent(timerTopic, {
+    enabled: true,
+    remaining_seconds: 7200,
+  });
+  await expect(page.getByText('2:00:00')).toBeVisible();
+
+  publishEvent(timerTopic, {
+    enabled: false,
+    remaining_seconds: 0,
+  });
+  const setTimer = shutdownTimer.getByRole('button', { name: 'Set timer' });
+  await expect(setTimer).toBeVisible();
+  await setTimer.click();
+  const slider = page.getByRole('slider');
+  await slider.press('ArrowRight');
+  await slider.press('ArrowRight');
+  await page.getByRole('button', { name: 'Start timer' }).click();
+
+  await expect.poll(() => (
+    rpcCalls.filter(call => (
+      call.plugin === 'timer_shutdown' && call.method === 'start'
+    ))
+  )).toHaveLength(1);
+  const [startCall] = rpcCalls.filter(call => (
+    call.plugin === 'timer_shutdown' && call.method === 'start'
+  ));
+  expect(startCall.kwargs).toEqual({ wait_seconds: 300 });
+  expect(rpcCalls.filter(call => (
+    call.plugin === 'timer_shutdown' && call.method === 'cancel'
+  ))).toHaveLength(1);
 });

--- a/src/webapp/public/locales/de/translation.json
+++ b/src/webapp/public/locales/de/translation.json
@@ -85,7 +85,8 @@
           }
         },
         "timers": {
-          "description": "Wähle die Anzahl der Minuten nachdem die Aktion ausgeführt werden soll."
+          "description": "Wähle die Anzahl der Minuten nachdem die Aktion ausgeführt werden soll.",
+          "restart": "Laufenden Timer neu starten"
         },
         "synchronisation": {
           "rfidcards": {

--- a/src/webapp/public/locales/en/translation.json
+++ b/src/webapp/public/locales/en/translation.json
@@ -85,7 +85,8 @@
           }
         },
         "timers": {
-          "description": "Choose the amount of minutes you want the action to be performed."
+          "description": "Choose the amount of minutes you want the action to be performed.",
+          "restart": "Restart existing timer"
         },
         "synchronisation": {
           "rfidcards": {

--- a/src/webapp/src/commands/index.js
+++ b/src/webapp/src/commands/index.js
@@ -180,7 +180,8 @@ const commands = {
     _package: 'timers',
     plugin: 'timer_fade_volume',
     method: 'start',
-    argKeys: ['wait_seconds'],
+    argKeys: ['wait_seconds', 'restart'],
+    argDefaults: { restart: true },
   },
   'timer_shutdown.cancel': {
     _package: 'timers',
@@ -196,7 +197,8 @@ const commands = {
     _package: 'timers',
     plugin: 'timer_shutdown',
     method: 'start',
-    argKeys: ['wait_seconds'],
+    argKeys: ['wait_seconds', 'restart'],
+    argDefaults: { restart: true },
   },
   'timer_stop_player.cancel': {
     _package: 'timers',
@@ -212,7 +214,8 @@ const commands = {
     _package: 'timers',
     plugin: 'timer_stop_player',
     method: 'start',
-    argKeys: ['wait_seconds'],
+    argKeys: ['wait_seconds', 'restart'],
+    argDefaults: { restart: true },
   },
 
 
@@ -230,7 +233,8 @@ const commands = {
     _package: 'timers',
     plugin: 'timer_idle_shutdown',
     method: 'start',
-    argKeys: ['wait_seconds'],
+    argKeys: ['wait_seconds', 'restart'],
+    argDefaults: { restart: true },
   },
 
 

--- a/src/webapp/src/components/Cards/controls/actions-controls.test.jsx
+++ b/src/webapp/src/components/Cards/controls/actions-controls.test.jsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { expect, test, vi } from 'vitest';
+
+import request from '../../../utils/request';
+import ActionsControls from './actions-controls';
+
+
+vi.mock('../../../utils/request', () => ({
+  default: vi.fn().mockResolvedValue({ result: null }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: key => ({
+      'general.buttons.delete': 'Delete',
+      'general.buttons.save': 'Save',
+    })[key] || key,
+  }),
+}));
+
+test('saving a legacy timer card submits restart=true', async () => {
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter initialEntries={['/cards/123/edit']}>
+      <Routes>
+        <Route
+          path="/cards/:cardId/edit"
+          element={
+            <ActionsControls
+              actionData={{
+                action: 'timers',
+                command: {
+                  name: 'timer_shutdown',
+                  args: { wait_seconds: 300 },
+                },
+              }}
+              cardId="123"
+            />
+          }
+        />
+        <Route path="/cards" element={<div>Cards</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Save' }));
+
+  await waitFor(() => {
+    expect(request).toHaveBeenCalledWith('registerCard', {
+      card_id: '123',
+      cmd_alias: 'timer_shutdown',
+      overwrite: true,
+      args: [300, true],
+    });
+  });
+});

--- a/src/webapp/src/components/Cards/controls/actions/timers/slider-set-timer.jsx
+++ b/src/webapp/src/components/Cards/controls/actions/timers/slider-set-timer.jsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
 
 import {
+  Checkbox,
+  FormControlLabel,
   Grid,
   Typography,
 } from '@mui/material';
@@ -18,10 +20,17 @@ const SliderSetTimer = ({
   const { t } = useTranslation();
 
   const { action, command } = getActionAndCommand(actionData);
-  const [wait_seconds] = getArgsValues(actionData);
+  const [wait_seconds, restart = true] = getArgsValues(actionData);
 
   const onChangeCommitted = (event, wait_seconds) => {
-    handleActionDataChange(action, command, { wait_seconds })
+    handleActionDataChange(action, command, { wait_seconds, restart })
+  };
+
+  const onRestartChange = (event) => {
+    handleActionDataChange(action, command, {
+      wait_seconds,
+      restart: event.target.checked,
+    });
   };
 
   return (
@@ -39,6 +48,15 @@ const SliderSetTimer = ({
         <SliderTimer
           value={wait_seconds || 0}
           onChangeCommitted={onChangeCommitted}
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={restart}
+              onChange={onRestartChange}
+            />
+          }
+          label={t('cards.controls.actions.timers.restart')}
         />
       </Grid>
     </Grid>

--- a/src/webapp/src/components/Cards/controls/actions/timers/slider-set-timer.test.jsx
+++ b/src/webapp/src/components/Cards/controls/actions/timers/slider-set-timer.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test, vi } from 'vitest';
+
+import SliderSetTimer from './slider-set-timer';
+
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: key => ({
+      'cards.controls.actions.timers.description': 'Timer duration',
+      'cards.controls.actions.timers.restart': 'Restart existing timer',
+    })[key] || key,
+  }),
+}));
+
+test('legacy timer cards default restart on and persist checkbox changes', async () => {
+  const user = userEvent.setup();
+  const handleActionDataChange = vi.fn();
+  render(
+    <SliderSetTimer
+      actionData={{
+        action: 'timers',
+        command: {
+          name: 'timer_shutdown',
+          args: { wait_seconds: 300 },
+        },
+      }}
+      handleActionDataChange={handleActionDataChange}
+    />,
+  );
+
+  const restart = screen.getByRole('checkbox', {
+    name: 'Restart existing timer',
+  });
+  expect(restart).toBeChecked();
+  await user.click(restart);
+
+  expect(handleActionDataChange).toHaveBeenCalledWith(
+    'timers',
+    'timer_shutdown',
+    {
+      wait_seconds: 300,
+      restart: false,
+    },
+  );
+});

--- a/src/webapp/src/components/Cards/utils.js
+++ b/src/webapp/src/components/Cards/utils.js
@@ -61,9 +61,14 @@ const buildActionData = (action, command = {}, args = {}) => {
 const getArgsValues = (actionData) => {
   const { command } = getActionAndCommand(actionData);
   const argKeys = getCommandArgKeys(command);
+  const { [command]: { argDefaults = {} } = {} } = commands;
 
   return argKeys.map(
-    key => actionData.command.args[key]
+    key => (
+      actionData.command.args[key] === undefined
+        ? argDefaults[key]
+        : actionData.command.args[key]
+    )
   );
 };
 

--- a/src/webapp/src/components/Cards/utils.test.js
+++ b/src/webapp/src/components/Cards/utils.test.js
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest';
+
+import commands from '../../commands';
+import {
+  buildActionData,
+  getArgsValues,
+} from './utils';
+
+
+test('timer commands map and default the restart argument', () => {
+  for (const command of [
+    'timer_fade_volume',
+    'timer_idle_shutdown',
+    'timer_shutdown',
+    'timer_stop_player',
+  ]) {
+    expect(commands[command].argKeys).toEqual(['wait_seconds', 'restart']);
+  }
+
+  const legacy = buildActionData(
+    'timers',
+    'timer_shutdown',
+    [300],
+  );
+  expect(getArgsValues(legacy)).toEqual([300, true]);
+
+  const explicit = buildActionData(
+    'timers',
+    'timer_shutdown',
+    [300, false],
+  );
+  expect(getArgsValues(explicit)).toEqual([300, false]);
+});

--- a/src/webapp/src/components/Settings/timers/timer.jsx
+++ b/src/webapp/src/components/Settings/timers/timer.jsx
@@ -1,67 +1,84 @@
-import { useCallback, useEffect, useState } from 'react';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, ListItem, ListItemText, Typography } from '@mui/material';
 import { Countdown } from '../../general';
+import PubSubContext from '../../../context/pubsub/context';
 import SetTimerDialog from './set-timer-dialog';
 import request from '../../../utils/request';
 
 // Custom hook to manage timer state and logic
 const useTimer = (type) => {
   const pluginName = `timer_${type.replace('-', '_')}`;
+  const topic = `timers.${pluginName}`;
+  const { state: publisherState = {} } = useContext(PubSubContext);
+  const publishedStatus = publisherState[topic];
+  const publisherVersion = useRef(0);
+  const hasPublishedState = useRef(false);
   const [timerState, setTimerState] = useState({
     error: null,
     enabled: false,
     isLoading: true,
     status: { enabled: false },
     waitSeconds: 0,
-    running: true
+    running: true,
+    revision: 0,
   });
 
+  const applyTimerStatus = useCallback((timerStatus) => {
+    setTimerState(prev => ({
+      ...prev,
+      status: timerStatus,
+      enabled: timerStatus?.enabled ?? false,
+      running: timerStatus?.running ?? true,
+      error: null,
+      isLoading: false,
+      revision: prev.revision + 1,
+    }));
+  }, []);
+
   const fetchTimerStatus = useCallback(async () => {
-    try {
-      const { result: timerStatus, error: timerStatusError } = await request(`${pluginName}.get_state`);
-
-      if (timerStatusError) {
-        throw timerStatusError;
-      }
-
+    const requestedAtVersion = publisherVersion.current;
+    const { result: timerStatus, error } = await request(
+      `${pluginName}.get_state`,
+    );
+    if (error) {
       setTimerState(prev => ({
         ...prev,
-        status: timerStatus,
-        enabled: timerStatus?.enabled,
-        running: timerStatus.running ?? true,
-        error: null,
-        isLoading: false
-      }));
-    } catch (error) {
-      setTimerState(prev => ({
-        ...prev,
-        enabled: false,
         error,
-        isLoading: false
+        isLoading: false,
       }));
+      return;
     }
-  }, [pluginName]);
+    if (publisherVersion.current === requestedAtVersion) {
+      applyTimerStatus(timerStatus);
+    }
+  }, [applyTimerStatus, pluginName]);
 
   const cancelTimer = async () => {
-    try {
-      await request(`${pluginName}.cancel`);
-      setTimerState(prev => ({ ...prev, enabled: false }));
-    } catch (error) {
+    const { error } = await request(`${pluginName}.cancel`);
+    if (error) {
       setTimerState(prev => ({ ...prev, error }));
+      return;
     }
+    await fetchTimerStatus();
   };
 
   const setTimer = async (wait_seconds) => {
-    try {
-      await cancelTimer();
-      if (wait_seconds > 0) {
-        await request(pluginName, { wait_seconds });
-        await fetchTimerStatus();
-      }
-    } catch (error) {
-      setTimerState(prev => ({ ...prev, error }));
+    if (wait_seconds <= 0) {
+      return;
     }
+    const { error } = await request(pluginName, { wait_seconds });
+    if (error) {
+      setTimerState(prev => ({ ...prev, error }));
+      return;
+    }
+    await fetchTimerStatus();
   };
 
   const setWaitSeconds = (seconds) => {
@@ -72,6 +89,17 @@ const useTimer = (type) => {
     fetchTimerStatus();
   }, [fetchTimerStatus]);
 
+  useEffect(() => {
+    if (publishedStatus !== undefined) {
+      hasPublishedState.current = true;
+      publisherVersion.current += 1;
+      applyTimerStatus(publishedStatus);
+    }
+    else if (hasPublishedState.current) {
+      fetchTimerStatus();
+    }
+  }, [applyTimerStatus, fetchTimerStatus, publishedStatus]);
+
   return {
     ...timerState,
     setTimer,
@@ -81,7 +109,7 @@ const useTimer = (type) => {
 };
 
 // Separate component for timer actions
-const TimerActions = ({ enabled, running, status, error, isLoading, type, onSetTimer, onCancelTimer, waitSeconds, onSetWaitSeconds }) => {
+const TimerActions = ({ enabled, running, status, revision, error, isLoading, type, onSetTimer, onCancelTimer, waitSeconds, onSetWaitSeconds }) => {
   const { t } = useTranslation();
 
   return (
@@ -89,7 +117,7 @@ const TimerActions = ({ enabled, running, status, error, isLoading, type, onSetT
       {enabled && running && (
         <Countdown
           seconds={status.remaining_seconds}
-          onEnd={() => onCancelTimer()}
+          resetKey={revision}
           stringEnded={t('settings.timers.ended')}
         />
       )}
@@ -137,3 +165,8 @@ const Timer = ({ type }) => {
 };
 
 export default Timer;
+
+export {
+  TimerActions,
+  useTimer,
+};

--- a/src/webapp/src/components/Settings/timers/timer.test.jsx
+++ b/src/webapp/src/components/Settings/timers/timer.test.jsx
@@ -1,0 +1,157 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  afterEach,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+import PubSubContext from '../../../context/pubsub/context';
+import request from '../../../utils/request';
+import Timer, { useTimer } from './timer';
+
+
+vi.mock('../../../utils/request', () => ({
+  default: vi.fn(),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: key => ({
+      'settings.timers.shutdown.title': 'Shut Down',
+      'settings.timers.shutdown.label': 'Shutdown timer',
+      'settings.timers.ended': 'Done',
+      'settings.timers.set': 'Set timer',
+      'settings.timers.cancel': 'Cancel',
+    })[key] || key,
+  }),
+}));
+
+const provider = (state, child) => (
+  <PubSubContext.Provider value={{ state, setState: vi.fn() }}>
+    {child}
+  </PubSubContext.Provider>
+);
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise(promiseResolve => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+};
+
+beforeEach(() => {
+  request.mockResolvedValue({
+    result: {
+      enabled: false,
+      remaining_seconds: 0,
+    },
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+test('uses RPC initially and publisher events for remote restart and cancel', async () => {
+  request.mockResolvedValueOnce({
+    result: {
+      enabled: true,
+      remaining_seconds: 60,
+    },
+  });
+  const { rerender } = render(provider({}, <Timer type="shutdown" />));
+
+  expect(await screen.findByText('1:00')).toBeVisible();
+
+  rerender(provider({
+    'timers.timer_shutdown': {
+      enabled: true,
+      remaining_seconds: 120,
+    },
+  }, <Timer type="shutdown" />));
+  expect(await screen.findByText('2:00')).toBeVisible();
+
+  rerender(provider({
+    'timers.timer_shutdown': {
+      enabled: false,
+      remaining_seconds: 0,
+    },
+  }, <Timer type="shutdown" />));
+  expect(await screen.findByRole('button', { name: 'Set timer' })).toBeVisible();
+});
+
+test('does not let a late RPC fallback overwrite publisher state', async () => {
+  const rpc = deferred();
+  request.mockReturnValueOnce(rpc.promise);
+  const { rerender } = render(provider({}, <Timer type="shutdown" />));
+
+  rerender(provider({
+    'timers.timer_shutdown': {
+      enabled: true,
+      remaining_seconds: 300,
+    },
+  }, <Timer type="shutdown" />));
+  expect(await screen.findByText('5:00')).toBeVisible();
+
+  await act(async () => {
+    rpc.resolve({
+      result: {
+        enabled: false,
+        remaining_seconds: 0,
+      },
+    });
+    await rpc.promise;
+  });
+
+  expect(screen.getByText('5:00')).toBeVisible();
+});
+
+test('local countdown expiry does not cancel the backend timer', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  render(provider({
+    'timers.timer_shutdown': {
+      enabled: true,
+      remaining_seconds: 1,
+    },
+  }, <Timer type="shutdown" />));
+
+  await act(async () => {
+    await Promise.resolve();
+    vi.advanceTimersByTime(1500);
+  });
+
+  expect(screen.getByText('Done')).toBeVisible();
+  expect(request).not.toHaveBeenCalledWith('timer_shutdown.cancel');
+});
+
+const HookHarness = () => {
+  const timer = useTimer('shutdown');
+  return (
+    <>
+      <button onClick={() => timer.setTimer(300)}>Start</button>
+      <button onClick={timer.cancelTimer}>Cancel timer</button>
+    </>
+  );
+};
+
+test('start relies on backend restart defaults without cancelling first', async () => {
+  const user = userEvent.setup();
+  render(provider({}, <HookHarness />));
+  await waitFor(() => (
+    expect(request).toHaveBeenCalledWith('timer_shutdown.get_state')
+  ));
+  request.mockClear();
+
+  await user.click(screen.getByRole('button', { name: 'Start' }));
+
+  expect(request).toHaveBeenCalledWith(
+    'timer_shutdown',
+    { wait_seconds: 300 },
+  );
+  expect(request).not.toHaveBeenCalledWith('timer_shutdown.cancel');
+});

--- a/src/webapp/src/components/general/Countdown.js
+++ b/src/webapp/src/components/general/Countdown.js
@@ -1,27 +1,28 @@
-import { useCallback, useEffect, useRef,  useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { toHHMMSS } from '../../utils/utils';
 
-const Countdown = ({ onEnd, seconds, stringEnded = undefined }) => {
-  // This is required to avoid async updates on unmounted compomemts
-  // https://github.com/facebook/react/issues/14227
-  const isMounted = useRef(null);
-  const [time, setTime] = useState(seconds);
+const normalizeSeconds = (seconds) => (
+  Math.max(0, Number(seconds) || 0)
+);
 
-  const onEndCallback = useCallback(() => onEnd(), [onEnd]);
+const Countdown = ({ resetKey, seconds, stringEnded = undefined }) => {
+  const [time, setTime] = useState(() => normalizeSeconds(seconds));
 
   useEffect(() => {
-    isMounted.current = true;
+    const initialSeconds = normalizeSeconds(seconds);
+    const deadline = Date.now() + initialSeconds * 1000;
+    setTime(initialSeconds);
 
-    if (time === 0) return onEndCallback();
-    setTimeout(() => {
-      if (isMounted.current) setTime(time - 1)
-    }, 1000);
-
-    return () => {
-      isMounted.current = false;
+    if (initialSeconds === 0) {
+      return undefined;
     }
-  }, [onEndCallback, time]);
+
+    const interval = setInterval(() => {
+      setTime(Math.max(0, (deadline - Date.now()) / 1000));
+    }, 250);
+    return () => clearInterval(interval);
+  }, [resetKey, seconds]);
 
   if (time) return toHHMMSS(Math.round(time));
   if (stringEnded) return stringEnded;

--- a/src/webapp/src/components/general/Countdown.test.jsx
+++ b/src/webapp/src/components/general/Countdown.test.jsx
@@ -1,0 +1,47 @@
+import { act, render, screen } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+import Countdown from './Countdown';
+
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test('resets its local deadline when authoritative state changes', () => {
+  const { rerender } = render(
+    <Countdown resetKey={1} seconds={5} stringEnded="Done" />,
+  );
+  expect(screen.getByText('0:05')).toBeVisible();
+
+  act(() => {
+    vi.advanceTimersByTime(2000);
+  });
+  expect(screen.getByText('0:03')).toBeVisible();
+
+  rerender(
+    <Countdown resetKey={2} seconds={10} stringEnded="Done" />,
+  );
+  expect(screen.getByText('0:10')).toBeVisible();
+});
+
+test('clamps at zero and only changes its display on expiry', () => {
+  render(<Countdown resetKey={1} seconds={1} stringEnded="Done" />);
+
+  act(() => {
+    vi.advanceTimersByTime(1500);
+  });
+
+  expect(screen.getByText('Done')).toBeVisible();
+});

--- a/src/webapp/src/config.js
+++ b/src/webapp/src/config.js
@@ -10,6 +10,10 @@ const SUBSCRIPTIONS = [
   'host.temperature.cpu',
   'playerstatus',
   'rfid.card_id',
+  'timers.timer_fade_volume',
+  'timers.timer_idle_shutdown',
+  'timers.timer_shutdown',
+  'timers.timer_stop_player',
   'volume.level',
 ];
 


### PR DESCRIPTION
## Summary

- subscribe the Web App to all four public timer topics and use RPC state only for initial/fallback loading
- ignore late RPC responses after publisher events and reset display countdowns from each authoritative state revision
- make countdown expiry display-only and remove cancel-before-start from the live Settings UI
- add the `restart` timer-card argument with a checked-by-default control and `true` fallback for legacy cards
- preserve existing timer labels and disabled, paused, and ended presentation
- add unit coverage for publisher/RPC ordering, countdown behavior, card defaults, and request payloads
- add desktop/mobile Playwright coverage for remote start, restart, cancellation, and local commands

Part of #2687.

## Verification

- `mise exec node@22.22.0 -- npm run lint`
- `mise exec node@22.22.0 -- npm test` (`10 test files, 26 tests passed`)
- `mise exec node@22.22.0 -- npm run build`
- `mise exec node@22.22.0 -- npx playwright test -g "timer settings follow authoritative backend state"` (`2 passed`, desktop and mobile)