### PR TITLE
Run v3 CI checks for any development branch

### DIFF
--- a/.github/workflows/markdown_v3.yml
+++ b/.github/workflows/markdown_v3.yml
@@ -1,9 +1,8 @@
 name: Markdown Linting
 
 on:
+  # Version 3 branches inherit this workflow, so their names are unrestricted.
   push:
-    branches:
-        - 'future3/**'
     paths:
         - '**.md'
   pull_request:

--- a/.github/workflows/pythonpackage_future3.yml
+++ b/.github/workflows/pythonpackage_future3.yml
@@ -1,9 +1,8 @@
 name: Python + Docs Checks and Tests
 
 on:
+  # Version 3 branches inherit this workflow, so their names are unrestricted.
   push:
-    branches:
-        - 'future3/**'
     paths:
         - '.github/workflows/pythonpackage_future3.yml'
         - '.flake8'

--- a/.github/workflows/test_docker_debian_v3.yml
+++ b/.github/workflows/test_docker_debian_v3.yml
@@ -4,9 +4,8 @@ on:
   schedule:
     # run at 17:00 every sunday
     - cron: '0 17 * * 0'
+  # Version 3 branches inherit this workflow, so their names are unrestricted.
   push:
-    branches:
-        - 'future3/**'
     paths:
         - '.github/workflows/test_docker_debian*.yml'
         - 'installation/**'
@@ -16,7 +15,7 @@ on:
         - 'packages*.txt'
         - 'requirements*.txt'
   pull_request:
-    # The branches below must be a subset of the branches above
+    # Keep PR checks scoped to version 3 target branches while v2 coexists.
     branches:
         - future3/develop
         - future3/main


### PR DESCRIPTION
## Summary

- run the Markdown, Python/docs, and Debian installation push workflows for any branch containing the v3 workflows
- retain the existing path filters and v3 pull request target filters
- keep CodeQL and release publication scoped to their official branches

This applies the branch-inheritance approach introduced for Web App bundles in #2698. Legacy branches remain unaffected because they do not contain these v3 workflow files.

## Verification

- `actionlint .github/workflows/markdown_v3.yml .github/workflows/pythonpackage_future3.yml .github/workflows/test_docker_debian_v3.yml`
- `git diff --check`
- pushed from the non-prefixed `fix/ci-any-v3-branch` branch to exercise the unrestricted push triggers