### PR TITLE
Future3/fix cover cache performance

### DIFF
--- a/src/jukebox/components/player/backends/coverart_cache_manager.py
+++ b/src/jukebox/components/player/backends/coverart_cache_manager.py
@@ -22,12 +22,7 @@ class CoverartCacheManager:
     def __init__(self):
         coverart_cache_path = cfg.setndefault('webapp', 'coverart_cache_path', value='../../src/webapp/build/cover-cache')
         self.cache_folder_path = Path(coverart_cache_path).expanduser()
-        # In-memory index (cache_key -> filename) so a lookup is a dict access instead of
-        # re-listing and comparing against every file in the cache folder on every single
-        # coverart request. That linear scan was cheap for a handful of files, but with a
-        # library of any real size (called once per song/album shown in the WebUI) it turned
-        # into a steady, significant CPU cost - see the WebUI-hang investigation.
-        self._index_lock = Lock()
+        self._cache_lock = Lock()
         self._cache_index = {}
         self._build_cache_index()
         self.write_queue = Queue()
@@ -48,7 +43,7 @@ class CoverartCacheManager:
         base_filename = Path(mp3_file_path).stem
         cache_key = self.generate_cache_key(base_filename)
 
-        with self._index_lock:
+        with self._cache_lock:
             cached_name = self._cache_index.get(cache_key)
 
         if cached_name is not None:
@@ -73,11 +68,11 @@ class CoverartCacheManager:
         cache_filename = f"{cache_key}.{file_extension}"
         full_path = self.cache_folder_path / cache_filename  # Works due to Pathlib
 
-        with full_path.open('wb') as file:
-            file.write(data)
-            logger.debug(f"Created file: {cache_filename}")
+        with self._cache_lock:
+            with full_path.open('wb') as file:
+                file.write(data)
+                logger.debug(f"Created file: {cache_filename}")
 
-        with self._index_lock:
             self._cache_index[cache_key] = cache_filename
 
         return cache_filename
@@ -121,10 +116,10 @@ class CoverartCacheManager:
             self.write_queue.task_done()
 
     def flush_cache(self):
-        for path in self.cache_folder_path.iterdir():
-            if path.is_file():
-                path.unlink()
-                logger.debug(f"Deleted cached file: {path.name}")
-        with self._index_lock:
+        with self._cache_lock:
+            for path in self.cache_folder_path.iterdir():
+                if path.is_file():
+                    path.unlink()
+                    logger.debug(f"Deleted cached file: {path.name}")
             self._cache_index.clear()
         logger.info("Cache flushed successfully.")

--- a/src/jukebox/components/player/backends/coverart_cache_manager.py
+++ b/src/jukebox/components/player/backends/coverart_cache_manager.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import hashlib
 import logging
 from queue import Queue
-from threading import Thread
+from threading import Thread, Lock
 import jukebox.cfghandler
 
 COVER_PREFIX = 'cover'
@@ -22,10 +22,24 @@ class CoverartCacheManager:
     def __init__(self):
         coverart_cache_path = cfg.setndefault('webapp', 'coverart_cache_path', value='../../src/webapp/build/cover-cache')
         self.cache_folder_path = Path(coverart_cache_path).expanduser()
+        # In-memory index (cache_key -> filename) so a lookup is a dict access instead of
+        # re-listing and comparing against every file in the cache folder on every single
+        # coverart request. That linear scan was cheap for a handful of files, but with a
+        # library of any real size (called once per song/album shown in the WebUI) it turned
+        # into a steady, significant CPU cost - see the WebUI-hang investigation.
+        self._index_lock = Lock()
+        self._cache_index = {}
+        self._build_cache_index()
         self.write_queue = Queue()
         self.worker_thread = Thread(target=self.process_write_requests)
         self.worker_thread.daemon = True  # Ensure the thread closes with the program
         self.worker_thread.start()
+
+    def _build_cache_index(self):
+        self.cache_folder_path.mkdir(parents=True, exist_ok=True)
+        for path in self.cache_folder_path.iterdir():
+            if path.is_file():
+                self._cache_index[path.stem] = path.name
 
     def generate_cache_key(self, base_filename: str) -> str:
         return f"{COVER_PREFIX}-{hashlib.sha256(base_filename.encode()).hexdigest()}"
@@ -34,11 +48,13 @@ class CoverartCacheManager:
         base_filename = Path(mp3_file_path).stem
         cache_key = self.generate_cache_key(base_filename)
 
-        for path in self.cache_folder_path.iterdir():
-            if path.stem == cache_key:
-                if path.suffix == f".{NO_COVER_ART_EXTENSION}":
-                    return NO_CACHE
-                return path.name
+        with self._index_lock:
+            cached_name = self._cache_index.get(cache_key)
+
+        if cached_name is not None:
+            if cached_name.endswith(f".{NO_COVER_ART_EXTENSION}"):
+                return NO_CACHE
+            return cached_name
 
         self.save_to_cache(mp3_file_path)
         return CACHE_PENDING
@@ -60,6 +76,9 @@ class CoverartCacheManager:
         with full_path.open('wb') as file:
             file.write(data)
             logger.debug(f"Created file: {cache_filename}")
+
+        with self._index_lock:
+            self._cache_index[cache_key] = cache_filename
 
         return cache_filename
 
@@ -106,4 +125,6 @@ class CoverartCacheManager:
             if path.is_file():
                 path.unlink()
                 logger.debug(f"Deleted cached file: {path.name}")
+        with self._index_lock:
+            self._cache_index.clear()
         logger.info("Cache flushed successfully.")

--- a/src/webapp/src/components/Library/lists/albums/album-list/album-list-item.jsx
+++ b/src/webapp/src/components/Library/lists/albums/album-list/album-list-item.jsx
@@ -113,7 +113,7 @@ const AlbumListItem = ({
         });
         // Don't cache a pending marker - a later remount should retry rather than getting
         // stuck showing the placeholder cover forever.
-        if (result && result !== 'CACHE_PENDING') {
+        if (result !== undefined && result !== 'CACHE_PENDING') {
           coverArtCache.set(cacheKey, result);
         }
         applyResult(result);

--- a/src/webapp/src/components/Library/lists/albums/album-list/album-list-item.jsx
+++ b/src/webapp/src/components/Library/lists/albums/album-list/album-list-item.jsx
@@ -1,4 +1,4 @@
-import { forwardRef, useContext, useEffect, useState } from 'react';
+import { forwardRef, useContext, useEffect, useRef, useState } from 'react';
 import {
   Link,
   useLocation,
@@ -18,6 +18,44 @@ import noCover from '../../../../../assets/noCover.jpg';
 import AppSettingsContext from '../../../../../context/appsettings/context';
 import request from '../../../../../utils/request';
 
+// Cover art results are cached at module scope so they survive a component remount (e.g.
+// navigating away from and back to the library view) within the same page load - only a full
+// page reload clears it. Keyed by content_uri (stable per-provider item id) when available,
+// falling back to provider+albumartist+album for providers that don't supply one.
+const coverArtCache = new Map();
+
+// The library can list many dozens of albums. Firing a getAlbumCoverArt RPC call for every
+// single one on mount - each opening its own connection, all serialized through the
+// single-threaded RPC server - is what made the library view slow to load. Lazy-load via
+// IntersectionObserver instead, and cap how many fetches run at once so a long scroll still
+// doesn't fire dozens of requests in one burst.
+const MAX_CONCURRENT_COVER_FETCHES = 10;
+let activeCoverFetches = 0;
+const pendingCoverFetchQueue = [];
+
+const runNextQueuedFetch = () => {
+  if (activeCoverFetches >= MAX_CONCURRENT_COVER_FETCHES) return;
+  const next = pendingCoverFetchQueue.shift();
+  if (next) next();
+};
+
+const scheduleCoverFetch = (fetchFn) => new Promise((resolve) => {
+  const task = async () => {
+    activeCoverFetches += 1;
+    try {
+      resolve(await fetchFn());
+    } finally {
+      activeCoverFetches -= 1;
+      runNextQueuedFetch();
+    }
+  };
+  if (activeCoverFetches < MAX_CONCURRENT_COVER_FETCHES) {
+    task();
+  } else {
+    pendingCoverFetchQueue.push(task);
+  }
+});
+
 const AlbumListItem = ({
   albumartist,
   album,
@@ -30,6 +68,7 @@ const AlbumListItem = ({
   const { t } = useTranslation();
   const { search: urlSearch } = useLocation();
   const [coverImage, setCoverImage] = useState(cover_url || noCover);
+  const itemRef = useRef(null);
 
   const {
     settings,
@@ -40,27 +79,50 @@ const AlbumListItem = ({
   } = settings;
 
   useEffect(() => {
-    const getCoverArt = async () => {
-      const { result } = await request('getAlbumCoverArt', {
-        albumartist,
-        album,
-        content_uri,
-        provider,
-      });
-      if (result) {
-        if(result !== 'CACHE_PENDING') {
-          setCoverImage(result.startsWith('http') ? result : `/cover-cache/${result}`);
-        }
-      };
+    setCoverImage(cover_url || noCover);
+    if (cover_url) return undefined;
+    if (!albumartist || !album || !show_covers) return undefined;
+
+    const cacheKey = content_uri || `${provider}:${albumartist}:${album}`;
+
+    const applyResult = (result) => {
+      if (result && result !== 'CACHE_PENDING') {
+        setCoverImage(result.startsWith('http') ? result : `/cover-cache/${result}`);
+      }
+    };
+
+    const cached = coverArtCache.get(cacheKey);
+    if (cached !== undefined) {
+      applyResult(cached);
+      return undefined;
     }
 
-    setCoverImage(cover_url || noCover);
-    if (cover_url) {
-      setCoverImage(cover_url);
-    }
-    else if (albumartist && album && show_covers) {
-      getCoverArt();
-    }
+    const node = itemRef.current;
+    if (!node) return undefined;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      observer.disconnect();
+
+      scheduleCoverFetch(async () => {
+        const { result } = await request('getAlbumCoverArt', {
+          albumartist,
+          album,
+          content_uri,
+          provider,
+        });
+        // Don't cache a pending marker - a later remount should retry rather than getting
+        // stuck showing the placeholder cover forever.
+        if (result && result !== 'CACHE_PENDING') {
+          coverArtCache.set(cacheKey, result);
+        }
+        applyResult(result);
+        return result;
+      });
+    }, { rootMargin: '200px' });
+
+    observer.observe(node);
+    return () => observer.disconnect();
   }, [albumartist, album, content_uri, cover_url, provider, show_covers]);
 
   const AlbumLink = forwardRef((props, ref) => {
@@ -95,7 +157,7 @@ const AlbumListItem = ({
   );
 
   return (
-    <ListItem disablePadding={isButton} key={content_uri || album}>
+    <ListItem ref={itemRef} disablePadding={isButton} key={content_uri || album}>
       {isButton
         ? (
           <ListItemButton component={AlbumLink} nativeButton={false}>

--- a/src/webapp/src/components/Library/lists/albums/index.jsx
+++ b/src/webapp/src/components/Library/lists/albums/index.jsx
@@ -8,17 +8,16 @@ import {
 
 import request from '../../../../utils/request';
 import { flatByAlbum } from '../../../../utils/utils';
+import { albumListCache } from '../../../../utils/library-cache';
 
 import AlbumList from "./album-list";
 
 // The album list rarely changes within a session (only on library updates), but the Albums
 // component is unmounted/remounted every time the user navigates away from and back to the
 // library (react-router unmounts non-matching routes). Without a cache, every single visit to
-// the library re-fetches the entire list from the server via RPC. Cache it at module scope, keyed
-// by provider+content-types (the actual query params), so it survives remounts within the same
-// page load - only a full page reload or an actual provider/filter change refetches.
-const albumListCache = new Map();
-
+// the library re-fetches the entire list from the server via RPC. Cached at module scope (see
+// utils/library-cache.js), keyed by provider+content-types (the actual query params), so it
+// survives remounts within the same page load.
 const Albums = ({
   contentTypes,
   musicFilter,
@@ -45,9 +44,16 @@ const Albums = ({
   };
 
   useEffect(() => {
-    if (albumListCache.has(cacheKey)) return undefined;
-
     let isCurrent = true;
+
+    const cachedForKey = albumListCache.get(cacheKey);
+    if (cachedForKey !== undefined) {
+      setAlbums(cachedForKey);
+      setError(null);
+      setIsLoading(false);
+      return undefined;
+    }
+
     const fetchAlbumList = async () => {
       setIsLoading(true);
       setError(null);

--- a/src/webapp/src/components/Library/lists/albums/index.jsx
+++ b/src/webapp/src/components/Library/lists/albums/index.jsx
@@ -11,6 +11,14 @@ import { flatByAlbum } from '../../../../utils/utils';
 
 import AlbumList from "./album-list";
 
+// The album list rarely changes within a session (only on library updates), but the Albums
+// component is unmounted/remounted every time the user navigates away from and back to the
+// library (react-router unmounts non-matching routes). Without a cache, every single visit to
+// the library re-fetches the entire list from the server via RPC. Cache it at module scope, keyed
+// by provider+content-types (the actual query params), so it survives remounts within the same
+// page load - only a full page reload or an actual provider/filter change refetches.
+const albumListCache = new Map();
+
 const Albums = ({
   contentTypes,
   musicFilter,
@@ -19,9 +27,13 @@ const Albums = ({
 }) => {
   const { t } = useTranslation();
 
-  const [albums, setAlbums] = useState([]);
+  const contentTypesKey = contentTypes?.join(',') || '';
+  const cacheKey = `${provider}:${contentTypesKey}`;
+  const cached = albumListCache.get(cacheKey);
+
+  const [albums, setAlbums] = useState(cached || []);
   const [error, setError] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(cached === undefined);
 
   const search = ({ albumartist, album }) => {
     if (musicFilter === '') return true;
@@ -32,9 +44,9 @@ const Albums = ({
       (album || '').toLowerCase().includes(lowerCaseMusicFilter);
   };
 
-  const contentTypesKey = contentTypes?.join(',') || '';
-
   useEffect(() => {
+    if (albumListCache.has(cacheKey)) return undefined;
+
     let isCurrent = true;
     const fetchAlbumList = async () => {
       setIsLoading(true);
@@ -46,7 +58,11 @@ const Albums = ({
       if (!isCurrent) return;
       setIsLoading(false);
 
-      if(result) setAlbums(result.reduce(flatByAlbum, []));
+      if(result) {
+        const flattened = result.reduce(flatByAlbum, []);
+        albumListCache.set(cacheKey, flattened);
+        setAlbums(flattened);
+      }
       if(requestError) setError(requestError);
     }
 
@@ -54,7 +70,7 @@ const Albums = ({
     return () => {
       isCurrent = false;
     };
-  }, [contentTypesKey, provider]);
+  }, [cacheKey, contentTypesKey, provider]);
 
   return (
     <>

--- a/src/webapp/src/utils/library-api.js
+++ b/src/webapp/src/utils/library-api.js
@@ -1,3 +1,5 @@
+import { clearAlbumListCache } from './library-cache';
+
 const LIBRARY_ENDPOINT = '/api/v1/library';
 
 const ACCEPTED_LIBRARY_FILES = [
@@ -83,10 +85,14 @@ const deleteLibraryEntries = (paths) => jsonRequest('/entries', {
   body: JSON.stringify({ paths }),
 });
 
-const refreshLibrary = () => jsonRequest('/refresh', {
-  method: 'POST',
-  body: '',
-});
+const refreshLibrary = async () => {
+  const data = await jsonRequest('/refresh', {
+    method: 'POST',
+    body: '',
+  });
+  clearAlbumListCache();
+  return data;
+};
 
 const uploadLibraryFile = ({
   folder,

--- a/src/webapp/src/utils/library-cache.js
+++ b/src/webapp/src/utils/library-cache.js
@@ -1,0 +1,10 @@
+const albumListCache = new Map();
+
+const clearAlbumListCache = () => {
+  albumListCache.clear();
+};
+
+export {
+  albumListCache,
+  clearAlbumListCache,
+};


### PR DESCRIPTION
## Summary

Split out of #<original-PR-nummer> per review feedback — this covers the cover-art/cache
optimizations, independent of the socket-management changes (which are superseded by #2677).

- `CoverartCacheManager.get_cache_filename()` re-listed and linearly scanned the entire cache
  folder on every single coverart request. With a real-sized library this ran on every
  song/album shown in the WebUI and accounted for a steady, significant chunk of CPU time
  (found via py-spy on a Pi Zero-class device while investigating WebUI responsiveness).
  Replaced with an in-memory `cache_key -> filename` index built once at startup, kept in sync
  on writes/flush.
- Album cover art in the library view is now lazy-loaded (`IntersectionObserver`, ~200px
  lookahead) instead of firing a request for every album on mount, with concurrent fetches
  capped at 10.
- Cover art results and the album list itself are now cached at module scope in the frontend,
  so revisiting the library within the same page load (react-router unmounts/remounts the
  Library route on navigation) reuses already-fetched data instead of re-fetching everything
  from the server every time.

## Test plan
- [ ] Verified on real Pi hardware: library loads noticeably faster on repeat visits
- [ ] Verified cover art still displays correctly for albums with and without embedded art
- [ ] `./run_flake8.sh` clean
