### PR TITLE
Build Web App bundles for any v3 branch

### DIFF
--- a/.github/workflows/test_build_webapp_v3.yml
+++ b/.github/workflows/test_build_webapp_v3.yml
@@ -4,11 +4,11 @@ on:
   schedule:
     # run at 18:00 every sunday
     - cron: '0 18 * * 0'
+  # Version 3 branches inherit this workflow, so their names are unrestricted.
   push:
-    branches:
-        - 'future3/**'
+  workflow_dispatch:
   pull_request:
-    # The branches below must be a subset of the branches above
+    # Keep PR checks scoped to version 3 target branches while v2 coexists.
     branches:
         - future3/develop
         - future3/main
@@ -78,7 +78,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     needs: [build]
     runs-on: ubuntu-latest
 

--- a/ci/installation/test_webapp_bundle_download.sh
+++ b/ci/installation/test_webapp_bundle_download.sh
@@ -140,7 +140,7 @@ if missing_output=$(_run_setup_jukebox_webapp 2>&1); then
 fi
 [[ "${missing_output}" == *"${TEST_COMMIT}"* ]]
 [[ "${missing_output}" == *"Test Build Web App v3"* ]]
-[[ "${missing_output}" == *"future3/"* ]]
+[[ "${missing_output}" == *"https://github.com/${GIT_USER}/${GIT_REPO_NAME}/actions/workflows/test_build_webapp_v3.yml"* ]]
 [[ "${missing_output}" == *"Actions read/write permissions"* ]]
 
 # The legacy local-build mode fails explicitly.
@@ -154,7 +154,7 @@ fi
 
 source "${REPOSITORY_ROOT}/installation/routines/customize_options.sh"
 
-GIT_BRANCH="future3/test-bundles"
+GIT_BRANCH="feature/test-bundles"
 GIT_BRANCH_RELEASE="future3/main"
 GIT_BRANCH_DEVELOP="future3/develop"
 GIT_USER="contributor"

--- a/documentation/builders/installation.md
+++ b/documentation/builders/installation.md
@@ -74,12 +74,10 @@ You can also install a specific branch and/or a fork repository. Update the vari
 
 > [!IMPORTANT]
 > A fork repository must be named '*RPi-Jukebox-RFID*' like the official
-> repository. While version 2 and version 3 coexist in this repository,
-> development branch names must start with `future3/`. Only this namespace
-> triggers the version 3 Web App bundle workflow.
+> repository.
 
 ```bash
-cd; GIT_USER='your-github-user' GIT_BRANCH='future3/my-feature' bash <(wget -qO- https://raw.githubusercontent.com/MiczFlor/RPi-Jukebox-RFID/future3/develop/installation/install-jukebox.sh)
+cd; GIT_USER='your-github-user' GIT_BRANCH='feature/my-change' bash <(wget -qO- https://raw.githubusercontent.com/MiczFlor/RPi-Jukebox-RFID/future3/develop/installation/install-jukebox.sh)
 ```
 
 The installer uses HTTPS and fetches only the selected branch with shallow history. Set `GIT_USE_SSH=true` to opt in to SSH access. The installed checkout remains a normal tracking branch, so `git pull` works as usual.

--- a/documentation/developers/development-environment.md
+++ b/documentation/developers/development-environment.md
@@ -23,7 +23,7 @@ We recommend to use at least a Pi 3 or Pi Zero 2 for development. While this har
 
 1. Follow the [installation preperation](../builders/installation.md#install-raspberry-pi-os-lite) steps
 1. [Install](../builders/installation.md#development) your feature/fork branch of the Jukebox software. The official repository will be set as `upstream`.
-1. If the commit changes the Web App, wait for its [exact CI bundle](./webapp.md#ci-bundles) before installing it on the Raspberry Pi.
+1. Wait for the commit's [exact CI bundle](./webapp.md#ci-bundles) before installing it on the Raspberry Pi.
 
 ## Develop on local machine
 

--- a/documentation/developers/webapp.md
+++ b/documentation/developers/webapp.md
@@ -19,22 +19,23 @@ available, publish or rerun the `Test Build Web App v3` workflow for that
 commit, then rerun the installation. The legacy
 `ENABLE_WEBAPP_PROD_DOWNLOAD=false` local-build mode is unsupported.
 
-Pushes to `future3/**` branches retain the exact bundle as a GitHub Actions
+Pushes to any version 3 branch retain the exact bundle as a GitHub Actions
 artifact for 14 days and publish it to the `webapp-development` prerelease.
-The `future3/` namespace prevents version 3 workflows from running on
-incompatible legacy branches while both versions share this repository. Pull
-request workflows remain read-only.
+Branch names are unrestricted: branches created from version 3 inherit this
+workflow, while incompatible legacy branches do not contain it. The workflow
+can also be run manually for a selected branch. Pull request workflows remain
+read-only and do not publish bundles.
 
 For a fork:
 
-1. Name development branches `future3/<name>`.
 1. Open the fork's **Actions** tab and enable workflows. If GitHub lists
    `Test Build Web App v3` as disabled, enable that workflow as well. If the
    workflow is not listed, set the fork's default branch to `future3/develop`.
 1. Under **Settings > Actions > General > Workflow permissions**, select
    **Read and write permissions** so the workflow can publish the bundle.
-1. Push the commit and wait for `Test Build Web App v3` to complete before
-   running the installer.
+1. Push the commit to a branch with any name, or select that branch when
+   starting `Test Build Web App v3` manually.
+1. Wait for the workflow to complete before running the installer.
 
 ### Download a CI bundle manually
 

--- a/installation/routines/setup_jukebox_webapp.sh
+++ b/installation/routines/setup_jukebox_webapp.sh
@@ -112,9 +112,9 @@ _run_setup_jukebox_webapp() {
             git_head_hash=$(git -C "${INSTALLATION_PATH}" rev-parse --verify --quiet HEAD) \
               || exit_on_error "Could not determine the installed commit"
             exit_on_error "No pre-built Web App bundle found for commit ${git_head_hash}.
-Development branch names must start with 'future3/' to trigger 'Test Build Web App v3'.
-In forks, enable this workflow and grant Actions read/write permissions.
-Push or rerun the workflow for this exact commit, then rerun the installation."
+Enable 'Test Build Web App v3' and grant Actions read/write permissions in the source repository:
+https://github.com/${GIT_USER}/${GIT_REPO_NAME}/actions/workflows/test_build_webapp_v3.yml
+Push this exact commit or run the workflow manually, wait for it to publish the bundle, then rerun the installation."
         fi
     elif [[ "$ENABLE_WEBAPP_PROD_DOWNLOAD" == false ]]; then
         exit_on_error "Local Web App builds were removed and ENABLE_WEBAPP_PROD_DOWNLOAD=false is unsupported.


### PR DESCRIPTION
## Summary

- run `Test Build Web App v3` for pushes to any branch containing the v3 workflow
- add a manual workflow trigger that also publishes the exact-commit bundle
- keep pull request checks restricted to the existing v3 target branches
- remove the temporary `future3/` naming requirement from developer documentation
- make missing-bundle errors link directly to the source repository workflow
- cover a non-prefixed `feature/**` branch in the installer configuration test

Push workflows are loaded from the pushed branch. Version 3 branches inherit this workflow and the compatible Web App sources, regardless of their name; the legacy `develop` and `master` branches do not contain the v3 workflow and remain unaffected.

## Verification

- `bash ci/installation/test_webapp_bundle_download.sh`
- `bash -n installation/routines/setup_jukebox_webapp.sh ci/installation/test_webapp_bundle_download.sh`
- `actionlint .github/workflows/test_build_webapp_v3.yml`
- `markdownlint-cli2 --no-globs` for the three changed documentation files
- `git diff --check`
- fork Web App build and publish: https://github.com/pabera/RPi-Jukebox-RFID/actions/runs/30981264265
- exact bundle URL returns HTTP 200 before opening this PR