### PR TITLE
player: allow play() to start at a playlist position

### DIFF
--- a/documentation/developers/player-backends.md
+++ b/documentation/developers/player-backends.md
@@ -39,6 +39,24 @@ Folder playback, folder browsing, local library updates, and cover-cache
 flushing route to the default backend. Transport controls such as pause, next,
 seek, and volume continue to target the active backend.
 
+`play` optionally takes a position in the backend's current playlist:
+
+```python
+play(pos=None)
+```
+
+Without `pos` playback starts at the current position, which is the behaviour
+of the argument-less call every existing client uses. With `pos` playback jumps
+to that position, counting from 0, and leaves the rest of the playlist queued
+so that next and previous keep working afterwards.
+
+The coordinator forwards `pos` only when a caller provides it, so a backend
+whose `play()` takes no arguments keeps serving every existing call and raises
+`TypeError` only when a client actually requests a position. A backend without
+an addressable playlist should raise `NotImplementedError` for a `pos` other
+than `None` rather than ignore it, so that the limitation is visible to the
+client instead of looking like a jump that silently did nothing.
+
 ## Library Contract
 
 Each catalog backend describes its Web App navigation through

--- a/src/jukebox/components/player/backends/mpd.py
+++ b/src/jukebox/components/player/backends/mpd.py
@@ -337,9 +337,22 @@ class PlayerMPD:
         return state
 
     @plugs.tag
-    def play(self):
+    def play(self, pos=None):
+        """
+        Start playback
+
+        Without *pos* playback starts at the current playlist position, which is the behaviour
+        of the argument-less call. With *pos* playback starts at that position of the current
+        playlist, leaving the playlist itself untouched.
+
+        :param pos: Optional position in the current playlist, counting from 0.
+                    A position outside the playlist raises :class:`mpd.base.CommandError`
+        """
         with self.mpd_lock:
-            self.mpd_client.play()
+            if pos is None:
+                self.mpd_client.play()
+            else:
+                self.mpd_client.play(int(pos))
 
     @plugs.tag
     def stop(self):

--- a/src/jukebox/components/player/coordinator.py
+++ b/src/jukebox/components/player/coordinator.py
@@ -142,8 +142,17 @@ class PlayerCoordinator:
         return self._call_default('update_wait')
 
     @plugs.tag
-    def play(self):
-        return self._call_active('play')
+    def play(self, pos=None):
+        """
+        Start playback on the active backend
+
+        :param pos: Optional position in the backend's current playlist, counting from 0.
+                    Omit to start at the current position
+        """
+        # Forward only when given, so backends with an argument-less play() keep working
+        if pos is None:
+            return self._call_active('play')
+        return self._call_active('play', pos)
 
     @plugs.tag
     def stop(self):

--- a/test/player/test_mpd_backend_contract.py
+++ b/test/player/test_mpd_backend_contract.py
@@ -2,6 +2,9 @@ from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock, sentinel
 
+import mpd
+import pytest
+
 import jukebox.publishing as publishing
 
 from components.player.backends.mpd import PlayerMPD
@@ -9,6 +12,39 @@ from components.player.backends.mpd import PlayerMPD
 
 def mpd_backend():
     return PlayerMPD.__new__(PlayerMPD)
+
+
+@pytest.mark.parametrize(
+    ('pos', 'expected_args'),
+    [
+        (None, ()),
+        # Position 0 must reach mpd instead of being mistaken for an omitted argument
+        (0, (0,)),
+        (3, (3,)),
+        # RPC arguments arrive from JSON and from YAML card configurations
+        ('3', (3,)),
+    ],
+)
+def test_play_starts_at_the_requested_playlist_position(pos, expected_args):
+    backend = mpd_backend()
+    backend.mpd_lock = nullcontext()
+    play = Mock()
+    backend.mpd_client = SimpleNamespace(play=play)
+
+    backend.play(pos)
+
+    play.assert_called_once_with(*expected_args)
+
+
+def test_play_reports_a_position_outside_the_playlist():
+    backend = mpd_backend()
+    backend.mpd_lock = nullcontext()
+    backend.mpd_client = SimpleNamespace(
+        play=Mock(side_effect=mpd.base.CommandError('Bad song index')),
+    )
+
+    with pytest.raises(mpd.base.CommandError):
+        backend.play(99)
 
 
 def test_library_source_describes_local_views():

--- a/test/player/test_player_coordinator.py
+++ b/test/player/test_player_coordinator.py
@@ -50,6 +50,7 @@ def test_rejects_invalid_backend_registrations():
         ('update', (), ()),
         ('update_wait', (), ()),
         ('play', (), ()),
+        ('play', (3,), (3,)),
         ('stop', (), ()),
         ('pause', (), (1,)),
         ('pause', (0,), (0,)),
@@ -99,6 +100,18 @@ def test_delegates_existing_player_contract(
 
     assert result is sentinel.result
     backend_method.assert_called_once_with(*backend_args)
+
+
+def test_play_forwards_the_first_playlist_position():
+    # Position 0 is a valid position and must not be mistaken for an omitted argument,
+    # which would silently turn 'play the first track' into 'resume where we are'
+    backend_play = Mock(return_value=sentinel.result)
+    coordinator = PlayerCoordinator()
+    coordinator.register_backend('mpd', backend_with(play=backend_play))
+
+    coordinator.play(0)
+
+    backend_play.assert_called_once_with(0)
 
 
 def test_switch_stops_old_backend_before_new_content_starts():


### PR DESCRIPTION
player.ctrl.playlistinfo lets a client read the current queue, but there is no way to start playback at a position in it. play() takes no arguments, resume() restores the position the box saved itself, seek() moves within the current track, and map_filename_to_playlist_pos()/remove()/move() raise NotImplementedError. The only remaining route is walking the queue with next(), which is slow, audible, and cannot reach a position at all while random is enabled.

MPD supports `play <SONGPOS>` and the backend already relies on it internally - _next_in_stopped_state(), _prev_in_stopped_state() and rewind() all call self.mpd_client.play(pos). This exposes that capability instead of keeping it private.

play(pos=None) keeps the argument-less call byte-for-byte identical, so the Web App play button, `alias: play` cards, GPIO and MQTT actions and second_swipe_action: play are unaffected. The coordinator forwards pos only when a caller provides it, so a backend whose play() takes no arguments is never handed a None and keeps serving every existing call. The guard is `pos is None` rather than a truthiness check, because position 0 is a valid position - the tests cover that case explicitly.

pos is coerced with int() since RPC arguments arrive from JSON and from YAML card configurations, where a position may be a string. A position outside the playlist raises mpd.base.CommandError, which the RPC layer reports as an error reply; unlike next() and prev() this is not swallowed, because play(pos) arrives over RPC rather than on the status-poll or card-reader thread, and a caller that receives a success reply followed by silence cannot tell what happened.