### PR TITLE
Execute host power commands and shutdown jingle reliably

### DIFF
--- a/installation/routines/setup_jukebox_core.sh
+++ b/installation/routines/setup_jukebox_core.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 JUKEBOX_SERVICE_NAME="${SYSTEMD_USR_PATH}/jukebox-daemon.service"
+JUKEBOX_SUDOERS_FILE="/etc/sudoers.d/rpi-jukebox-rfid"
 
 _jukebox_core_install_python_requirements() {
   print_lc "  Install Python requirements"
@@ -59,6 +60,24 @@ _jukebox_core_register_as_service() {
   systemctl --user enable jukebox-daemon.service
 }
 
+_jukebox_core_register_power_permissions() {
+  print_lc "  Register Jukebox shutdown permissions"
+  local sudoers_temp="${JUKEBOX_SUDOERS_FILE}.tmp"
+
+  sudo install \
+    -o root \
+    -g root \
+    -m 0440 \
+    "${INSTALLATION_PATH}/resources/system/rpi-jukebox-rfid-sudoers" \
+    "${sudoers_temp}"
+  sudo sed -i "s|%%CURRENT_USER%%|${CURRENT_USER}|g" "${sudoers_temp}"
+  if ! sudo visudo -cf "${sudoers_temp}"; then
+    sudo rm -f "${sudoers_temp}"
+    exit_on_error "ERROR: Invalid Jukebox sudoers configuration"
+  fi
+  sudo mv -f "${sudoers_temp}" "${JUKEBOX_SUDOERS_FILE}"
+}
+
 _jukebox_core_check() {
     print_verify_installation
 
@@ -79,8 +98,10 @@ _jukebox_core_check() {
     verify_files_chown "${CURRENT_USER}" "${CURRENT_USER_GROUP}" "${SETTINGS_PATH}/logger.yaml"
 
     verify_files_chown root root "${SYSTEMD_USR_PATH}/jukebox-daemon.service"
+    verify_files_chmod_chown 440 root root "${JUKEBOX_SUDOERS_FILE}"
 
     verify_file_contains_string "${INSTALLATION_PATH}" "${JUKEBOX_SERVICE_NAME}"
+    verify_file_contains_string "NOPASSWD" "${JUKEBOX_SUDOERS_FILE}"
 
     verify_service_enablement jukebox-daemon.service enabled --user
 }
@@ -89,6 +110,7 @@ _run_setup_jukebox_core() {
     _jukebox_core_install_python_requirements
     _jukebox_core_install_settings
     _jukebox_core_register_as_service
+    _jukebox_core_register_power_permissions
     _jukebox_core_check
 }
 

--- a/resources/system/rpi-jukebox-rfid-sudoers
+++ b/resources/system/rpi-jukebox-rfid-sudoers
@@ -1,0 +1,1 @@
+%%CURRENT_USER%% ALL=(root) NOPASSWD: /usr/sbin/shutdown -h now, /usr/sbin/shutdown -r now, /sbin/shutdown -h now, /sbin/shutdown -r now

--- a/src/jukebox/components/hostif/linux/__init__.py
+++ b/src/jukebox/components/hostif/linux/__init__.py
@@ -1,10 +1,13 @@
 # RPi-Jukebox-RFID Version 3
 # Copyright (c) See file LICENSE in project root folder
 
+import logging
 import os
 import shutil
 import subprocess
-import logging
+import threading
+import time
+
 import jukebox.plugs as plugin
 import jukebox.cfghandler
 import jukebox.publishing
@@ -21,45 +24,88 @@ try:
 except Exception:
     pass
 
+POWER_COMMAND_DELAY_SECONDS = 1
+POWER_COMMAND_TIMEOUT_SECONDS = 10
+POWER_COMMAND_OPTIONS = {
+    'shutdown': '-h',
+    'reboot': '-r',
+}
+
 
 # ---------------------------------------------------------------------------
 # Shutdown / Reboot
 # ---------------------------------------------------------------------------
+def _execute_power_command(action):
+    time.sleep(POWER_COMMAND_DELAY_SECONDS)
+    sudo_command = shutil.which('sudo')
+    shutdown_command = shutil.which('shutdown')
+    if sudo_command is None or shutdown_command is None:
+        missing = 'sudo' if sudo_command is None else 'shutdown'
+        logger.error(
+            "Cannot %s host: required command '%s' was not found",
+            action,
+            missing,
+        )
+        return
+
+    command = [
+        sudo_command,
+        '-n',
+        shutdown_command,
+        POWER_COMMAND_OPTIONS[action],
+        'now',
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=POWER_COMMAND_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        logger.exception('Failed to execute host %s command', action)
+        return
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or 'no error output').strip()
+        logger.error(
+            'Host %s command failed with exit code %s: %s',
+            action,
+            result.returncode,
+            detail,
+        )
+        return
+    logger.info('Host %s command accepted by the operating system', action)
+
+
+def _schedule_power_command(action):
+    if IS_DEBUG:
+        logger.info('Host %s command skipped due to debug mode', action)
+        return
+    worker = threading.Thread(
+        target=_execute_power_command,
+        args=(action,),
+        daemon=True,
+        name=f'host.{action}',
+    )
+    worker.start()
+    logger.info('Host %s command scheduled', action)
+
+
 @plugin.register
 def shutdown():
     """Shutdown the host machine"""
     logger.info('Shutting down host system now')
-    debug_flag = '-k' if IS_DEBUG else ''
-    # Detach the shell and wait 1 second before command execution
-    # for return value to pass up the RPC call stack.
-    # The return value has no meaning itself, but the RPC call stack should complete correctly
-    # In order to really detach the shell command, we also need to detach the pipes for outputs
-    # If omit that, there is a dead lock and the service will not shut down properly
-    # This works on the RPi w/o further authentication, on other machines a systemctl reboot may work better
-    # If authentication is required, the command will simply not execute and time out
-    ret = subprocess.run(f'(sleep 1; sudo shutdown {debug_flag} -h now) &', shell=True, capture_output=False,
-                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
-                         stdin=subprocess.DEVNULL)
-    if ret.returncode != 0:
-        logger.error(f"{ret.stdout}")
-    if IS_DEBUG:
-        logger.info('Skipping system command due to debug mode')
-    logger.info('Shutdown command dispatched to host')
+    _schedule_power_command('shutdown')
 
 
 @plugin.register
 def reboot():
     """Reboot the host machine"""
-    logger.info('Rebooting down host system now')
-    debug_flag = '-k' if IS_DEBUG else ''
-    ret = subprocess.run(f'(sleep 1; sudo shutdown {debug_flag} -r now) &', shell=True, capture_output=False,
-                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
-                         stdin=subprocess.DEVNULL)
-    if ret.returncode != 0:
-        logger.error(f"{ret.stdout}")
-    if IS_DEBUG:
-        logger.info('Reboot command skipped due to debug mode')
-    logger.info('Reboot command dispatched to host')
+    logger.info('Rebooting host system now')
+    _schedule_power_command('reboot')
 
 
 @plugin.register

--- a/src/jukebox/components/jingle/alsawave/__init__.py
+++ b/src/jukebox/components/jingle/alsawave/__init__.py
@@ -38,10 +38,14 @@ class AlsaWave:
                                    periodsize=period_size,
                                    device=device_name)
 
-            data = f.readframes(period_size)
-            while data:
-                device.write(data)
+            try:
                 data = f.readframes(period_size)
+                while data:
+                    device.write(data)
+                    data = f.readframes(period_size)
+            finally:
+                # PCM.close() drains pending playback; object destruction does not.
+                device.close()
 
     @plugin.tag
     def play(self, filename):

--- a/test/hostif/test_linux_temperature.py
+++ b/test/hostif/test_linux_temperature.py
@@ -55,6 +55,97 @@ def _patch_get_publisher(hostif_linux, monkeypatch, get_publisher):
     monkeypatch.setattr(timer_module.publishing, 'get_publisher', get_publisher)
 
 
+def test_shutdown_schedules_delayed_power_command(
+        hostif_linux,
+        monkeypatch):
+    worker = MagicMock()
+    thread_factory = MagicMock(return_value=worker)
+    monkeypatch.setattr(hostif_linux, 'IS_DEBUG', False)
+    monkeypatch.setattr(hostif_linux.threading, 'Thread', thread_factory)
+
+    hostif_linux.shutdown()
+
+    thread_factory.assert_called_once_with(
+        target=hostif_linux._execute_power_command,
+        args=('shutdown',),
+        daemon=True,
+        name='host.shutdown',
+    )
+    worker.start.assert_called_once_with()
+
+
+def test_debug_mode_does_not_schedule_power_command(
+        hostif_linux,
+        monkeypatch):
+    thread_factory = MagicMock()
+    monkeypatch.setattr(hostif_linux, 'IS_DEBUG', True)
+    monkeypatch.setattr(hostif_linux.threading, 'Thread', thread_factory)
+
+    hostif_linux.reboot()
+
+    thread_factory.assert_not_called()
+
+
+def test_power_command_uses_noninteractive_sudo_and_reports_acceptance(
+        hostif_linux,
+        monkeypatch,
+        caplog):
+    result = MagicMock(returncode=0, stdout='', stderr='')
+    run = MagicMock(return_value=result)
+    commands = {
+        'sudo': '/usr/bin/sudo',
+        'shutdown': '/usr/sbin/shutdown',
+    }
+    monkeypatch.setattr(hostif_linux.time, 'sleep', MagicMock())
+    monkeypatch.setattr(
+        hostif_linux.shutil,
+        'which',
+        lambda command: commands[command],
+    )
+    monkeypatch.setattr(hostif_linux.subprocess, 'run', run)
+
+    with caplog.at_level(logging.INFO, logger='jb.host.lnx'):
+        hostif_linux._execute_power_command('shutdown')
+
+    run.assert_called_once_with(
+        [
+            '/usr/bin/sudo',
+            '-n',
+            '/usr/sbin/shutdown',
+            '-h',
+            'now',
+        ],
+        capture_output=True,
+        check=False,
+        stdin=hostif_linux.subprocess.DEVNULL,
+        text=True,
+        timeout=hostif_linux.POWER_COMMAND_TIMEOUT_SECONDS,
+    )
+    assert 'accepted by the operating system' in caplog.text
+
+
+def test_power_command_logs_sudo_failure(
+        hostif_linux,
+        monkeypatch,
+        caplog):
+    result = MagicMock(
+        returncode=1,
+        stdout='',
+        stderr='sudo: a password is required',
+    )
+    run = MagicMock(return_value=result)
+    monkeypatch.setattr(hostif_linux.time, 'sleep', MagicMock())
+    monkeypatch.setattr(hostif_linux.shutil, 'which', lambda command: command)
+    monkeypatch.setattr(hostif_linux.subprocess, 'run', run)
+
+    with caplog.at_level(logging.ERROR, logger='jb.host.lnx'):
+        hostif_linux._execute_power_command('reboot')
+
+    assert run.call_args.args[0][-2:] == ['-r', 'now']
+    assert 'exit code 1' in caplog.text
+    assert 'sudo: a password is required' in caplog.text
+
+
 def test_unavailable_sensor_leaves_temperature_timer_disabled(
         hostif_linux, monkeypatch, caplog):
     publisher = MagicMock()

--- a/test/jingle/test_alsawave.py
+++ b/test/jingle/test_alsawave.py
@@ -1,0 +1,86 @@
+import importlib
+import sys
+import wave
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+import jukebox.plugs as plugin
+
+
+def _passthrough_decorator(obj=None, **ignored_kwargs):
+    if obj is None:
+        return lambda decorated: decorated
+    return obj
+
+
+@pytest.fixture
+def alsawave(monkeypatch):
+    pcm = MagicMock()
+    alsaaudio = SimpleNamespace(
+        PCM=MagicMock(return_value=pcm),
+        PCM_FORMAT_U8=1,
+        PCM_FORMAT_S16_LE=2,
+        PCM_FORMAT_S24_3LE=3,
+        PCM_FORMAT_S32_LE=4,
+    )
+    monkeypatch.setitem(sys.modules, 'alsaaudio', alsaaudio)
+    monkeypatch.setattr(plugin, 'register', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'initialize', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'finalize', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'atexit', _passthrough_decorator)
+    monkeypatch.setattr(plugin, 'tag', _passthrough_decorator)
+
+    sys.modules.pop('components.jingle.alsawave', None)
+    sys.modules.pop('components.jingle', None)
+    module = importlib.import_module('components.jingle.alsawave')
+    monkeypatch.setattr(
+        module.cfg,
+        'setndefault',
+        lambda *keys, value: value,
+    )
+    yield module, alsaaudio, pcm
+    sys.modules.pop('components.jingle.alsawave', None)
+    sys.modules.pop('components.jingle', None)
+
+
+def _write_wave(path):
+    with wave.open(str(path), 'wb') as output:
+        output.setnchannels(1)
+        output.setsampwidth(1)
+        output.setframerate(8)
+        output.writeframes(b'\x01\x02')
+
+
+def test_wave_playback_closes_pcm_after_writing(alsawave, tmp_path):
+    module, alsaaudio, pcm = alsawave
+    filename = tmp_path / 'jingle.wav'
+    _write_wave(filename)
+
+    module.AlsaWave._play_wave_core(str(filename))
+
+    alsaaudio.PCM.assert_called_once_with(
+        channels=1,
+        rate=8,
+        format=alsaaudio.PCM_FORMAT_U8,
+        periodsize=1,
+        device='default',
+    )
+    assert pcm.method_calls == [
+        call.write(b'\x01'),
+        call.write(b'\x02'),
+        call.close(),
+    ]
+
+
+def test_wave_playback_closes_pcm_after_write_failure(alsawave, tmp_path):
+    module, ignored_alsaaudio, pcm = alsawave
+    filename = tmp_path / 'jingle.wav'
+    _write_wave(filename)
+    pcm.write.side_effect = RuntimeError('write failed')
+
+    with pytest.raises(RuntimeError, match='write failed'):
+        module.AlsaWave._play_wave_core(str(filename))
+
+    pcm.close.assert_called_once_with()


### PR DESCRIPTION
## Summary

- replace the detached shell command for shutdown/reboot with a delayed Python worker
- invoke `sudo -n` with an argument list, bounded timeout, and captured output
- log success only after the operating system accepts the command and report the real stderr/exit code on failure
- install a validated sudoers rule limited to `shutdown -h now` and `shutdown -r now` for fresh installations
- retain debug-mode suppression and the one-second delay that lets RPC responses complete
- explicitly close the ALSA PCM stream so queued shutdown-jingle samples drain before daemon exit
- add coverage for power-command handling and WAV playback cleanup

Raspberry Pi logs after #2692 prove the idle controller reaches its terminal state and invokes `host.shutdown`. The old host implementation discarded the background `sudo shutdown` result and logged success regardless of failure. Hardware testing confirmed this PR fixes the actual shutdown.

The follow-up shutdown-jingle investigation found that `PCM.write()` only queues samples. The WAV backend relied on object destruction, whose pyalsaaudio path closes the device without draining it. That is harmless at startup because the process remains alive, but daemon exit can discard the entire short shutdown sound. An explicit `PCM.close()` blocks until queued playback is drained.

Raspberry Pi hardware testing confirmed both timer-driven shutdown and shutdown-jingle playback.

Part of #2687.

## Verification

- focused host, systemd, and jingle tests (`10 passed`)
- `./run_flake8.sh`
- full local suite (`143 passed, 1 skipped`; one unrelated API executor-order failure passed in isolation)
- `bash -n installation/routines/setup_jukebox_core.sh`
- generated sudoers entry validated with `visudo -cf -`