### PR TITLE
Build Web App bundles for all branches

### DIFF
--- a/.github/workflows/test_build_webapp_v3.yml
+++ b/.github/workflows/test_build_webapp_v3.yml
@@ -4,11 +4,9 @@ on:
   schedule:
     # run at 18:00 every sunday
     - cron: '0 18 * * 0'
+  # Every installable commit needs an exact bundle, regardless of branch name.
   push:
-    branches:
-        - 'future3/**'
   pull_request:
-    # The branches below must be a subset of the branches above
     branches:
         - future3/develop
         - future3/main

--- a/ci/installation/test_webapp_bundle_download.sh
+++ b/ci/installation/test_webapp_bundle_download.sh
@@ -140,6 +140,8 @@ if missing_output=$(_run_setup_jukebox_webapp 2>&1); then
 fi
 [[ "${missing_output}" == *"${TEST_COMMIT}"* ]]
 [[ "${missing_output}" == *"Test Build Web App v3"* ]]
+[[ "${missing_output}" == *"https://github.com/${GIT_USER}/${GIT_REPO_NAME}/actions/workflows/test_build_webapp_v3.yml"* ]]
+[[ "${missing_output}" == *"Actions read/write permissions"* ]]
 
 # The legacy local-build mode fails explicitly.
 ENABLE_WEBAPP_PROD_DOWNLOAD=false
@@ -152,7 +154,7 @@ fi
 
 source "${REPOSITORY_ROOT}/installation/routines/customize_options.sh"
 
-GIT_BRANCH="future3/test-bundles"
+GIT_BRANCH="feature/test-bundles"
 GIT_BRANCH_RELEASE="future3/main"
 GIT_BRANCH_DEVELOP="future3/develop"
 GIT_USER="contributor"

--- a/documentation/developers/development-environment.md
+++ b/documentation/developers/development-environment.md
@@ -23,7 +23,7 @@ We recommend to use at least a Pi 3 or Pi Zero 2 for development. While this har
 
 1. Follow the [installation preperation](../builders/installation.md#install-raspberry-pi-os-lite) steps
 1. [Install](../builders/installation.md#development) your feature/fork branch of the Jukebox software. The official repository will be set as `upstream`.
-1. If the commit changes the Web App, wait for its [exact CI bundle](./webapp.md#ci-bundles) before installing it on the Raspberry Pi.
+1. Wait for the commit's [exact CI bundle](./webapp.md#ci-bundles) before installing it on the Raspberry Pi.
 
 ## Develop on local machine
 

--- a/documentation/developers/webapp.md
+++ b/documentation/developers/webapp.md
@@ -19,11 +19,18 @@ available, publish or rerun the `Test Build Web App v3` workflow for that
 commit, then rerun the installation. The legacy
 `ENABLE_WEBAPP_PROD_DOWNLOAD=false` local-build mode is unsupported.
 
-Pushes to `future3/**` branches retain the exact bundle as a GitHub Actions
-artifact for 14 days and publish it to the `webapp-development` prerelease.
-Pull request workflows remain read-only. Forks must enable repository Actions
-and grant the workflow token `contents: write` permission to publish their
-development bundles.
+Pushes to any branch retain the exact bundle as a GitHub Actions artifact for
+14 days and publish it to the `webapp-development` prerelease. Pull request
+workflows remain read-only.
+
+For a fork:
+
+1. Open its **Actions** tab and enable workflows. If GitHub lists
+   `Test Build Web App v3` as disabled, enable that workflow as well.
+1. Under **Settings > Actions > General > Workflow permissions**, select
+   **Read and write permissions** so the workflow can publish the bundle.
+1. Push the commit to the branch you intend to install and wait for
+   `Test Build Web App v3` to complete before running the installer.
 
 ### Download a CI bundle manually
 

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -112,7 +112,9 @@ _run_setup_jukebox_webapp() {
             git_head_hash=$(git -C "${INSTALLATION_PATH}" rev-parse --verify --quiet HEAD) \
               || exit_on_error "Could not determine the installed commit"
             exit_on_error "No pre-built Web App bundle found for commit ${git_head_hash}.
-Publish or rerun the 'Test Build Web App v3' workflow for this exact commit, then rerun the installation."
+Enable the 'Test Build Web App v3' workflow and grant Actions read/write permissions in the source repository:
+https://github.com/${GIT_USER}/${GIT_REPO_NAME}/actions/workflows/test_build_webapp_v3.yml
+Push this exact commit, wait for the workflow to publish its bundle, then rerun the installation."
         fi
     elif [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false ]]; then
         exit_on_error "Local Web App builds were removed and ENABLE_WEBAPP_PROD_DOWNLOAD=false is unsupported.


### PR DESCRIPTION
## Summary

- run `Test Build Web App v3` for pushes to every branch, without requiring a `future3/**` prefix
- document how fork owners enable Actions and grant bundle publication permissions
- make missing-bundle installer errors link directly to the source repository workflow
- clarify that every installable commit needs an exact CI bundle, including backend-only changes

Feature branches such as `feature/**` could previously be selected by the installer but never produced a Web App bundle because the workflow only handled pushes to `future3/**`. The installer then failed despite using a supported branch installation command.

## Verification

- `bash ci/installation/test_webapp_bundle_download.sh`
- `bash -n installation/routines/setup_jukebox_webapp.sh ci/installation/test_webapp_bundle_download.sh`
- workflow YAML parse
- `git diff --check`