### PR TITLE
Make idle shutdown deadline persistent

### DIFF
--- a/resources/default-settings/jukebox.default.yaml
+++ b/resources/default-settings/jukebox.default.yaml
@@ -111,6 +111,7 @@ timers:
   idle_shutdown:
     # If you want the box to shutdown on inactivity automatically, configure timeout_sec with a number of seconds (at least 60).
     # Inactivity is defined as: no music playing, no active SSH sessions, no changes in configs or audio content.
+    # The setting persists across reboots until it is cancelled or set to 0.
     timeout_sec: 0
   # These timers are always disabled after start
   # The following values only give the default values.

--- a/src/jukebox/components/timers/idle_shutdown_timer.py
+++ b/src/jukebox/components/timers/idle_shutdown_timer.py
@@ -239,6 +239,40 @@ class IdleShutdownTimer:
         self._snapshot_error_logged = False
         return snapshot
 
+    @staticmethod
+    def _persist_timeout(timeout):
+        with cfg:
+            previous_timeout = cfg.getn(
+                'timers',
+                'idle_shutdown',
+                'timeout_sec',
+                default=0,
+            )
+            cfg.setn(
+                'timers',
+                'idle_shutdown',
+                'timeout_sec',
+                value=timeout,
+            )
+            try:
+                cfg.save(only_if_changed=True)
+            except Exception:
+                cfg.setn(
+                    'timers',
+                    'idle_shutdown',
+                    'timeout_sec',
+                    value=previous_timeout,
+                )
+                raise
+
+    def _start_countdown_locked(self, now):
+        self._running = True
+        self._deadline = now + self._wait_seconds
+        if self._wait_seconds <= self._grace_seconds:
+            self._phase = _PHASE_GRACE
+        else:
+            self._phase = _PHASE_COUNTDOWN
+
     def _begin_locked(self, wait_seconds):
         self._controller_generation += 1
         now = self._clock()
@@ -246,13 +280,12 @@ class IdleShutdownTimer:
         self._enabled = True
         self._running = False
         self._shutdown_latched = False
-        self._deadline = now + wait_seconds
         self._baseline = self._take_snapshot_locked()
         if self._baseline is None:
             self._phase = _PHASE_NEEDS_BASELINE
+            self._deadline = now + wait_seconds
         else:
-            self._phase = _PHASE_COUNTDOWN
-            self._running = True
+            self._start_countdown_locked(now)
         self._publish_locked()
         return self._controller_generation
 
@@ -279,12 +312,7 @@ class IdleShutdownTimer:
         with self._lock:
             if self._enabled and not restart:
                 return
-            cfg.setn(
-                'timers',
-                'idle_shutdown',
-                'timeout_sec',
-                value=timeout,
-            )
+            self._persist_timeout(timeout)
             generation = self._begin_locked(timeout)
         self._start_monitor(generation)
 
@@ -292,12 +320,7 @@ class IdleShutdownTimer:
     def cancel(self):
         """Disable idle shutdown and persist the disabled configuration."""
         with self._lock:
-            cfg.setn(
-                'timers',
-                'idle_shutdown',
-                'timeout_sec',
-                value=0,
-            )
+            self._persist_timeout(0)
             transitioned = self._enabled
             self._enabled = False
             self._controller_generation += 1
@@ -348,9 +371,7 @@ class IdleShutdownTimer:
                 self._publish_locked()
             return
         self._baseline = snapshot
-        self._running = True
-        self._phase = _PHASE_COUNTDOWN
-        self._deadline = now + self._wait_seconds
+        self._start_countdown_locked(now)
         self._publish_locked()
 
     def _postpone_for_detector_error_locked(self, now, errors):
@@ -374,10 +395,12 @@ class IdleShutdownTimer:
             self._publish_locked()
             return False
         if self._baseline != snapshot:
+            logger.info(
+                'Filesystem activity detected; restarting idle shutdown '
+                'countdown',
+            )
             self._baseline = snapshot
-            self._running = True
-            self._phase = _PHASE_COUNTDOWN
-            self._deadline = now + self._wait_seconds
+            self._start_countdown_locked(now)
             self._publish_locked()
             return False
         return True
@@ -407,17 +430,25 @@ class IdleShutdownTimer:
             self._capture_baseline_locked(now)
             return False
 
-        if now < self._deadline:
-            return False
-
-        if not self._check_filesystem_locked(now):
-            return False
-
         if self._phase == _PHASE_COUNTDOWN:
+            verification_at = self._deadline - self._grace_seconds
+            if now < verification_at:
+                return False
+            if not self._check_filesystem_locked(now):
+                return False
             self._phase = _PHASE_GRACE
-            self._deadline = now + self._grace_seconds
+            logger.info(
+                'Idle shutdown entered its final filesystem verification '
+                'window',
+            )
             self._publish_locked()
-            return False
+            if now < self._deadline:
+                return False
+        else:
+            if now < self._deadline:
+                return False
+            if not self._check_filesystem_locked(now):
+                return False
 
         self._shutdown_latched = True
         self._enabled = False

--- a/test/timers/test_idle_shutdown_timer.py
+++ b/test/timers/test_idle_shutdown_timer.py
@@ -71,6 +71,12 @@ def controller_factory(monkeypatch):
         'setn',
         lambda *keys, value: config_writes.append((keys, value)),
     )
+    publisher.config_saves = []
+    monkeypatch.setattr(
+        idle_shutdown.cfg,
+        'save',
+        lambda **kwargs: publisher.config_saves.append(kwargs),
+    )
 
     def create(
             *,
@@ -79,7 +85,9 @@ def controller_factory(monkeypatch):
             playback_detector=lambda: False,
             ssh_detector=lambda: False,
             snapshotter=lambda: ('baseline',),
-            shutdown_action=lambda: None):
+            shutdown_action=lambda: None,
+            check_interval=3600,
+            grace_seconds=60):
         timer = IdleShutdownTimer(
             'timers',
             idle_timeout,
@@ -87,8 +95,8 @@ def controller_factory(monkeypatch):
             playback_detector=playback_detector,
             ssh_detector=ssh_detector,
             snapshotter=snapshotter,
-            check_interval=3600,
-            grace_seconds=60,
+            check_interval=check_interval,
+            grace_seconds=grace_seconds,
             shutdown_action=shutdown_action,
         )
         controllers.append(timer)
@@ -129,6 +137,19 @@ def test_disabled_and_invalid_startup_create_no_monitor_thread(
         'wait_seconds': 0,
     }
     assert 'remains disabled' in caplog.text
+
+
+def test_persisted_timeout_starts_monitor_without_rewriting_configuration(
+        controller_factory):
+    create, config_writes, publisher = controller_factory
+    timer = create(idle_timeout=1800)
+
+    assert timer.get_state()['enabled'] is True
+    assert timer.get_state()['running'] is True
+    assert timer.get_state()['wait_seconds'] == 1800
+    assert timer.timer_thread.is_alive()
+    assert config_writes == []
+    assert publisher.config_saves == []
 
 
 def test_enable_restart_and_restart_false(controller_factory):
@@ -182,7 +203,7 @@ def test_playback_ssh_and_file_activity_reset_deadline(
     create, _, _ = controller_factory
     clock = FakeClock()
     activity = {'playback': False, 'ssh': False}
-    snapshots = SnapshotSequence(('a',), ('b',), ('c',))
+    snapshots = SnapshotSequence(('a',), ('b',), ('c',), ('d',))
     timer = create(
         clock=clock,
         playback_detector=lambda: activity['playback'],
@@ -231,7 +252,7 @@ def test_filesystem_scans_only_at_baseline_expiry_and_grace(
         snapshotter=snapshots,
         shutdown_action=lambda: shutdowns.append(True),
     )
-    timer.start(60)
+    timer.start(120)
 
     for _ in range(5):
         clock.advance(10)
@@ -334,8 +355,6 @@ def test_shutdown_is_latched_and_published_once(controller_factory):
     timer.start(60)
     clock.advance(60)
     timer._poll()
-    clock.advance(60)
-    timer._poll()
     timer._poll()
 
     disabled = [
@@ -349,9 +368,33 @@ def test_shutdown_is_latched_and_published_once(controller_factory):
     assert timer.get_state()['enabled'] is False
 
 
+def test_periodic_worker_reaches_shutdown_without_manual_poll(
+        controller_factory):
+    create, _, _ = controller_factory
+    snapshots = SnapshotSequence(('same',))
+    shutdowns = []
+    timer = create(
+        clock=time.monotonic,
+        snapshotter=snapshots,
+        shutdown_action=lambda: shutdowns.append(True),
+        check_interval=0.01,
+        grace_seconds=0.03,
+    )
+
+    with timer._lock:
+        generation = timer._begin_locked(0.06)
+    timer._start_monitor(generation)
+
+    wait_until(lambda: shutdowns == [True])
+    wait_until(lambda: not timer.timer_thread.is_alive())
+
+    assert snapshots.calls >= 2
+    assert timer.get_state()['enabled'] is False
+
+
 def test_cancel_persists_zero_while_close_preserves_configuration(
         controller_factory):
-    create, config_writes, _ = controller_factory
+    create, config_writes, publisher = controller_factory
     cancelled = create()
     cancelled.start(60)
     cancelled.cancel()
@@ -360,15 +403,21 @@ def test_cancel_persists_zero_while_close_preserves_configuration(
         ('timers', 'idle_shutdown', 'timeout_sec'),
         0,
     )
+    assert publisher.config_saves == [
+        {'only_if_changed': True},
+        {'only_if_changed': True},
+    ]
     assert cancelled.get_state()['enabled'] is False
 
     preserved = create()
     preserved.start(120)
     writes_before_close = list(config_writes)
+    saves_before_close = list(publisher.config_saves)
     worker = preserved.timer_thread
     preserved.close()
 
     assert config_writes == writes_before_close
+    assert publisher.config_saves == saves_before_close
     assert not worker.is_alive()
 
 


### PR DESCRIPTION
## Summary

- run the 60-second filesystem verification window inside the configured idle duration instead of extending the visible countdown by another minute
- flush idle timeout enable/cancel changes to `jukebox.yaml` immediately
- continue enabling idle monitoring automatically from a persisted non-zero timeout at daemon startup
- add journal messages when filesystem activity restarts the countdown and when final verification begins
- add real periodic-worker shutdown coverage in addition to fake-clock state-machine tests

This follows Raspberry Pi testing of #2689 where activity correctly reset the countdown but shutdown was not observed at the displayed deadline. The existing worker reaches its shutdown callback in a threaded test; the hidden post-countdown grace period was the likely mismatch. Hardware confirmation of the actual host shutdown remains required before merge.

Part of #2687.

## Verification

- `./run_pytest.sh` (`138 passed, 1 skipped`)
- `./run_flake8.sh`