### PR TITLE
Clarify Web App CI setup for future3 branches

### DIFF
--- a/ci/installation/test_webapp_bundle_download.sh
+++ b/ci/installation/test_webapp_bundle_download.sh
@@ -140,6 +140,8 @@ if missing_output=$(_run_setup_jukebox_webapp 2>&1); then
 fi
 [[ "${missing_output}" == *"${TEST_COMMIT}"* ]]
 [[ "${missing_output}" == *"Test Build Web App v3"* ]]
+[[ "${missing_output}" == *"future3/"* ]]
+[[ "${missing_output}" == *"Actions read/write permissions"* ]]
 
 # The legacy local-build mode fails explicitly.
 ENABLE_WEBAPP_PROD_DOWNLOAD=false

--- a/documentation/builders/installation.md
+++ b/documentation/builders/installation.md
@@ -73,7 +73,10 @@ cd; GIT_BRANCH='future3/develop' bash <(wget -qO- https://raw.githubusercontent.
 You can also install a specific branch and/or a fork repository. Update the variables to refer to your desired location. (The URL must not necessarily be updated, unless you have actually updated the file being downloaded.)
 
 > [!IMPORTANT]
-> A fork repository must be named '*RPi-Jukebox-RFID*' like the official repository
+> A fork repository must be named '*RPi-Jukebox-RFID*' like the official
+> repository. While version 2 and version 3 coexist in this repository,
+> development branch names must start with `future3/`. Only this namespace
+> triggers the version 3 Web App bundle workflow.
 
 ```bash
 cd; GIT_USER='MiczFlor' GIT_BRANCH='future3/develop' bash <(wget -qO- https://raw.githubusercontent.com/MiczFlor/RPi-Jukebox-RFID/future3/develop/installation/install-jukebox.sh)

--- a/documentation/developers/webapp.md
+++ b/documentation/developers/webapp.md
@@ -21,9 +21,20 @@ commit, then rerun the installation. The legacy
 
 Pushes to `future3/**` branches retain the exact bundle as a GitHub Actions
 artifact for 14 days and publish it to the `webapp-development` prerelease.
-Pull request workflows remain read-only. Forks must enable repository Actions
-and grant the workflow token `contents: write` permission to publish their
-development bundles.
+The `future3/` namespace prevents version 3 workflows from running on
+incompatible legacy branches while both versions share this repository. Pull
+request workflows remain read-only.
+
+For a fork:
+
+1. Name development branches `future3/<name>`.
+1. Open the fork's **Actions** tab and enable workflows. If GitHub lists
+   `Test Build Web App v3` as disabled, enable that workflow as well. If the
+   workflow is not listed, set the fork's default branch to `future3/develop`.
+1. Under **Settings > Actions > General > Workflow permissions**, select
+   **Read and write permissions** so the workflow can publish the bundle.
+1. Push the commit and wait for `Test Build Web App v3` to complete before
+   running the installer.
 
 ### Download a CI bundle manually
 

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -112,7 +112,9 @@ _run_setup_jukebox_webapp() {
             git_head_hash=$(git -C "${INSTALLATION_PATH}" rev-parse --verify --quiet HEAD) \
               || exit_on_error "Could not determine the installed commit"
             exit_on_error "No pre-built Web App bundle found for commit ${git_head_hash}.
-Publish or rerun the 'Test Build Web App v3' workflow for this exact commit, then rerun the installation."
+Development branch names must start with 'future3/' to trigger 'Test Build Web App v3'.
+In forks, enable this workflow and grant Actions read/write permissions.
+Push or rerun the workflow for this exact commit, then rerun the installation."
         fi
     elif [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false ]]; then
         exit_on_error "Local Web App builds were removed and ENABLE_WEBAPP_PROD_DOWNLOAD=false is unsupported.


### PR DESCRIPTION
## Summary

- document that installable development branches currently need the `future3/` namespace
- explain how fork owners expose and enable the v3 workflow and grant bundle publication permissions
- make missing-bundle installer errors mention the branch namespace and required Actions settings
- cover the new diagnostic guidance in the installer test

The `future3/**` workflow filter remains unchanged. It intentionally prevents version 3 jobs from running against incompatible legacy branches while both versions share the repository. The filter and official branch references should be updated separately when `future3/main` moves to `main`.

## Verification

- `bash ci/installation/test_webapp_bundle_download.sh`
- `bash -n installation/routines/setup_jukebox_webapp.sh ci/installation/test_webapp_bundle_download.sh`
- `git diff --check`