### PR TITLE
fix: key the cover art cache on the library-relative path

### DIFF
--- a/src/jukebox/components/player/backends/coverart_cache_manager.py
+++ b/src/jukebox/components/player/backends/coverart_cache_manager.py
@@ -13,6 +13,10 @@ COVER_PREFIX = 'cover'
 NO_COVER_ART_EXTENSION = 'no-art'
 NO_CACHE = ''
 CACHE_PENDING = 'CACHE_PENDING'
+#: Bump whenever the cache key changes, so entries written by an older
+#: version are purged instead of being served for the wrong audio file
+CACHE_SCHEMA_VERSION = '2'
+CACHE_SCHEMA_MARKER = '.cache-schema'
 
 logger = logging.getLogger('jb.CoverartCacheManager')
 cfg = jukebox.cfghandler.get_handler('jukebox')
@@ -22,17 +26,29 @@ class CoverartCacheManager:
     def __init__(self):
         coverart_cache_path = cfg.setndefault('webapp', 'coverart_cache_path', value='../../src/webapp/build/cover-cache')
         self.cache_folder_path = Path(coverart_cache_path).expanduser()
+        try:
+            self.cache_folder_path.mkdir(parents=True, exist_ok=True)
+            self._migrate_cache()
+        except OSError as e:
+            logger.error(f"Could not prepare cover art cache folder {self.cache_folder_path}: {e}")
         self.write_queue = Queue()
         self.worker_thread = Thread(target=self.process_write_requests)
         self.worker_thread.daemon = True  # Ensure the thread closes with the program
         self.worker_thread.start()
 
-    def generate_cache_key(self, base_filename: str) -> str:
-        return f"{COVER_PREFIX}-{hashlib.sha256(base_filename.encode()).hexdigest()}"
+    def generate_cache_key(self, cache_id: str) -> str:
+        return f"{COVER_PREFIX}-{hashlib.sha256(cache_id.encode()).hexdigest()}"
 
-    def get_cache_filename(self, mp3_file_path: str) -> str:
-        base_filename = Path(mp3_file_path).stem
-        cache_key = self.generate_cache_key(base_filename)
+    def get_cache_filename(self, mp3_file_path: str, cache_id: str) -> str:
+        """Look up the cached cover art for an audio file
+
+        :param mp3_file_path: Absolute path of the audio file, used to extract the cover art
+        :param cache_id: Identifies the audio file uniquely within the library and is what the
+            cache is keyed on: the path relative to the music library root, extension included.
+            Keying on the bare filename would make every identically named track in the library
+            share a single cover.
+        """
+        cache_key = self.generate_cache_key(cache_id)
 
         for path in self.cache_folder_path.iterdir():
             if path.stem == cache_key:
@@ -40,15 +56,14 @@ class CoverartCacheManager:
                     return NO_CACHE
                 return path.name
 
-        self.save_to_cache(mp3_file_path)
+        self.save_to_cache(mp3_file_path, cache_id)
         return CACHE_PENDING
 
-    def save_to_cache(self, mp3_file_path: str):
-        self.write_queue.put(mp3_file_path)
+    def save_to_cache(self, mp3_file_path: str, cache_id: str):
+        self.write_queue.put((mp3_file_path, cache_id))
 
-    def _save_to_cache(self, mp3_file_path: str):
-        base_filename = Path(mp3_file_path).stem
-        cache_key = self.generate_cache_key(base_filename)
+    def _save_to_cache(self, mp3_file_path: str, cache_id: str):
+        cache_key = self.generate_cache_key(cache_id)
 
         file_extension, data = self._extract_album_art(mp3_file_path)
         if file_extension == NO_COVER_ART_EXTENSION:  # Check if cover has been added as separate file in folder
@@ -94,16 +109,33 @@ class CoverartCacheManager:
 
     def process_write_requests(self):
         while True:
-            mp3_file_path = self.write_queue.get()
+            mp3_file_path, cache_id = self.write_queue.get()
             try:
-                self._save_to_cache(mp3_file_path)
+                self._save_to_cache(mp3_file_path, cache_id)
             except Exception as e:
                 logger.error(f"Error processing write request: {e}")
             self.write_queue.task_done()
 
-    def flush_cache(self):
-        for path in self.cache_folder_path.iterdir():
+    def _migrate_cache(self):
+        """Purge cover files written with an outdated cache key"""
+        marker = self.cache_folder_path / CACHE_SCHEMA_MARKER
+        try:
+            if marker.read_text().strip() == CACHE_SCHEMA_VERSION:
+                return
+        except OSError:
+            pass  # No marker yet: the cache predates the schema version
+
+        logger.info("Cover art cache key changed, purging stale entries")
+        self._purge_cover_files()
+        marker.write_text(CACHE_SCHEMA_VERSION)
+
+    def _purge_cover_files(self):
+        """Delete the cached covers, leaving bookkeeping files like the schema marker in place"""
+        for path in self.cache_folder_path.glob(f'{COVER_PREFIX}-*'):
             if path.is_file():
                 path.unlink()
                 logger.debug(f"Deleted cached file: {path.name}")
+
+    def flush_cache(self):
+        self._purge_cover_files()
         logger.info("Cache flushed successfully.")

--- a/src/jukebox/components/player/backends/coverart_cache_manager.py
+++ b/src/jukebox/components/player/backends/coverart_cache_manager.py
@@ -27,10 +27,15 @@ class CoverartCacheManager:
         coverart_cache_path = cfg.setndefault('webapp', 'coverart_cache_path', value='../../src/webapp/build/cover-cache')
         self.cache_folder_path = Path(coverart_cache_path).expanduser()
         try:
-            self.cache_folder_path.mkdir(parents=True, exist_ok=True)
+            if not self.cache_folder_path.exists():
+                # Deliberately without parents=True: a missing parent means coverart_cache_path does
+                # not point into the Web App, and covers written there would never be served. Better
+                # to report that than to silently create a folder nobody reads
+                logger.warning(f"Creating missing cover art cache folder {self.cache_folder_path.resolve()}")
+                self.cache_folder_path.mkdir(exist_ok=True)
             self._migrate_cache()
         except OSError as e:
-            logger.error(f"Could not prepare cover art cache folder {self.cache_folder_path}: {e}")
+            logger.error(f"Cover art cache folder {self.cache_folder_path.resolve()} is not usable: {e}")
         self.write_queue = Queue()
         self.worker_thread = Thread(target=self.process_write_requests)
         self.worker_thread.daemon = True  # Ensure the thread closes with the program
@@ -109,9 +114,9 @@ class CoverartCacheManager:
 
     def process_write_requests(self):
         while True:
-            mp3_file_path, cache_id = self.write_queue.get()
+            request = self.write_queue.get()
             try:
-                self._save_to_cache(mp3_file_path, cache_id)
+                self._save_to_cache(*request)
             except Exception as e:
                 logger.error(f"Error processing write request: {e}")
             self.write_queue.task_done()

--- a/src/jukebox/components/player/backends/mpd.py
+++ b/src/jukebox/components/player/backends/mpd.py
@@ -561,7 +561,9 @@ class PlayerMPD:
     @plugs.tag
     def get_single_coverart(self, song_url):
         mp3_file_path = Path(components.player.get_music_library_path(), song_url).expanduser()
-        cache_filename = self.coverart_cache_manager.get_cache_filename(mp3_file_path)
+        # song_url is relative to the music library root and therefore identifies the
+        # audio file uniquely, which the bare filename does not
+        cache_filename = self.coverart_cache_manager.get_cache_filename(mp3_file_path, song_url)
 
         return cache_filename
 

--- a/test/player/test_coverart_cache_manager.py
+++ b/test/player/test_coverart_cache_manager.py
@@ -1,0 +1,154 @@
+from pathlib import Path
+from queue import Queue
+
+import pytest
+
+from components.player.backends.coverart_cache_manager import (
+    CACHE_PENDING,
+    CACHE_SCHEMA_MARKER,
+    CACHE_SCHEMA_VERSION,
+    NO_CACHE,
+    NO_COVER_ART_EXTENSION,
+    CoverartCacheManager,
+)
+
+
+# Two audiobooks ripped by the same tool, so both use the publisher's chapter naming
+BOOK_A = 'Marc-Uwe Kling - Das NEINhorn/1-01 Kapitel 1.mp3'
+BOOK_B = 'Marc-Uwe Kling - Das NEINhorn und die SchLANGEWEILE/1-01 Kapitel 1.mp3'
+
+ARTWORK = {
+    BOOK_A: b'\xff\xd8\xff' + b'A' * 200,
+    BOOK_B: b'\xff\xd8\xff' + b'B' * 400,
+}
+
+
+def cache_manager(cache_folder: Path) -> CoverartCacheManager:
+    """Build a manager without its config handler, cache migration and worker thread"""
+    manager = CoverartCacheManager.__new__(CoverartCacheManager)
+    manager.cache_folder_path = cache_folder
+    manager.write_queue = Queue()
+    return manager
+
+
+@pytest.fixture
+def cache_folder(tmp_path):
+    folder = tmp_path / 'cover-cache'
+    folder.mkdir()
+    return folder
+
+
+@pytest.fixture
+def library(tmp_path):
+    root = tmp_path / 'library'
+    for song_url in ARTWORK:
+        track = root / song_url
+        track.parent.mkdir(parents=True, exist_ok=True)
+        track.write_bytes(b'')
+    return root
+
+
+@pytest.fixture
+def embedded_artwork(monkeypatch, library):
+    """Serve distinct album art per audio file, without building real MP3 fixtures"""
+    def _extract_album_art(self, mp3_file_path):
+        song_url = Path(mp3_file_path).relative_to(library).as_posix()
+        return ('jpg', ARTWORK[song_url])
+
+    monkeypatch.setattr(CoverartCacheManager, '_extract_album_art', _extract_album_art)
+
+
+def drain(manager):
+    """Run the queued extractions that the worker thread would pick up"""
+    while not manager.write_queue.empty():
+        manager._save_to_cache(*manager.write_queue.get())
+
+
+def test_same_filename_in_different_folders_gets_its_own_cover(cache_folder, library, embedded_artwork):
+    manager = cache_manager(cache_folder)
+
+    assert manager.get_cache_filename(library / BOOK_A, BOOK_A) == CACHE_PENDING
+    assert manager.get_cache_filename(library / BOOK_B, BOOK_B) == CACHE_PENDING
+    drain(manager)
+
+    cover_a = manager.get_cache_filename(library / BOOK_A, BOOK_A)
+    cover_b = manager.get_cache_filename(library / BOOK_B, BOOK_B)
+
+    assert cover_a != cover_b
+    assert (cache_folder / cover_a).read_bytes() == ARTWORK[BOOK_A]
+    assert (cache_folder / cover_b).read_bytes() == ARTWORK[BOOK_B]
+
+
+def test_the_same_song_keeps_hitting_the_same_cache_entry(cache_folder, library, embedded_artwork):
+    manager = cache_manager(cache_folder)
+
+    assert manager.get_cache_filename(library / BOOK_A, BOOK_A) == CACHE_PENDING
+    drain(manager)
+
+    cover = manager.get_cache_filename(library / BOOK_A, BOOK_A)
+
+    assert cover != CACHE_PENDING
+    assert manager.get_cache_filename(library / BOOK_A, BOOK_A) == cover
+    assert manager.write_queue.empty()  # A cached cover must not be extracted again
+
+
+def test_a_missing_cover_does_not_suppress_same_named_files_elsewhere(cache_folder, library, monkeypatch):
+    monkeypatch.setattr(
+        CoverartCacheManager,
+        '_extract_album_art',
+        lambda self, mp3_file_path: (NO_COVER_ART_EXTENSION, b''),
+    )
+    manager = cache_manager(cache_folder)
+
+    manager.get_cache_filename(library / BOOK_A, BOOK_A)
+    drain(manager)
+
+    assert manager.get_cache_filename(library / BOOK_A, BOOK_A) == NO_CACHE
+    assert manager.get_cache_filename(library / BOOK_B, BOOK_B) == CACHE_PENDING
+
+
+def test_the_file_extension_is_part_of_the_cache_key():
+    manager = CoverartCacheManager.__new__(CoverartCacheManager)
+
+    mp3 = manager.generate_cache_key('Das Neinhorn/Kapitel 1.mp3')
+    m4b = manager.generate_cache_key('Das Neinhorn/Kapitel 1.m4b')
+
+    assert mp3 != m4b
+
+
+def test_migration_purges_covers_written_with_an_older_cache_key(cache_folder):
+    manager = cache_manager(cache_folder)
+    stale = cache_folder / 'cover-beb9192b.jpg'
+    stale.write_bytes(b'stale')
+    gitkeep = cache_folder / '.gitkeep'
+    gitkeep.touch()
+
+    manager._migrate_cache()
+
+    assert not stale.exists()
+    assert gitkeep.exists()  # Docker bind-mounts the cache folder, .gitkeep is tracked
+    assert (cache_folder / CACHE_SCHEMA_MARKER).read_text() == CACHE_SCHEMA_VERSION
+
+
+def test_migration_leaves_an_up_to_date_cache_alone(cache_folder):
+    manager = cache_manager(cache_folder)
+    (cache_folder / CACHE_SCHEMA_MARKER).write_text(CACHE_SCHEMA_VERSION)
+    cover = cache_folder / 'cover-0123abcd.jpg'
+    cover.write_bytes(b'current')
+
+    manager._migrate_cache()
+
+    assert cover.exists()
+
+
+def test_flushing_keeps_the_schema_marker(cache_folder):
+    manager = cache_manager(cache_folder)
+    marker = cache_folder / CACHE_SCHEMA_MARKER
+    marker.write_text(CACHE_SCHEMA_VERSION)
+    cover = cache_folder / 'cover-0123abcd.jpg'
+    cover.write_bytes(b'current')
+
+    manager.flush_cache()
+
+    assert not cover.exists()
+    assert marker.exists()  # Otherwise the next start would purge the cache all over again

--- a/test/player/test_coverart_cache_manager.py
+++ b/test/player/test_coverart_cache_manager.py
@@ -1,8 +1,12 @@
+import time
 from pathlib import Path
 from queue import Queue
+from threading import Thread
+from types import SimpleNamespace
 
 import pytest
 
+import components.player.backends.coverart_cache_manager as coverart_cache
 from components.player.backends.coverart_cache_manager import (
     CACHE_PENDING,
     CACHE_SCHEMA_MARKER,
@@ -152,3 +156,52 @@ def test_flushing_keeps_the_schema_marker(cache_folder):
 
     assert not cover.exists()
     assert marker.exists()  # Otherwise the next start would purge the cache all over again
+
+
+@pytest.fixture
+def configured_cache_path(monkeypatch):
+    """Point the config handler at a path of the test's choosing"""
+    def _configure(path):
+        monkeypatch.setattr(
+            coverart_cache,
+            'cfg',
+            SimpleNamespace(setndefault=lambda *args, **kwargs: str(path)),
+        )
+    return _configure
+
+
+def test_a_missing_cache_folder_is_created(tmp_path, configured_cache_path):
+    cache_folder = tmp_path / 'build' / 'cover-cache'
+    cache_folder.parent.mkdir(parents=True)
+    configured_cache_path(cache_folder)
+
+    CoverartCacheManager()
+
+    assert (cache_folder / CACHE_SCHEMA_MARKER).read_text() == CACHE_SCHEMA_VERSION
+
+
+def test_a_cache_path_pointing_nowhere_is_reported_instead_of_created(tmp_path, configured_cache_path, caplog):
+    # A missing parent means the configured path does not point into the Web App, so covers
+    # written there would never be served
+    cache_folder = tmp_path / 'typo' / 'cover-cache'
+    configured_cache_path(cache_folder)
+
+    CoverartCacheManager()
+
+    assert not cache_folder.parent.exists()
+    assert 'is not usable' in caplog.text
+
+
+def test_a_malformed_write_request_does_not_stop_the_worker(cache_folder, library, embedded_artwork):
+    manager = cache_manager(cache_folder)
+    Thread(target=manager.process_write_requests, daemon=True).start()
+    expected_cover = cache_folder / f'{manager.generate_cache_key(BOOK_A)}.jpg'
+
+    manager.write_queue.put('not a write request')
+    manager.write_queue.put((library / BOOK_A, BOOK_A))
+
+    deadline = time.monotonic() + 5
+    while not expected_cover.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert expected_cover.exists(), 'the worker thread stopped after the malformed request'

--- a/test/player/test_mpd_backend_contract.py
+++ b/test/player/test_mpd_backend_contract.py
@@ -1,7 +1,9 @@
 from contextlib import nullcontext
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, sentinel
 
+import components.player
 import jukebox.publishing as publishing
 
 from components.player.backends.mpd import PlayerMPD
@@ -83,4 +85,18 @@ def test_inactive_backend_does_not_publish_status(monkeypatch):
     publisher.send.assert_called_once_with(
         'playerstatus',
         {'state': 'stop', 'provider': 'mpd'},
+    )
+
+
+def test_get_single_coverart_keys_the_cache_on_the_library_relative_path(monkeypatch):
+    monkeypatch.setattr(components.player, 'get_music_library_path', lambda: '/home/pi/audiofolders')
+    backend = mpd_backend()
+    backend.coverart_cache_manager = Mock()
+    song_url = 'Das Neinhorn/1-01 Kapitel 1.mp3'
+
+    backend.get_single_coverart(song_url)
+
+    backend.coverart_cache_manager.get_cache_filename.assert_called_once_with(
+        Path('/home/pi/audiofolders', song_url),
+        song_url,
     )


### PR DESCRIPTION
CoverartCacheManager keyed the cache on Path(mp3_file_path).stem, so every audio file sharing a filename shared one cache entry no matter which folder it lived in. On an audiobook library that is the normal case, not an edge case: publishers name chapters "1-01 Kapitel 1.mp3" or plain "01.mp3", so dozens of albums collided on a single cover. Whichever file was extracted last won, and the others silently served its artwork. Keying on the stem had two further consequences: a single untagged track wrote a `no-art` marker that suppressed covers for every same-named file in the library, and an MP3 and an M4B rip of the same chapter collided inside one folder.

Key the cache on the path relative to the music library root instead, extension included. get_single_coverart already receives that value as song_url, so it is threaded through get_cache_filename, the write queue and _save_to_cache. The player coordinator and the Web App are unaffected: the returned value is still a bare filename served from /cover-cache.

Changing the key orphans every existing cache entry, so the cache folder now carries a schema marker. When it is missing or outdated, the cover files are purged once on start and the cache regenerates on demand - the first browse of a large library after the update is slower than usual. Purging matches only `cover-*` so it no longer deletes the .gitkeep that Docker relies on; flush_cache() shares that helper and keeps the marker in place.